### PR TITLE
Support arbitrary configurations in `@SwiftSyntaxRule`

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -6,7 +6,7 @@ load(
     "swift_compiler_plugin"
 )
 
-copts = ["-enable-upcoming-feature", "ExistentialAny"]
+copts = ["-enable-upcoming-feature", "ExistentialAny", "-cross-module-optimization"]
 
 # Targets
 

--- a/BUILD
+++ b/BUILD
@@ -6,7 +6,7 @@ load(
     "swift_compiler_plugin"
 )
 
-copts = ["-enable-upcoming-feature", "ExistentialAny", "-cross-module-optimization"]
+copts = ["-enable-upcoming-feature", "ExistentialAny"]
 
 # Targets
 

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,8 @@ import CompilerPluginSupport
 import PackageDescription
 
 let swiftFeatures: [SwiftSetting] = [
-    .enableUpcomingFeature("ExistentialAny")
+    .enableUpcomingFeature("ExistentialAny"),
+    .unsafeFlags(["-cross-module-optimization"])
 ]
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -3,8 +3,7 @@ import CompilerPluginSupport
 import PackageDescription
 
 let swiftFeatures: [SwiftSetting] = [
-    .enableUpcomingFeature("ExistentialAny"),
-    .unsafeFlags(["-cross-module-optimization"])
+    .enableUpcomingFeature("ExistentialAny")
 ]
 
 let package = Package(

--- a/Source/SwiftLintBuiltInRules/Helpers/LegacyFunctionRuleHelper.swift
+++ b/Source/SwiftLintBuiltInRules/Helpers/LegacyFunctionRuleHelper.swift
@@ -3,12 +3,13 @@ import SwiftSyntaxBuilder
 
 /// A helper to hold a visitor and rewriter that can lint and correct legacy NS/CG functions to a more modern syntax.
 enum LegacyFunctionRuleHelper {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor<Configuration: RuleConfiguration>: ViolationsSyntaxVisitor<Configuration> {
         private let legacyFunctions: [String: RewriteStrategy]
 
-        init(legacyFunctions: [String: RewriteStrategy]) {
+        init(configuration: Configuration, locationConverter: SourceLocationConverter,
+             legacyFunctions: [String: RewriteStrategy]) {
             self.legacyFunctions = legacyFunctions
-            super.init(viewMode: .sourceAccurate)
+            super.init(configuration: configuration, locationConverter: locationConverter)
         }
 
         override func visitPost(_ node: FunctionCallExprSyntax) {

--- a/Source/SwiftLintBuiltInRules/Helpers/LegacyFunctionRuleHelper.swift
+++ b/Source/SwiftLintBuiltInRules/Helpers/LegacyFunctionRuleHelper.swift
@@ -6,10 +6,9 @@ enum LegacyFunctionRuleHelper {
     final class Visitor<Configuration: RuleConfiguration>: ViolationsSyntaxVisitor<Configuration> {
         private let legacyFunctions: [String: RewriteStrategy]
 
-        init(configuration: Configuration, locationConverter: SourceLocationConverter,
-             legacyFunctions: [String: RewriteStrategy]) {
+        init(configuration: Configuration, file: SwiftLintFile, legacyFunctions: [String: RewriteStrategy]) {
             self.legacyFunctions = legacyFunctions
-            super.init(configuration: configuration, locationConverter: locationConverter)
+            super.init(configuration: configuration, file: file)
         }
 
         override func visitPost(_ node: FunctionCallExprSyntax) {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/AnonymousArgumentInMultilineClosureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/AnonymousArgumentInMultilineClosureRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct AnonymousArgumentInMultilineClosureRule: SwiftSyntaxRule, OptInRule {
+@SwiftSyntaxRule
+struct AnonymousArgumentInMultilineClosureRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(
@@ -30,21 +31,10 @@ struct AnonymousArgumentInMultilineClosureRule: SwiftSyntaxRule, OptInRule {
             """)
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(locationConverter: file.locationConverter)
-    }
 }
 
 private extension AnonymousArgumentInMultilineClosureRule {
-    final class Visitor: ViolationsSyntaxVisitor {
-        private let locationConverter: SourceLocationConverter
-
-        init(locationConverter: SourceLocationConverter) {
-            self.locationConverter = locationConverter
-            super.init(viewMode: .sourceAccurate)
-        }
-
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visit(_ node: ClosureExprSyntax) -> SyntaxVisitorContinueKind {
             let startLocation = locationConverter.location(for: node.leftBrace.positionAfterSkippingLeadingTrivia)
             let endLocation = locationConverter.location(for: node.rightBrace.endPositionBeforeTrailingTrivia)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/BlockBasedKVORule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/BlockBasedKVORule.swift
@@ -36,7 +36,7 @@ struct BlockBasedKVORule: Rule {
 }
 
 private extension BlockBasedKVORule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FunctionDeclSyntax) {
             guard node.modifiers.contains(keyword: .override),
                   case let parameterList = node.signature.parameterClause.parameters,

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ConvenienceTypeRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ConvenienceTypeRule.swift
@@ -151,7 +151,7 @@ private extension ConvenienceTypeRule {
                 return false
             }
 
-            return ConvenienceTypeCheckVisitor(configuration: configuration, locationConverter: locationConverter)
+            return ConvenienceTypeCheckVisitor(configuration: configuration, file: file)
                 .walk(tree: members, handler: \.canBeConvenienceType)
         }
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ConvenienceTypeRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ConvenienceTypeRule.swift
@@ -118,7 +118,7 @@ struct ConvenienceTypeRule: OptInRule {
 }
 
 private extension ConvenienceTypeRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
 
         override func visitPost(_ node: StructDeclSyntax) {
@@ -151,44 +151,44 @@ private extension ConvenienceTypeRule {
                 return false
             }
 
-            return ConvenienceTypeCheckVisitor(viewMode: .sourceAccurate)
+            return ConvenienceTypeCheckVisitor(configuration: configuration, locationConverter: locationConverter)
                 .walk(tree: members, handler: \.canBeConvenienceType)
         }
     }
-}
 
-private class ConvenienceTypeCheckVisitor: ViolationsSyntaxVisitor {
-    override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .all }
+    final class ConvenienceTypeCheckVisitor: ViolationsSyntaxVisitor<ConfigurationType> {
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .all }
 
-    private(set) var canBeConvenienceType = true
+        private(set) var canBeConvenienceType = true
 
-    override func visitPost(_ node: VariableDeclSyntax) {
-        if node.isInstanceVariable {
-            canBeConvenienceType = false
-        } else if node.attributes.containsObjc {
-            canBeConvenienceType = false
-        }
-    }
-
-    override func visitPost(_ node: FunctionDeclSyntax) {
-        if node.modifiers.containsStaticOrClass {
-            if node.attributes.containsObjc {
+        override func visitPost(_ node: VariableDeclSyntax) {
+            if node.isInstanceVariable {
+                canBeConvenienceType = false
+            } else if node.attributes.containsObjc {
                 canBeConvenienceType = false
             }
-        } else {
-            canBeConvenienceType = false
         }
-    }
 
-    override func visitPost(_ node: InitializerDeclSyntax) {
-        if !node.attributes.hasUnavailableAttribute {
-            canBeConvenienceType = false
+        override func visitPost(_ node: FunctionDeclSyntax) {
+            if node.modifiers.containsStaticOrClass {
+                if node.attributes.containsObjc {
+                    canBeConvenienceType = false
+                }
+            } else {
+                canBeConvenienceType = false
+            }
         }
-    }
 
-    override func visitPost(_ node: SubscriptDeclSyntax) {
-        if !node.modifiers.containsStaticOrClass {
-            canBeConvenienceType = false
+        override func visitPost(_ node: InitializerDeclSyntax) {
+            if !node.attributes.hasUnavailableAttribute {
+                canBeConvenienceType = false
+            }
+        }
+
+        override func visitPost(_ node: SubscriptDeclSyntax) {
+            if !node.modifiers.containsStaticOrClass {
+                canBeConvenienceType = false
+            }
         }
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedAssertRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedAssertRule.swift
@@ -26,7 +26,7 @@ struct DiscouragedAssertRule: OptInRule {
 }
 
 private extension DiscouragedAssertRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FunctionCallExprSyntax) {
             guard node.calledExpression.as(DeclReferenceExprSyntax.self)?.baseName.text == "assert",
                   let firstArg = node.arguments.first,

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedNoneNameRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedNoneNameRule.swift
@@ -180,7 +180,7 @@ struct DiscouragedNoneNameRule: OptInRule {
 }
 
 private extension DiscouragedNoneNameRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: EnumCaseElementSyntax) {
             let emptyParams = node.parameterClause?.parameters.isEmpty ?? true
             if emptyParams, node.name.isNone {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedObjectLiteralRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedObjectLiteralRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct DiscouragedObjectLiteralRule: SwiftSyntaxRule, OptInRule {
+@SwiftSyntaxRule
+struct DiscouragedObjectLiteralRule: OptInRule {
     var configuration = DiscouragedObjectLiteralConfiguration()
 
     static let description = RuleDescription(
@@ -21,21 +22,10 @@ struct DiscouragedObjectLiteralRule: SwiftSyntaxRule, OptInRule {
             Example("let color = ↓#colorLiteral(red: 0.9607843161, green: 0.7058823705, blue: 0.200000003, alpha: 1)")
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(configuration: configuration)
-    }
 }
 
 private extension DiscouragedObjectLiteralRule {
-    final class Visitor: ViolationsSyntaxVisitor {
-        private let configuration: ConfigurationType
-
-        init(configuration: ConfigurationType) {
-            self.configuration = configuration
-            super.init(viewMode: .sourceAccurate)
-        }
-
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: MacroExpansionExprSyntax) {
             guard
                 case let .identifier(identifierText) = node.macroName.tokenKind,

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedOptionalBooleanRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedOptionalBooleanRule.swift
@@ -15,7 +15,7 @@ struct DiscouragedOptionalBooleanRule: OptInRule {
 }
 
 private extension DiscouragedOptionalBooleanRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: OptionalTypeSyntax) {
             if node.wrappedType.as(IdentifierTypeSyntax.self)?.typeName == "Bool" {
                 violations.append(node.positionAfterSkippingLeadingTrivia)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitEnumRawValueRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitEnumRawValueRule.swift
@@ -80,7 +80,7 @@ struct ExplicitEnumRawValueRule: OptInRule {
 }
 
 private extension ExplicitEnumRawValueRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
 
         override func visitPost(_ node: EnumCaseElementSyntax) {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitTopLevelACLRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitTopLevelACLRule.swift
@@ -31,7 +31,7 @@ struct ExplicitTopLevelACLRule: OptInRule {
 }
 
 private extension ExplicitTopLevelACLRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .all }
 
         override func visitPost(_ node: ClassDeclSyntax) {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitTypeInterfaceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitTypeInterfaceRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct ExplicitTypeInterfaceRule: OptInRule, SwiftSyntaxRule {
+@SwiftSyntaxRule
+struct ExplicitTypeInterfaceRule: OptInRule {
     var configuration = ExplicitTypeInterfaceConfiguration()
 
     static let description = RuleDescription(
@@ -68,22 +69,11 @@ struct ExplicitTypeInterfaceRule: OptInRule, SwiftSyntaxRule {
             """)
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(configuration: configuration)
-    }
 }
 
 private extension ExplicitTypeInterfaceRule {
-    final class Visitor: ViolationsSyntaxVisitor {
-        let configuration: ExplicitTypeInterfaceConfiguration
-
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
-
-        init(configuration: ExplicitTypeInterfaceConfiguration) {
-            self.configuration = configuration
-            super.init(viewMode: .sourceAccurate)
-        }
 
         override func visitPost(_ node: VariableDeclSyntax) {
             if node.modifiers.contains(keyword: .class) {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/FallthroughRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/FallthroughRule.swift
@@ -31,7 +31,7 @@ struct FallthroughRule: OptInRule {
 }
 
 private extension FallthroughRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FallThroughStmtSyntax) {
             violations.append(node.positionAfterSkippingLeadingTrivia)
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/FatalErrorMessageRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/FatalErrorMessageRule.swift
@@ -37,7 +37,7 @@ struct FatalErrorMessageRule: OptInRule {
 }
 
 private extension FatalErrorMessageRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FunctionCallExprSyntax) {
             guard let expression = node.calledExpression.as(DeclReferenceExprSyntax.self),
                   expression.baseName.text == "fatalError",

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ForWhereRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ForWhereRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct ForWhereRule: SwiftSyntaxRule {
+@SwiftSyntaxRule
+struct ForWhereRule: Rule {
     var configuration = ForWhereConfiguration()
 
     static let description = RuleDescription(
@@ -115,21 +116,10 @@ struct ForWhereRule: SwiftSyntaxRule {
             """, configuration: ["allow_for_as_filter": true])
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(allowForAsFilter: configuration.allowForAsFilter)
-    }
 }
 
 private extension ForWhereRule {
-    final class Visitor: ViolationsSyntaxVisitor {
-        private let allowForAsFilter: Bool
-
-        init(allowForAsFilter: Bool) {
-            self.allowForAsFilter = allowForAsFilter
-            super.init(viewMode: .sourceAccurate)
-        }
-
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: ForStmtSyntax) {
             guard node.whereClause == nil,
                   let onlyExprStmt = node.body.statements.onlyElement?.item.as(ExpressionStmtSyntax.self),
@@ -142,7 +132,7 @@ private extension ForWhereRule {
                 return
             }
 
-            if allowForAsFilter, ifExpr.containsReturnStatement {
+            if configuration.allowForAsFilter, ifExpr.containsReturnStatement {
                 return
             }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ForceCastRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ForceCastRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct ForceCastRule: SwiftSyntaxRule {
+@SwiftSyntaxRule
+struct ForceCastRule: Rule {
     var configuration = SeverityConfiguration<Self>(.error)
 
     static let description = RuleDescription(
@@ -13,14 +14,10 @@ struct ForceCastRule: SwiftSyntaxRule {
         ],
         triggeringExamples: [ Example("NSNumber() ↓as! Int") ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(viewMode: .sourceAccurate)
-    }
 }
 
 private extension ForceCastRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: AsExprSyntax) {
             if node.questionOrExclamationMark?.tokenKind == .exclamationMark {
                 violations.append(node.asKeyword.positionAfterSkippingLeadingTrivia)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ForceTryRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ForceTryRule.swift
@@ -27,7 +27,7 @@ struct ForceTryRule: Rule {
 }
 
 private extension ForceTryRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: TryExprSyntax) {
             if node.questionOrExclamationMark?.tokenKind == .exclamationMark {
                 violations.append(node.positionAfterSkippingLeadingTrivia)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ForceUnwrappingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ForceUnwrappingRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct ForceUnwrappingRule: OptInRule, SwiftSyntaxRule {
+@SwiftSyntaxRule
+struct ForceUnwrappingRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(
@@ -64,14 +65,10 @@ struct ForceUnwrappingRule: OptInRule, SwiftSyntaxRule {
             Example("map[\"a\"]↓!↓!")
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(viewMode: .sourceAccurate)
-    }
 }
 
 private extension ForceUnwrappingRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: ForceUnwrapExprSyntax) {
             violations.append(node.exclamationMark.positionAfterSkippingLeadingTrivia)
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/FunctionDefaultParameterAtEndRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/FunctionDefaultParameterAtEndRule.swift
@@ -52,7 +52,7 @@ struct FunctionDefaultParameterAtEndRule: OptInRule {
 }
 
 private extension FunctionDefaultParameterAtEndRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FunctionDeclSyntax) {
             guard !node.modifiers.contains(keyword: .override), node.signature.containsViolation else {
                 return

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/GenericTypeNameRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/GenericTypeNameRule.swift
@@ -1,7 +1,8 @@
 import Foundation
 import SwiftSyntax
 
-struct GenericTypeNameRule: SwiftSyntaxRule {
+@SwiftSyntaxRule
+struct GenericTypeNameRule: Rule {
     var configuration = NameConfiguration<Self>(minLengthWarning: 1,
                                                 minLengthError: 0,
                                                 maxLengthWarning: 20,
@@ -47,21 +48,10 @@ struct GenericTypeNameRule: SwiftSyntaxRule {
             ]
         }
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(configuration: configuration)
-    }
 }
 
 private extension GenericTypeNameRule {
-    final class Visitor: ViolationsSyntaxVisitor {
-        private let configuration: ConfigurationType
-
-        init(configuration: ConfigurationType) {
-            self.configuration = configuration
-            super.init(viewMode: .sourceAccurate)
-        }
-
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: GenericParameterSyntax) {
             let name = node.name.text
             guard !name.isEmpty, !configuration.shouldExclude(name: name) else { return }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ImplicitlyUnwrappedOptionalRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ImplicitlyUnwrappedOptionalRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct ImplicitlyUnwrappedOptionalRule: SwiftSyntaxRule, OptInRule {
+@SwiftSyntaxRule
+struct ImplicitlyUnwrappedOptionalRule: OptInRule {
     var configuration = ImplicitlyUnwrappedOptionalConfiguration()
 
     static let description = RuleDescription(
@@ -40,27 +41,16 @@ struct ImplicitlyUnwrappedOptionalRule: SwiftSyntaxRule, OptInRule {
             """)
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(mode: configuration.mode)
-    }
 }
 
 private extension ImplicitlyUnwrappedOptionalRule {
-    final class Visitor: ViolationsSyntaxVisitor {
-        private let mode: ConfigurationType.ImplicitlyUnwrappedOptionalModeConfiguration
-
-        init(mode: ConfigurationType.ImplicitlyUnwrappedOptionalModeConfiguration) {
-            self.mode = mode
-            super.init(viewMode: .sourceAccurate)
-        }
-
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: ImplicitlyUnwrappedOptionalTypeSyntax) {
             violations.append(node.positionAfterSkippingLeadingTrivia)
         }
 
         override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
-            switch mode {
+            switch configuration.mode {
             case .all:
                 return .visitChildren
             case .allExceptIBOutlets:

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/IsDisjointRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/IsDisjointRule.swift
@@ -23,7 +23,7 @@ struct IsDisjointRule: Rule {
 }
 
 private extension IsDisjointRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: MemberAccessExprSyntax) {
             guard
                 node.declName.baseName.text == "isEmpty",

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/JoinedDefaultParameterRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/JoinedDefaultParameterRule.swift
@@ -46,7 +46,7 @@ struct JoinedDefaultParameterRule: SwiftSyntaxCorrectableRule, OptInRule {
 }
 
 private extension JoinedDefaultParameterRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FunctionCallExprSyntax) {
             if let violationPosition = node.violationPosition {
                 violations.append(violationPosition)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyCGGeometryFunctionsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyCGGeometryFunctionsRule.swift
@@ -100,8 +100,12 @@ struct LegacyCGGeometryFunctionsRule: SwiftSyntaxCorrectableRule {
         "CGRectIntersection": .function(name: "intersection", argumentLabels: [""])
     ]
 
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        LegacyFunctionRuleHelper.Visitor(legacyFunctions: Self.legacyFunctions)
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor<ConfigurationType> {
+        LegacyFunctionRuleHelper.Visitor(
+            configuration: configuration,
+            locationConverter: file.locationConverter,
+            legacyFunctions: Self.legacyFunctions
+        )
     }
 
     func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyCGGeometryFunctionsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyCGGeometryFunctionsRule.swift
@@ -103,7 +103,7 @@ struct LegacyCGGeometryFunctionsRule: SwiftSyntaxCorrectableRule {
     func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor<ConfigurationType> {
         LegacyFunctionRuleHelper.Visitor(
             configuration: configuration,
-            locationConverter: file.locationConverter,
+            file: file,
             legacyFunctions: Self.legacyFunctions
         )
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyConstantRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyConstantRule.swift
@@ -24,7 +24,7 @@ struct LegacyConstantRule: SwiftSyntaxCorrectableRule {
 }
 
 private extension LegacyConstantRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: DeclReferenceExprSyntax) {
             if LegacyConstantRuleExamples.patterns.keys.contains(node.baseName.text) {
                 violations.append(node.positionAfterSkippingLeadingTrivia)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyConstructorRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyConstructorRule.swift
@@ -132,7 +132,7 @@ struct LegacyConstructorRule: SwiftSyntaxCorrectableRule {
 }
 
 private extension LegacyConstructorRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FunctionCallExprSyntax) {
             if let identifierExpr = node.calledExpression.as(DeclReferenceExprSyntax.self),
                constructorsToCorrectedNames[identifierExpr.baseName.text] != nil {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyHashingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyHashingRule.swift
@@ -76,7 +76,7 @@ struct LegacyHashingRule: Rule {
 }
 
 private extension LegacyHashingRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: VariableDeclSyntax) {
             guard
                 node.parent?.is(MemberBlockItemSyntax.self) == true,

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyMultipleRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyMultipleRule.swift
@@ -40,7 +40,7 @@ struct LegacyMultipleRule: OptInRule {
 }
 
 private extension LegacyMultipleRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: InfixOperatorExprSyntax) {
             guard let operatorNode = node.operator.as(BinaryOperatorExprSyntax.self),
                   operatorNode.operator.tokenKind == .binaryOperator("%"),

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyNSGeometryFunctionsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyNSGeometryFunctionsRule.swift
@@ -103,7 +103,7 @@ struct LegacyNSGeometryFunctionsRule: SwiftSyntaxCorrectableRule {
     func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor<ConfigurationType> {
         LegacyFunctionRuleHelper.Visitor(
             configuration: configuration,
-            locationConverter: file.locationConverter,
+            file: file,
             legacyFunctions: Self.legacyFunctions
         )
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyNSGeometryFunctionsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyNSGeometryFunctionsRule.swift
@@ -100,8 +100,12 @@ struct LegacyNSGeometryFunctionsRule: SwiftSyntaxCorrectableRule {
         "NSPointInRect": .function(name: "contains", argumentLabels: [""], reversed: true)
     ]
 
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        LegacyFunctionRuleHelper.Visitor(legacyFunctions: Self.legacyFunctions)
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor<ConfigurationType> {
+        LegacyFunctionRuleHelper.Visitor(
+            configuration: configuration,
+            locationConverter: file.locationConverter,
+            legacyFunctions: Self.legacyFunctions
+        )
     }
 
     func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyObjcTypeRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyObjcTypeRule.swift
@@ -69,7 +69,7 @@ struct LegacyObjcTypeRule: OptInRule {
 }
 
 private extension LegacyObjcTypeRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: IdentifierTypeSyntax) {
             if let typeName = node.typeName, legacyObjcTypes.contains(typeName) {
                 violations.append(node.positionAfterSkippingLeadingTrivia)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyRandomRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyRandomRule.swift
@@ -23,7 +23,7 @@ struct LegacyRandomRule: Rule {
 }
 
 private extension LegacyRandomRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         private static let legacyRandomFunctions: Set<String> = [
             "arc4random",
             "arc4random_uniform",

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoExtensionAccessModifierRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoExtensionAccessModifierRule.swift
@@ -24,7 +24,7 @@ struct NoExtensionAccessModifierRule: OptInRule {
 }
 
 private extension NoExtensionAccessModifierRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .all }
 
         override func visitPost(_ node: ExtensionDeclSyntax) {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoFallthroughOnlyRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoFallthroughOnlyRule.swift
@@ -15,7 +15,7 @@ struct NoFallthroughOnlyRule: Rule {
 }
 
 private extension NoFallthroughOnlyRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: SwitchCaseListSyntax) {
             let cases = node.compactMap { $0.as(SwitchCaseSyntax.self) }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PatternMatchingKeywordsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PatternMatchingKeywordsRule.swift
@@ -38,7 +38,7 @@ struct PatternMatchingKeywordsRule: OptInRule {
 private extension PatternMatchingKeywordsRule {
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: SwitchCaseItemSyntax) {
-            let localViolations = TupleVisitor(configuration: configuration, locationConverter: locationConverter)
+            let localViolations = TupleVisitor(configuration: configuration, file: file)
                 .walk(tree: node.pattern, handler: \.violations)
             violations.append(contentsOf: localViolations)
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PatternMatchingKeywordsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PatternMatchingKeywordsRule.swift
@@ -36,16 +36,16 @@ struct PatternMatchingKeywordsRule: OptInRule {
 }
 
 private extension PatternMatchingKeywordsRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: SwitchCaseItemSyntax) {
-            let localViolations = TupleVisitor(viewMode: .sourceAccurate)
+            let localViolations = TupleVisitor(configuration: configuration, locationConverter: locationConverter)
                 .walk(tree: node.pattern, handler: \.violations)
             violations.append(contentsOf: localViolations)
         }
     }
 }
 
-private final class TupleVisitor: ViolationsSyntaxVisitor {
+private final class TupleVisitor<Configuration: RuleConfiguration>: ViolationsSyntaxVisitor<Configuration> {
     override func visitPost(_ node: LabeledExprListSyntax) {
         let list = node.flatteningEnumPatterns()
             .compactMap { elem in

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferNimbleRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferNimbleRule.swift
@@ -25,7 +25,7 @@ struct PreferNimbleRule: OptInRule {
 }
 
 private extension PreferNimbleRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FunctionCallExprSyntax) {
             if let expr = node.calledExpression.as(DeclReferenceExprSyntax.self),
                expr.baseName.text.starts(with: "XCTAssert") {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferZeroOverExplicitInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferZeroOverExplicitInitRule.swift
@@ -44,7 +44,7 @@ struct PreferZeroOverExplicitInitRule: SwiftSyntaxCorrectableRule, OptInRule {
 }
 
 private extension PreferZeroOverExplicitInitRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FunctionCallExprSyntax) {
             if node.hasViolation {
                 violations.append(node.positionAfterSkippingLeadingTrivia)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PrivateOverFilePrivateRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PrivateOverFilePrivateRule.swift
@@ -1,5 +1,6 @@
 import SwiftSyntax
 
+@SwiftSyntaxRule
 struct PrivateOverFilePrivateRule: SwiftSyntaxCorrectableRule {
     var configuration = PrivateOverFilePrivateConfiguration()
 
@@ -54,10 +55,6 @@ struct PrivateOverFilePrivateRule: SwiftSyntaxCorrectableRule {
         ]
     )
 
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(validateExtensions: configuration.validateExtensions)
-    }
-
     func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             validateExtensions: configuration.validateExtensions,
@@ -68,14 +65,7 @@ struct PrivateOverFilePrivateRule: SwiftSyntaxCorrectableRule {
 }
 
 private extension PrivateOverFilePrivateRule {
-    final class Visitor: ViolationsSyntaxVisitor {
-        private let validateExtensions: Bool
-
-        init(validateExtensions: Bool) {
-            self.validateExtensions = validateExtensions
-            super.init(viewMode: .sourceAccurate)
-        }
-
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
             if let privateModifier = node.modifiers.fileprivateModifier {
                 violations.append(privateModifier.positionAfterSkippingLeadingTrivia)
@@ -84,7 +74,7 @@ private extension PrivateOverFilePrivateRule {
         }
 
         override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
-            if validateExtensions, let privateModifier = node.modifiers.fileprivateModifier {
+            if configuration.validateExtensions, let privateModifier = node.modifiers.fileprivateModifier {
                 violations.append(privateModifier.positionAfterSkippingLeadingTrivia)
             }
             return .skipChildren

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantNilCoalescingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantNilCoalescingRule.swift
@@ -31,7 +31,7 @@ struct RedundantNilCoalescingRule: OptInRule, SwiftSyntaxCorrectableRule {
 }
 
 private extension RedundantNilCoalescingRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: TokenSyntax) {
             if node.tokenKind.isNilCoalescingOperator,
                node.nextToken(viewMode: .sourceAccurate)?.tokenKind == .keyword(.nil) {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantObjcAttributeRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantObjcAttributeRule.swift
@@ -18,15 +18,15 @@ struct RedundantObjcAttributeRule: SwiftSyntaxRule, SubstitutionCorrectableRule 
         corrections: RedundantObjcAttributeRuleExamples.corrections
     )
 
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        final class Visitor: ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor<ConfigurationType> {
+        final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
             override func visitPost(_ node: AttributeListSyntax) {
                 if let objcAttribute = node.violatingObjCAttribute {
                     violations.append(objcAttribute.positionAfterSkippingLeadingTrivia)
                 }
             }
         }
-        return Visitor(viewMode: .sourceAccurate)
+        return Visitor(configuration: configuration, locationConverter: file.locationConverter)
     }
 
     func violationRanges(in file: SwiftLintFile) -> [NSRange] {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantObjcAttributeRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantObjcAttributeRule.swift
@@ -26,7 +26,7 @@ struct RedundantObjcAttributeRule: SwiftSyntaxRule, SubstitutionCorrectableRule 
                 }
             }
         }
-        return Visitor(configuration: configuration, locationConverter: file.locationConverter)
+        return Visitor(configuration: configuration, file: file)
     }
 
     func violationRanges(in file: SwiftLintFile) -> [NSRange] {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantOptionalInitializationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantOptionalInitializationRule.swift
@@ -114,7 +114,7 @@ struct RedundantOptionalInitializationRule: SwiftSyntaxCorrectableRule {
 }
 
 private extension RedundantOptionalInitializationRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: VariableDeclSyntax) {
             guard node.bindingSpecifier.tokenKind == .keyword(.var),
                   !node.modifiers.contains(keyword: .lazy) else {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantSetAccessControlRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantSetAccessControlRule.swift
@@ -61,7 +61,7 @@ struct RedundantSetAccessControlRule: Rule {
 }
 
 private extension RedundantSetAccessControlRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] {
             [FunctionDeclSyntax.self]
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantStringEnumValueRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantStringEnumValueRule.swift
@@ -62,7 +62,7 @@ struct RedundantStringEnumValueRule: Rule {
 }
 
 private extension RedundantStringEnumValueRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: EnumDeclSyntax) {
             guard node.isStringEnum else {
                 return

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ReturnValueFromVoidFunctionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ReturnValueFromVoidFunctionRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct ReturnValueFromVoidFunctionRule: OptInRule, SwiftSyntaxRule {
+@SwiftSyntaxRule
+struct ReturnValueFromVoidFunctionRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(
@@ -12,14 +13,10 @@ struct ReturnValueFromVoidFunctionRule: OptInRule, SwiftSyntaxRule {
         nonTriggeringExamples: ReturnValueFromVoidFunctionRuleExamples.nonTriggeringExamples,
         triggeringExamples: ReturnValueFromVoidFunctionRuleExamples.triggeringExamples
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(viewMode: .sourceAccurate)
-    }
 }
 
 private extension ReturnValueFromVoidFunctionRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: ReturnStmtSyntax) {
             if node.expression != nil,
                let functionNode = Syntax(node).enclosingFunction(),

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ShorthandOptionalBindingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ShorthandOptionalBindingRule.swift
@@ -89,7 +89,7 @@ struct ShorthandOptionalBindingRule: OptInRule, SwiftSyntaxCorrectableRule {
 }
 
 private extension ShorthandOptionalBindingRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: OptionalBindingConditionSyntax) {
             if node.isShadowingOptionalBinding {
                 violations.append(node.bindingSpecifier.positionAfterSkippingLeadingTrivia)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/StaticOperatorRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/StaticOperatorRule.swift
@@ -79,7 +79,7 @@ struct StaticOperatorRule: OptInRule {
 }
 
 private extension StaticOperatorRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .all }
 
         override func visitPost(_ node: FunctionDeclSyntax) {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/StrictFilePrivateRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/StrictFilePrivateRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct StrictFilePrivateRule: OptInRule, SwiftSyntaxRule {
+@SwiftSyntaxRule
+struct StrictFilePrivateRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(
@@ -122,14 +123,6 @@ struct StrictFilePrivateRule: OptInRule, SwiftSyntaxRule {
             """, excludeFromDocumentation: true)
         }
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor<ConfigurationType> {
-        Visitor(
-            configuration: configuration,
-            locationConverter: file.locationConverter,
-            file: file.syntaxTree
-        )
-    }
 }
 
 private enum ProtocolRequirementType: Equatable {
@@ -140,16 +133,9 @@ private enum ProtocolRequirementType: Equatable {
 
 private extension StrictFilePrivateRule {
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
-        private let file: SourceFileSyntax
-
-        init(configuration: ConfigurationType, locationConverter: SourceLocationConverter, file: SourceFileSyntax) {
-            self.file = file
-            super.init(configuration: configuration, locationConverter: locationConverter)
-        }
-
         private lazy var protocols = {
-            ProtocolCollector(configuration: configuration, locationConverter: locationConverter)
-                .walk(tree: file, handler: \.protocols)
+            ProtocolCollector(configuration: configuration, file: file)
+                .walk(tree: file.syntaxTree, handler: \.protocols)
         }()
 
         override func visitPost(_ node: DeclModifierSyntax) {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ToggleBoolRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ToggleBoolRule.swift
@@ -39,7 +39,7 @@ struct ToggleBoolRule: SwiftSyntaxCorrectableRule, OptInRule {
 }
 
 private extension ToggleBoolRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: ExprListSyntax) {
             if node.hasToggleBoolViolation {
                 violations.append(node.positionAfterSkippingLeadingTrivia)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/TrailingSemicolonRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/TrailingSemicolonRule.swift
@@ -34,7 +34,7 @@ struct TrailingSemicolonRule: SwiftSyntaxCorrectableRule {
 }
 
 private extension TrailingSemicolonRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: TokenSyntax) {
             if node.isTrailingSemicolon {
                 violations.append(node.positionAfterSkippingLeadingTrivia)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/TypeNameRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/TypeNameRule.swift
@@ -1,7 +1,8 @@
 import Foundation
 import SwiftSyntax
 
-struct TypeNameRule: SwiftSyntaxRule {
+@SwiftSyntaxRule
+struct TypeNameRule: Rule {
     var configuration = TypeNameConfiguration()
 
     static let description = RuleDescription(
@@ -16,21 +17,10 @@ struct TypeNameRule: SwiftSyntaxRule {
         nonTriggeringExamples: TypeNameRuleExamples.nonTriggeringExamples,
         triggeringExamples: TypeNameRuleExamples.triggeringExamples
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(configuration: configuration)
-    }
 }
 
 private extension TypeNameRule {
-    final class Visitor: ViolationsSyntaxVisitor {
-        private let configuration: TypeNameConfiguration
-
-        init(configuration: TypeNameConfiguration) {
-            self.configuration = configuration
-            super.init(viewMode: .sourceAccurate)
-        }
-
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: StructDeclSyntax) {
             if let violation = violation(identifier: node.name, modifiers: node.modifiers,
                                          inheritedTypes: node.inheritanceClause?.inheritedTypes) {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnavailableConditionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnavailableConditionRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct UnavailableConditionRule: SwiftSyntaxRule {
+@SwiftSyntaxRule
+struct UnavailableConditionRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(
@@ -68,14 +69,10 @@ struct UnavailableConditionRule: SwiftSyntaxRule {
             """)
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(viewMode: .sourceAccurate)
-    }
 }
 
 private extension UnavailableConditionRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: IfExprSyntax) {
             guard node.body.statements.isEmpty else {
                 return

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnavailableFunctionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnavailableFunctionRule.swift
@@ -73,7 +73,7 @@ struct UnavailableFunctionRule: OptInRule {
 }
 
 private extension UnavailableFunctionRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FunctionDeclSyntax) {
             guard !node.returnsNever,
                   !node.attributes.hasUnavailableAttribute,

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
@@ -12,6 +12,7 @@ private func embedInSwitch(
         """, file: file, line: line)
 }
 
+@SwiftSyntaxRule
 struct UnneededBreakInSwitchRule: SwiftSyntaxCorrectableRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
@@ -86,10 +87,6 @@ struct UnneededBreakInSwitchRule: SwiftSyntaxCorrectableRule {
         ]
     )
 
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(viewMode: .sourceAccurate)
-    }
-
     func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             locationConverter: file.locationConverter,
@@ -99,7 +96,7 @@ struct UnneededBreakInSwitchRule: SwiftSyntaxCorrectableRule {
 }
 
 private extension UnneededBreakInSwitchRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: SwitchCaseSyntax) {
             guard let statement = node.unneededBreak else {
                 return

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededSynthesizedInitializerRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededSynthesizedInitializerRule.swift
@@ -37,7 +37,7 @@ struct UnneededSynthesizedInitializerRule: SwiftSyntaxCorrectableRule {
 }
 
 private extension UnneededSynthesizedInitializerRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] {
             .allExcept(StructDeclSyntax.self, ClassDeclSyntax.self)
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UntypedErrorInCatchRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UntypedErrorInCatchRule.swift
@@ -1,5 +1,6 @@
 import SwiftSyntax
 
+@SwiftSyntaxRule
 struct UntypedErrorInCatchRule: OptInRule, SwiftSyntaxCorrectableRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
@@ -85,10 +86,6 @@ struct UntypedErrorInCatchRule: OptInRule, SwiftSyntaxCorrectableRule {
             Example("do {\n    try foo() \n} ↓catch (let error) {}"): Example("do {\n    try foo() \n} catch {}")
         ])
 
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(viewMode: .sourceAccurate)
-    }
-
     func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             locationConverter: file.locationConverter,
@@ -120,7 +117,7 @@ private extension CatchItemSyntax {
 }
 
 private extension UntypedErrorInCatchRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: CatchClauseSyntax) {
             guard let item = node.catchItems.onlyElement, item.isIdentifierPattern else {
                 return

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnusedEnumeratedRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnusedEnumeratedRule.swift
@@ -30,7 +30,7 @@ struct UnusedEnumeratedRule: Rule {
 }
 
 private extension UnusedEnumeratedRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: ForStmtSyntax) {
             guard let tuplePattern = node.pattern.as(TuplePatternSyntax.self),
                   tuplePattern.elements.count == 2,

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/VoidFunctionInTernaryConditionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/VoidFunctionInTernaryConditionRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct VoidFunctionInTernaryConditionRule: SwiftSyntaxRule {
+@SwiftSyntaxRule
+struct VoidFunctionInTernaryConditionRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(
@@ -105,14 +106,10 @@ struct VoidFunctionInTernaryConditionRule: SwiftSyntaxRule {
             """)
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(viewMode: .sourceAccurate)
-    }
 }
 
 private extension VoidFunctionInTernaryConditionRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: TernaryExprSyntax) {
             guard node.thenExpression.is(FunctionCallExprSyntax.self),
                   node.elseExpression.is(FunctionCallExprSyntax.self),

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/XCTFailMessageRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/XCTFailMessageRule.swift
@@ -37,7 +37,7 @@ struct XCTFailMessageRule: Rule {
 }
 
 private extension XCTFailMessageRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FunctionCallExprSyntax) {
             guard
                 let expression = node.calledExpression.as(DeclReferenceExprSyntax.self),

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/XCTSpecificMatcherRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/XCTSpecificMatcherRule.swift
@@ -1,7 +1,8 @@
 import SwiftOperators
 import SwiftSyntax
 
-struct XCTSpecificMatcherRule: SwiftSyntaxRule, OptInRule {
+@SwiftSyntaxRule
+struct XCTSpecificMatcherRule: OptInRule {
     var configuration = XCTSpecificMatcherConfiguration()
 
     static let description = RuleDescription(
@@ -12,21 +13,10 @@ struct XCTSpecificMatcherRule: SwiftSyntaxRule, OptInRule {
         nonTriggeringExamples: XCTSpecificMatcherRuleExamples.nonTriggeringExamples,
         triggeringExamples: XCTSpecificMatcherRuleExamples.triggeringExamples
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(configuration: configuration)
-    }
 }
 
 private extension XCTSpecificMatcherRule {
-    final class Visitor: ViolationsSyntaxVisitor {
-        let configuration: XCTSpecificMatcherConfiguration
-
-        init(configuration: XCTSpecificMatcherConfiguration) {
-            self.configuration = configuration
-            super.init(viewMode: .sourceAccurate)
-        }
-
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FunctionCallExprSyntax) {
             if configuration.matchers.contains(.twoArgumentAsserts),
                let suggestion = TwoArgsXCTAssert.violations(in: node) {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AnyObjectProtocolRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AnyObjectProtocolRule.swift
@@ -38,9 +38,9 @@ struct AnyObjectProtocolRule: SwiftSyntaxCorrectableRule, OptInRule {
         ]
     )
 
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor<ConfigurationType> {
         warnDeprecatedOnce()
-        return Visitor(viewMode: .sourceAccurate)
+        return Visitor(configuration: configuration, locationConverter: file.locationConverter)
     }
 
     func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
@@ -52,7 +52,7 @@ struct AnyObjectProtocolRule: SwiftSyntaxCorrectableRule, OptInRule {
 }
 
 private extension AnyObjectProtocolRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: ClassRestrictionTypeSyntax) {
             violations.append(node.positionAfterSkippingLeadingTrivia)
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AnyObjectProtocolRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AnyObjectProtocolRule.swift
@@ -40,7 +40,7 @@ struct AnyObjectProtocolRule: SwiftSyntaxCorrectableRule, OptInRule {
 
     func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor<ConfigurationType> {
         warnDeprecatedOnce()
-        return Visitor(configuration: configuration, locationConverter: file.locationConverter)
+        return Visitor(configuration: configuration, file: file)
     }
 
     func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ArrayInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ArrayInitRule.swift
@@ -52,7 +52,7 @@ struct ArrayInitRule: OptInRule {
 }
 
 private extension ArrayInitRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FunctionCallExprSyntax) {
             guard let memberAccess = node.calledExpression.as(MemberAccessExprSyntax.self),
                   memberAccess.declName.baseName.text == "map",

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/BalancedXCTestLifecycleRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/BalancedXCTestLifecycleRule.swift
@@ -117,7 +117,7 @@ private extension BalancedXCTestLifecycleRule {
                 return
             }
 
-            let methods = SetupTearDownVisitor(configuration: configuration, locationConverter: locationConverter)
+            let methods = SetupTearDownVisitor(configuration: configuration, file: file)
                 .walk(tree: node.memberBlock, handler: \.methods)
             guard methods.contains(.setUp) != methods.contains(.tearDown) else {
                 return

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/BalancedXCTestLifecycleRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/BalancedXCTestLifecycleRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct BalancedXCTestLifecycleRule: SwiftSyntaxRule, OptInRule {
+@SwiftSyntaxRule
+struct BalancedXCTestLifecycleRule: OptInRule {
     var configuration = BalancedXCTestLifecycleConfiguration()
 
     static let description = RuleDescription(
@@ -103,30 +104,20 @@ struct BalancedXCTestLifecycleRule: SwiftSyntaxRule, OptInRule {
             """#)
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(viewMode: .sourceAccurate, testParentClasses: configuration.testParentClasses)
-    }
 }
 
 // MARK: - Private
 
 private extension BalancedXCTestLifecycleRule {
-    final class Visitor: ViolationsSyntaxVisitor {
-        private let testParentClasses: Set<String>
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .all }
 
-        init(viewMode: SyntaxTreeViewMode, testParentClasses: Set<String>) {
-            self.testParentClasses = testParentClasses
-            super.init(viewMode: viewMode)
-        }
-
         override func visitPost(_ node: ClassDeclSyntax) {
-            guard node.isXCTestCase(testParentClasses) else {
+            guard node.isXCTestCase(configuration.testParentClasses) else {
                 return
             }
 
-            let methods = SetupTearDownVisitor(viewMode: .sourceAccurate)
+            let methods = SetupTearDownVisitor(configuration: configuration, locationConverter: locationConverter)
                 .walk(tree: node.memberBlock, handler: \.methods)
             guard methods.contains(.setUp) != methods.contains(.tearDown) else {
                 return
@@ -137,7 +128,7 @@ private extension BalancedXCTestLifecycleRule {
     }
 }
 
-private final class SetupTearDownVisitor: ViolationsSyntaxVisitor {
+private final class SetupTearDownVisitor<Configuration: RuleConfiguration>: ViolationsSyntaxVisitor<Configuration> {
     override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .all }
     private(set) var methods: Set<XCTMethod> = []
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ClassDelegateProtocolRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ClassDelegateProtocolRule.swift
@@ -32,7 +32,7 @@ struct ClassDelegateProtocolRule: Rule {
 }
 
 private extension ClassDelegateProtocolRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] {
             .allExcept(ProtocolDeclSyntax.self)
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/CompilerProtocolInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/CompilerProtocolInitRule.swift
@@ -24,7 +24,7 @@ struct CompilerProtocolInitRule: Rule {
 }
 
 private extension CompilerProtocolInitRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FunctionCallExprSyntax) {
             guard node.trailingClosure == nil else {
                 return

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/DeploymentTargetRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/DeploymentTargetRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct DeploymentTargetRule: SwiftSyntaxRule {
+@SwiftSyntaxRule
+struct DeploymentTargetRule {
     fileprivate typealias Version = DeploymentTargetConfiguration.Version
     var configuration = DeploymentTargetConfiguration()
 
@@ -13,50 +14,39 @@ struct DeploymentTargetRule: SwiftSyntaxRule {
         nonTriggeringExamples: DeploymentTargetRuleExamples.nonTriggeringExamples,
         triggeringExamples: DeploymentTargetRuleExamples.triggeringExamples
     )
+}
 
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(platformToConfiguredMinVersion: platformToConfiguredMinVersion)
-    }
+private enum AvailabilityType {
+    case condition
+    case attribute
+    case negativeCondition
 
-    private var platformToConfiguredMinVersion: [String: Version] {
-        return [
-            "iOS": configuration.iOSDeploymentTarget,
-            "iOSApplicationExtension": configuration.iOSAppExtensionDeploymentTarget,
-            "macOS": configuration.macOSDeploymentTarget,
-            "macOSApplicationExtension": configuration.macOSAppExtensionDeploymentTarget,
-            "OSX": configuration.macOSDeploymentTarget,
-            "tvOS": configuration.tvOSDeploymentTarget,
-            "tvOSApplicationExtension": configuration.tvOSAppExtensionDeploymentTarget,
-            "watchOS": configuration.watchOSDeploymentTarget,
-            "watchOSApplicationExtension": configuration.watchOSAppExtensionDeploymentTarget
-        ]
-    }
-
-    private enum AvailabilityType {
-        case condition
-        case attribute
-        case negativeCondition
-
-        var displayString: String {
-            switch self {
-            case .condition:
-                return "condition"
-            case .attribute:
-                return "attribute"
-            case .negativeCondition:
-                return "negative condition"
-            }
+    var displayString: String {
+        switch self {
+        case .condition:
+            return "condition"
+        case .attribute:
+            return "attribute"
+        case .negativeCondition:
+            return "negative condition"
         }
     }
 }
 
 private extension DeploymentTargetRule {
-    final class Visitor: ViolationsSyntaxVisitor {
-        private let platformToConfiguredMinVersion: [String: Version]
-
-        init(platformToConfiguredMinVersion: [String: Version]) {
-            self.platformToConfiguredMinVersion = platformToConfiguredMinVersion
-            super.init(viewMode: .sourceAccurate)
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
+        private var platformToConfiguredMinVersion: [String: Version] {
+            [
+                "iOS": configuration.iOSDeploymentTarget,
+                "iOSApplicationExtension": configuration.iOSAppExtensionDeploymentTarget,
+                "macOS": configuration.macOSDeploymentTarget,
+                "macOSApplicationExtension": configuration.macOSAppExtensionDeploymentTarget,
+                "OSX": configuration.macOSDeploymentTarget,
+                "tvOS": configuration.tvOSDeploymentTarget,
+                "tvOSApplicationExtension": configuration.tvOSAppExtensionDeploymentTarget,
+                "watchOS": configuration.watchOSDeploymentTarget,
+                "watchOSApplicationExtension": configuration.watchOSAppExtensionDeploymentTarget
+            ]
         }
 
         override func visitPost(_ node: AttributeSyntax) {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/DiscardedNotificationCenterObserverRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/DiscardedNotificationCenterObserverRule.swift
@@ -59,7 +59,7 @@ struct DiscardedNotificationCenterObserverRule: OptInRule {
 }
 
 private extension DiscardedNotificationCenterObserverRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FunctionCallExprSyntax) {
             guard
                 let calledExpression = node.calledExpression.as(MemberAccessExprSyntax.self),

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/DiscouragedDirectInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/DiscouragedDirectInitRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct DiscouragedDirectInitRule: SwiftSyntaxRule {
+@SwiftSyntaxRule
+struct DiscouragedDirectInitRule: Rule {
     var configuration = DiscouragedDirectInitConfiguration()
 
     static let description = RuleDescription(
@@ -34,24 +35,13 @@ struct DiscouragedDirectInitRule: SwiftSyntaxRule {
             Example("let foo = bar(bundle: ↓Bundle.init(), device: ↓UIDevice.init(), error: ↓NSError.init())")
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(discouragedInits: configuration.discouragedInits)
-    }
 }
 
 private extension DiscouragedDirectInitRule {
-    final class Visitor: ViolationsSyntaxVisitor {
-        private let discouragedInits: Set<String>
-
-        init(discouragedInits: Set<String>) {
-            self.discouragedInits = discouragedInits
-            super.init(viewMode: .sourceAccurate)
-        }
-
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FunctionCallExprSyntax) {
             guard node.arguments.isEmpty, node.trailingClosure == nil,
-                discouragedInits.contains(node.calledExpression.trimmedDescription) else {
+                  configuration.discouragedInits.contains(node.calledExpression.trimmedDescription) else {
                 return
             }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/DuplicateConditionsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/DuplicateConditionsRule.swift
@@ -158,7 +158,7 @@ struct DuplicateConditionsRule: Rule {
 }
 
 private extension DuplicateConditionsRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: IfExprSyntax) {
             if  node.parent?.is(IfExprSyntax.self) == true {
                 // We can skip these cases - they will be picked up when we visit the top level `if`

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/DuplicateEnumCasesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/DuplicateEnumCasesRule.swift
@@ -58,7 +58,7 @@ struct DuplicateEnumCasesRule: Rule {
 }
 
 private extension DuplicateEnumCasesRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: EnumDeclSyntax) {
             let enumElements = node.memberBlock.members
                 .flatMap { member -> EnumCaseElementListSyntax in

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/DuplicatedKeyInDictionaryLiteralRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/DuplicatedKeyInDictionaryLiteralRule.swift
@@ -80,7 +80,7 @@ struct DuplicatedKeyInDictionaryLiteralRule: Rule {
 }
 
 private extension DuplicatedKeyInDictionaryLiteralRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ list: DictionaryElementListSyntax) {
             let keys = list.map(\.key).compactMap { expr -> DictionaryKey? in
                 expr.stringContent.map {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/DynamicInlineRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/DynamicInlineRule.swift
@@ -25,7 +25,7 @@ struct DynamicInlineRule: Rule {
 }
 
 private extension DynamicInlineRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FunctionDeclSyntax) {
             if node.modifiers.contains(where: { $0.name.text == "dynamic" }),
                node.attributes.contains(where: { $0.as(AttributeSyntax.self)?.isInlineAlways == true }) {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/EmptyXCTestMethodRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/EmptyXCTestMethodRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct EmptyXCTestMethodRule: OptInRule, SwiftSyntaxRule {
+@SwiftSyntaxRule
+struct EmptyXCTestMethodRule: OptInRule {
     var configuration = EmptyXCTestMethodConfiguration()
 
     static let description = RuleDescription(
@@ -11,24 +12,14 @@ struct EmptyXCTestMethodRule: OptInRule, SwiftSyntaxRule {
         nonTriggeringExamples: EmptyXCTestMethodRuleExamples.nonTriggeringExamples,
         triggeringExamples: EmptyXCTestMethodRuleExamples.triggeringExamples
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(testParentClasses: configuration.testParentClasses)
-    }
 }
 
 private extension EmptyXCTestMethodRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .all }
-        private let testParentClasses: Set<String>
-
-        init(testParentClasses: Set<String>) {
-            self.testParentClasses = testParentClasses
-            super.init(viewMode: .sourceAccurate)
-        }
 
         override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
-            node.isXCTestCase(testParentClasses) ? .visitChildren : .skipChildren
+            node.isXCTestCase(configuration.testParentClasses) ? .visitChildren : .skipChildren
         }
 
         override func visitPost(_ node: FunctionDeclSyntax) {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/IBInspectableInExtensionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/IBInspectableInExtensionRule.swift
@@ -27,7 +27,7 @@ struct IBInspectableInExtensionRule: OptInRule {
 }
 
 private extension IBInspectableInExtensionRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] {
             .allExcept(ExtensionDeclSyntax.self, VariableDeclSyntax.self)
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/IdenticalOperandsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/IdenticalOperandsRule.swift
@@ -72,7 +72,7 @@ struct IdenticalOperandsRule: OptInRule {
 }
 
 private extension IdenticalOperandsRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: InfixOperatorExprSyntax) {
             guard let operatorNode = node.operator.as(BinaryOperatorExprSyntax.self),
                   IdenticalOperandsRule.operators.contains(operatorNode.operator.text) else {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/InertDeferRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/InertDeferRule.swift
@@ -85,7 +85,7 @@ struct InertDeferRule: SwiftSyntaxRule, OptInRule {
 
     func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor<ConfigurationType> {
         warnDeprecatedOnce()
-        return Visitor(configuration: configuration, locationConverter: file.locationConverter)
+        return Visitor(configuration: configuration, file: file)
     }
 }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/InertDeferRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/InertDeferRule.swift
@@ -83,14 +83,14 @@ struct InertDeferRule: SwiftSyntaxRule, OptInRule {
         ]
     )
 
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor<ConfigurationType> {
         warnDeprecatedOnce()
-        return Visitor(viewMode: .sourceAccurate)
+        return Visitor(configuration: configuration, locationConverter: file.locationConverter)
     }
 }
 
 private extension InertDeferRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: DeferStmtSyntax) {
             guard node.isLastStatement else {
                 return

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/LocalDocCommentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/LocalDocCommentRule.swift
@@ -43,7 +43,7 @@ struct LocalDocCommentRule: SwiftSyntaxRule, OptInRule {
     func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor<ConfigurationType> {
         Visitor(
             configuration: configuration,
-            locationConverter: file.locationConverter,
+            file: file,
             classifications: file.syntaxClassifications.filter { $0.kind != .none }
         )
     }
@@ -53,12 +53,12 @@ private extension LocalDocCommentRule {
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         private let docCommentRanges: [ByteSourceRange]
 
-        init(configuration: ConfigurationType, locationConverter: SourceLocationConverter,
+        init(configuration: ConfigurationType, file: SwiftLintFile,
              classifications: [SyntaxClassifiedRange]) {
             self.docCommentRanges = classifications
                 .filter { $0.kind == .docLineComment || $0.kind == .docBlockComment }
                 .map(\.range)
-            super.init(configuration: configuration, locationConverter: locationConverter)
+            super.init(configuration: configuration, file: file)
         }
 
         override func visitPost(_ node: FunctionDeclSyntax) {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/LocalDocCommentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/LocalDocCommentRule.swift
@@ -40,20 +40,25 @@ struct LocalDocCommentRule: SwiftSyntaxRule, OptInRule {
         ]
     )
 
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(classifications: file.syntaxClassifications.filter { $0.kind != .none })
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor<ConfigurationType> {
+        Visitor(
+            configuration: configuration,
+            locationConverter: file.locationConverter,
+            classifications: file.syntaxClassifications.filter { $0.kind != .none }
+        )
     }
 }
 
 private extension LocalDocCommentRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         private let docCommentRanges: [ByteSourceRange]
 
-        init(classifications: [SyntaxClassifiedRange]) {
+        init(configuration: ConfigurationType, locationConverter: SourceLocationConverter,
+             classifications: [SyntaxClassifiedRange]) {
             self.docCommentRanges = classifications
                 .filter { $0.kind == .docLineComment || $0.kind == .docBlockComment }
                 .map(\.range)
-            super.init(viewMode: .sourceAccurate)
+            super.init(configuration: configuration, locationConverter: locationConverter)
         }
 
         override func visitPost(_ node: FunctionDeclSyntax) {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/LowerACLThanParentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/LowerACLThanParentRule.swift
@@ -90,7 +90,7 @@ struct LowerACLThanParentRule: OptInRule, SwiftSyntaxCorrectableRule {
 }
 
 private extension LowerACLThanParentRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: DeclModifierSyntax) {
             if node.isHigherACLThanParent {
                 violations.append(node.positionAfterSkippingLeadingTrivia)

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/NSLocalizedStringKeyRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/NSLocalizedStringKeyRule.swift
@@ -34,7 +34,7 @@ struct NSLocalizedStringKeyRule: OptInRule {
 }
 
 private extension NSLocalizedStringKeyRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FunctionCallExprSyntax) {
             guard node.calledExpression.as(DeclReferenceExprSyntax.self)?.baseName.text == "NSLocalizedString" else {
                 return

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/NSLocalizedStringRequireBundleRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/NSLocalizedStringRequireBundleRule.swift
@@ -43,7 +43,7 @@ struct NSLocalizedStringRequireBundleRule: OptInRule {
 }
 
 private extension NSLocalizedStringRequireBundleRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FunctionCallExprSyntax) {
             if let identifierExpr = node.calledExpression.as(DeclReferenceExprSyntax.self),
                identifierExpr.baseName.tokenKind == .identifier("NSLocalizedString"),

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/NSNumberInitAsFunctionReferenceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/NSNumberInitAsFunctionReferenceRule.swift
@@ -26,7 +26,7 @@ struct NSNumberInitAsFunctionReferenceRule: Rule {
 }
 
 private extension NSNumberInitAsFunctionReferenceRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: MemberAccessExprSyntax) {
             guard node.declName.argumentNames.isEmptyOrNil,
                   node.declName.baseName.text == "init",

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/NSObjectPreferIsEqualRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/NSObjectPreferIsEqualRule.swift
@@ -15,7 +15,7 @@ struct NSObjectPreferIsEqualRule: Rule {
 }
 
 private extension NSObjectPreferIsEqualRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .extensionsAndProtocols }
 
         override func visitPost(_ node: FunctionDeclSyntax) {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/NotificationCenterDetachmentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/NotificationCenterDetachmentRule.swift
@@ -15,7 +15,7 @@ struct NotificationCenterDetachmentRule: Rule {
 }
 
 private extension NotificationCenterDetachmentRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FunctionCallExprSyntax) {
             guard node.isNotificationCenterDettachmentCall,
                   let arg = node.arguments.first,

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/OverrideInExtensionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/OverrideInExtensionRule.swift
@@ -36,11 +36,11 @@ struct OverrideInExtensionRule: OptInRule, SwiftSyntaxRule {
     func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor<ConfigurationType> {
         let allowedExtensions = ClassNameCollectingVisitor(
             configuration: configuration,
-            locationConverter: file.locationConverter
+            file: file
         ).walk(tree: file.syntaxTree, handler: \.classNames)
         return Visitor(
             configuration: configuration,
-            locationConverter: file.locationConverter,
+            file: file,
             allowedExtensions: allowedExtensions
         )
     }
@@ -50,10 +50,10 @@ private extension OverrideInExtensionRule {
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         private let allowedExtensions: Set<String>
 
-        init(configuration: ConfigurationType, locationConverter: SourceLocationConverter,
+        init(configuration: ConfigurationType, file: SwiftLintFile,
              allowedExtensions: Set<String>) {
             self.allowedExtensions = allowedExtensions
-            super.init(configuration: configuration, locationConverter: locationConverter)
+            super.init(configuration: configuration, file: file)
         }
 
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .allExcept(ExtensionDeclSyntax.self) }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/OverrideInExtensionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/OverrideInExtensionRule.swift
@@ -33,20 +33,27 @@ struct OverrideInExtensionRule: OptInRule, SwiftSyntaxRule {
         ]
     )
 
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        let allowedExtensions = ClassNameCollectingVisitor(viewMode: .sourceAccurate)
-            .walk(tree: file.syntaxTree, handler: \.classNames)
-        return Visitor(allowedExtensions: allowedExtensions)
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor<ConfigurationType> {
+        let allowedExtensions = ClassNameCollectingVisitor(
+            configuration: configuration,
+            locationConverter: file.locationConverter
+        ).walk(tree: file.syntaxTree, handler: \.classNames)
+        return Visitor(
+            configuration: configuration,
+            locationConverter: file.locationConverter,
+            allowedExtensions: allowedExtensions
+        )
     }
 }
 
 private extension OverrideInExtensionRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         private let allowedExtensions: Set<String>
 
-        init(allowedExtensions: Set<String>) {
+        init(configuration: ConfigurationType, locationConverter: SourceLocationConverter,
+             allowedExtensions: Set<String>) {
             self.allowedExtensions = allowedExtensions
-            super.init(viewMode: .sourceAccurate)
+            super.init(configuration: configuration, locationConverter: locationConverter)
         }
 
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .allExcept(ExtensionDeclSyntax.self) }
@@ -72,14 +79,14 @@ private extension OverrideInExtensionRule {
             return .visitChildren
         }
     }
-}
 
-private class ClassNameCollectingVisitor: ViolationsSyntaxVisitor {
-    private(set) var classNames: Set<String> = []
+    final class ClassNameCollectingVisitor: ViolationsSyntaxVisitor<ConfigurationType> {
+        private(set) var classNames: Set<String> = []
 
-    override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .all }
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .all }
 
-    override func visitPost(_ node: ClassDeclSyntax) {
-        classNames.insert(node.name.text)
+        override func visitPost(_ node: ClassDeclSyntax) {
+            classNames.insert(node.name.text)
+        }
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateActionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateActionRule.swift
@@ -34,7 +34,7 @@ struct PrivateActionRule: OptInRule {
 }
 
 private extension PrivateActionRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
             node.modifiers.containsPrivateOrFileprivate() ? .skipChildren : .visitChildren
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateOutletRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateOutletRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct PrivateOutletRule: SwiftSyntaxRule, OptInRule {
+@SwiftSyntaxRule
+struct PrivateOutletRule: OptInRule {
     var configuration = PrivateOutletConfiguration()
 
     static let description = RuleDescription(
@@ -75,21 +76,10 @@ struct PrivateOutletRule: SwiftSyntaxRule, OptInRule {
             """, configuration: ["allow_private_set": false], excludeFromDocumentation: true)
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(allowPrivateSet: configuration.allowPrivateSet)
-    }
 }
 
 private extension PrivateOutletRule {
-    final class Visitor: ViolationsSyntaxVisitor {
-        private let allowPrivateSet: Bool
-
-        init(allowPrivateSet: Bool) {
-            self.allowPrivateSet = allowPrivateSet
-            super.init(viewMode: .sourceAccurate)
-        }
-
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: MemberBlockItemSyntax) {
             guard
                 let decl = node.decl.as(VariableDeclSyntax.self),
@@ -99,7 +89,7 @@ private extension PrivateOutletRule {
                 return
             }
 
-            if allowPrivateSet && decl.modifiers.containsPrivateOrFileprivate(setOnly: true) {
+            if configuration.allowPrivateSet && decl.modifiers.containsPrivateOrFileprivate(setOnly: true) {
                 return
             }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateSubjectRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateSubjectRule.swift
@@ -15,7 +15,7 @@ struct PrivateSubjectRule: OptInRule {
 }
 
 private extension PrivateSubjectRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         private let subjectTypes: Set<String> = ["PassthroughSubject", "CurrentValueSubject"]
 
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateSwiftUIStatePropertyRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateSwiftUIStatePropertyRule.swift
@@ -196,7 +196,7 @@ struct PrivateSwiftUIStatePropertyRule: OptInRule {
 }
 
 private extension PrivateSwiftUIStatePropertyRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] {
             [ProtocolDeclSyntax.self]
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateUnitTestRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateUnitTestRule.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SwiftSyntax
 
+@SwiftSyntaxRule
 struct PrivateUnitTestRule: SwiftSyntaxCorrectableRule {
     var configuration = PrivateUnitTestConfiguration()
 
@@ -125,10 +126,6 @@ struct PrivateUnitTestRule: SwiftSyntaxCorrectableRule {
         ]
     )
 
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(configuration: configuration)
-    }
-
     func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             configuration: configuration,
@@ -139,15 +136,8 @@ struct PrivateUnitTestRule: SwiftSyntaxCorrectableRule {
 }
 
 private extension PrivateUnitTestRule {
-    final class Visitor: ViolationsSyntaxVisitor {
-        private let configuration: PrivateUnitTestConfiguration
-
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .all }
-
-        init(configuration: PrivateUnitTestConfiguration) {
-            self.configuration = configuration
-            super.init(viewMode: .sourceAccurate)
-        }
 
         override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
             !node.isPrivate && node.hasParent(configuredIn: configuration) ? .visitChildren : .skipChildren

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ProhibitedInterfaceBuilderRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ProhibitedInterfaceBuilderRule.swift
@@ -21,7 +21,7 @@ struct ProhibitedInterfaceBuilderRule: OptInRule {
 }
 
 private extension ProhibitedInterfaceBuilderRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: VariableDeclSyntax) {
             if node.isIBOutlet {
                 violations.append(node.bindingSpecifier.positionAfterSkippingLeadingTrivia)

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/QuickDiscouragedFocusedTestRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/QuickDiscouragedFocusedTestRule.swift
@@ -15,7 +15,7 @@ struct QuickDiscouragedFocusedTestRule: OptInRule {
 }
 
 private extension QuickDiscouragedFocusedTestRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .all }
 
         override func visitPost(_ node: FunctionCallExprSyntax) {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/QuickDiscouragedPendingTestRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/QuickDiscouragedPendingTestRule.swift
@@ -15,7 +15,7 @@ struct QuickDiscouragedPendingTestRule: OptInRule {
 }
 
 private extension QuickDiscouragedPendingTestRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .all }
 
         override func visitPost(_ node: FunctionCallExprSyntax) {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/RawValueForCamelCasedCodableEnumRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/RawValueForCamelCasedCodableEnumRule.swift
@@ -94,7 +94,7 @@ struct RawValueForCamelCasedCodableEnumRule: OptInRule {
 }
 
 private extension RawValueForCamelCasedCodableEnumRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         private let codableTypes = Set(["Codable", "Decodable", "Encodable"])
 
         override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/RequiredDeinitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/RequiredDeinitRule.swift
@@ -71,7 +71,7 @@ struct RequiredDeinitRule: OptInRule {
 private extension RequiredDeinitRule {
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: ClassDeclSyntax) {
-            let visitor = DeinitVisitor(configuration: configuration, locationConverter: locationConverter)
+            let visitor = DeinitVisitor(configuration: configuration, file: file)
             if !visitor.walk(tree: node.memberBlock, handler: \.hasDeinit) {
                 violations.append(node.classKeyword.positionAfterSkippingLeadingTrivia)
             }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/RequiredDeinitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/RequiredDeinitRule.swift
@@ -69,22 +69,22 @@ struct RequiredDeinitRule: OptInRule {
 }
 
 private extension RequiredDeinitRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: ClassDeclSyntax) {
-            let visitor = DeinitVisitor(viewMode: .sourceAccurate)
+            let visitor = DeinitVisitor(configuration: configuration, locationConverter: locationConverter)
             if !visitor.walk(tree: node.memberBlock, handler: \.hasDeinit) {
                 violations.append(node.classKeyword.positionAfterSkippingLeadingTrivia)
             }
         }
     }
-}
 
-private class DeinitVisitor: ViolationsSyntaxVisitor {
-    private(set) var hasDeinit = false
+    final class DeinitVisitor: ViolationsSyntaxVisitor<ConfigurationType> {
+        private(set) var hasDeinit = false
 
-    override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .all }
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .all }
 
-    override func visitPost(_ node: DeinitializerDeclSyntax) {
-        hasDeinit = true
+        override func visitPost(_ node: DeinitializerDeclSyntax) {
+            hasDeinit = true
+        }
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/RequiredEnumCaseRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/RequiredEnumCaseRule.swift
@@ -67,7 +67,8 @@ import SwiftSyntax
 ///     case accountCreated
 /// }
 /// ````
-struct RequiredEnumCaseRule: SwiftSyntaxRule, OptInRule {
+@SwiftSyntaxRule
+struct RequiredEnumCaseRule: OptInRule {
     var configuration = RequiredEnumCaseConfiguration()
 
     private static let exampleConfiguration = [
@@ -130,21 +131,10 @@ struct RequiredEnumCaseRule: SwiftSyntaxRule, OptInRule {
             """, configuration: exampleConfiguration)
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(configuration: configuration)
-    }
 }
 
 private extension RequiredEnumCaseRule {
-    final class Visitor: ViolationsSyntaxVisitor {
-        private let configuration: RequiredEnumCaseConfiguration
-
-        init(configuration: RequiredEnumCaseConfiguration) {
-            self.configuration = configuration
-            super.init(viewMode: .sourceAccurate)
-        }
-
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: EnumDeclSyntax) {
             guard configuration.protocols.isNotEmpty else {
                 return

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/SelfInPropertyInitializationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/SelfInPropertyInitializationRule.swift
@@ -93,7 +93,7 @@ struct SelfInPropertyInitializationRule: Rule {
 }
 
 private extension SelfInPropertyInitializationRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: VariableDeclSyntax) {
             guard !node.modifiers.contains(keyword: .lazy),
                   !node.modifiers.containsStaticOrClass,

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/StrongIBOutletRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/StrongIBOutletRule.swift
@@ -37,7 +37,7 @@ struct StrongIBOutletRule: SwiftSyntaxCorrectableRule, OptInRule {
 }
 
 private extension StrongIBOutletRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: VariableDeclSyntax) {
             if let violationPosition = node.violationPosition {
                 violations.append(violationPosition)

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/TestCaseAccessibilityRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/TestCaseAccessibilityRule.swift
@@ -37,7 +37,7 @@ private extension TestCaseAccessibilityRule {
                 return
             }
             violations.append(
-                contentsOf: XCTestClassVisitor(configuration: configuration, locationConverter: locationConverter)
+                contentsOf: XCTestClassVisitor(configuration: configuration, file: file)
                     .walk(tree: node.memberBlock, handler: \.violations)
             )
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/TestCaseAccessibilityRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/TestCaseAccessibilityRule.swift
@@ -1,8 +1,8 @@
 import Foundation
 import SwiftSyntax
 
-struct TestCaseAccessibilityRule: SwiftSyntaxRule, OptInRule,
-                                         SubstitutionCorrectableRule {
+@SwiftSyntaxRule
+struct TestCaseAccessibilityRule: OptInRule, SubstitutionCorrectableRule {
     var configuration = TestCaseAccessibilityConfiguration()
 
     static let description = RuleDescription(
@@ -14,10 +14,6 @@ struct TestCaseAccessibilityRule: SwiftSyntaxRule, OptInRule,
         triggeringExamples: TestCaseAccessibilityRuleExamples.triggeringExamples,
         corrections: TestCaseAccessibilityRuleExamples.corrections
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(allowedPrefixes: configuration.allowedPrefixes, testParentClasses: configuration.testParentClasses)
-    }
 
     func violationRanges(in file: SwiftLintFile) -> [NSRange] {
         makeVisitor(file: file)
@@ -33,101 +29,84 @@ struct TestCaseAccessibilityRule: SwiftSyntaxRule, OptInRule,
 }
 
 private extension TestCaseAccessibilityRule {
-    final class Visitor: ViolationsSyntaxVisitor {
-        private let allowedPrefixes: Set<String>
-        private let testParentClasses: Set<String>
-
-        init(allowedPrefixes: Set<String>, testParentClasses: Set<String>) {
-            self.allowedPrefixes = allowedPrefixes
-            self.testParentClasses = testParentClasses
-            super.init(viewMode: .sourceAccurate)
-        }
-
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .all }
 
         override func visitPost(_ node: ClassDeclSyntax) {
-            guard !testParentClasses.isDisjoint(with: node.inheritedTypes) else {
+            guard !configuration.testParentClasses.isDisjoint(with: node.inheritedTypes) else {
                 return
             }
-
             violations.append(
-                contentsOf: XCTestClassVisitor(allowedPrefixes: allowedPrefixes)
+                contentsOf: XCTestClassVisitor(configuration: configuration, locationConverter: locationConverter)
                     .walk(tree: node.memberBlock, handler: \.violations)
             )
         }
     }
-}
 
-private final class XCTestClassVisitor: ViolationsSyntaxVisitor {
-    private let allowedPrefixes: Set<String>
+    final class XCTestClassVisitor: ViolationsSyntaxVisitor<ConfigurationType> {
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .all }
 
-    init(allowedPrefixes: Set<String>) {
-        self.allowedPrefixes = allowedPrefixes
-        super.init(viewMode: .sourceAccurate)
-    }
-
-    override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .all }
-
-    override func visitPost(_ node: VariableDeclSyntax) {
-        guard !node.modifiers.containsPrivateOrFileprivate(),
-              !XCTestHelpers.isXCTestVariable(node) else {
-            return
-        }
-
-        for binding in node.bindings {
-            guard let pattern = binding.pattern.as(IdentifierPatternSyntax.self),
-                  case let name = pattern.identifier.text,
-                  !allowedPrefixes.contains(where: name.hasPrefix) else {
-                continue
+        override func visitPost(_ node: VariableDeclSyntax) {
+            guard !node.modifiers.containsPrivateOrFileprivate(),
+                  !XCTestHelpers.isXCTestVariable(node) else {
+                return
             }
 
-            violations.append(node.bindingSpecifier.positionAfterSkippingLeadingTrivia)
-            return
+            for binding in node.bindings {
+                guard let pattern = binding.pattern.as(IdentifierPatternSyntax.self),
+                      case let name = pattern.identifier.text,
+                      !configuration.allowedPrefixes.contains(where: name.hasPrefix) else {
+                    continue
+                }
+
+                violations.append(node.bindingSpecifier.positionAfterSkippingLeadingTrivia)
+                return
+            }
         }
-    }
 
-    override func visitPost(_ node: FunctionDeclSyntax) {
-        guard hasViolation(modifiers: node.modifiers, identifierToken: node.name),
-              !XCTestHelpers.isXCTestFunction(node) else {
-            return
+        override func visitPost(_ node: FunctionDeclSyntax) {
+            guard hasViolation(modifiers: node.modifiers, identifierToken: node.name),
+                  !XCTestHelpers.isXCTestFunction(node) else {
+                return
+            }
+
+            violations.append(node.positionAfterSkippingLeadingTrivia)
         }
 
-        violations.append(node.positionAfterSkippingLeadingTrivia)
-    }
-
-    override func visitPost(_ node: ClassDeclSyntax) {
-        if hasViolation(modifiers: node.modifiers, identifierToken: node.name) {
-            violations.append(node.classKeyword.positionAfterSkippingLeadingTrivia)
+        override func visitPost(_ node: ClassDeclSyntax) {
+            if hasViolation(modifiers: node.modifiers, identifierToken: node.name) {
+                violations.append(node.classKeyword.positionAfterSkippingLeadingTrivia)
+            }
         }
-    }
 
-    override func visitPost(_ node: EnumDeclSyntax) {
-        if hasViolation(modifiers: node.modifiers, identifierToken: node.name) {
-            violations.append(node.enumKeyword.positionAfterSkippingLeadingTrivia)
+        override func visitPost(_ node: EnumDeclSyntax) {
+            if hasViolation(modifiers: node.modifiers, identifierToken: node.name) {
+                violations.append(node.enumKeyword.positionAfterSkippingLeadingTrivia)
+            }
         }
-    }
 
-    override func visitPost(_ node: StructDeclSyntax) {
-        if hasViolation(modifiers: node.modifiers, identifierToken: node.name) {
-            violations.append(node.structKeyword.positionAfterSkippingLeadingTrivia)
+        override func visitPost(_ node: StructDeclSyntax) {
+            if hasViolation(modifiers: node.modifiers, identifierToken: node.name) {
+                violations.append(node.structKeyword.positionAfterSkippingLeadingTrivia)
+            }
         }
-    }
 
-    override func visitPost(_ node: ActorDeclSyntax) {
-        if hasViolation(modifiers: node.modifiers, identifierToken: node.name) {
-            violations.append(node.actorKeyword.positionAfterSkippingLeadingTrivia)
+        override func visitPost(_ node: ActorDeclSyntax) {
+            if hasViolation(modifiers: node.modifiers, identifierToken: node.name) {
+                violations.append(node.actorKeyword.positionAfterSkippingLeadingTrivia)
+            }
         }
-    }
 
-    override func visitPost(_ node: TypeAliasDeclSyntax) {
-        if hasViolation(modifiers: node.modifiers, identifierToken: node.name) {
-            violations.append(node.typealiasKeyword.positionAfterSkippingLeadingTrivia)
+        override func visitPost(_ node: TypeAliasDeclSyntax) {
+            if hasViolation(modifiers: node.modifiers, identifierToken: node.name) {
+                violations.append(node.typealiasKeyword.positionAfterSkippingLeadingTrivia)
+            }
         }
-    }
 
-    private func hasViolation(modifiers: DeclModifierListSyntax, identifierToken: TokenSyntax) -> Bool {
-           !modifiers.containsPrivateOrFileprivate()
-        && !allowedPrefixes.contains(where: identifierToken.text.hasPrefix)
+        private func hasViolation(modifiers: DeclModifierListSyntax, identifierToken: TokenSyntax) -> Bool {
+               !modifiers.containsPrivateOrFileprivate()
+            && !configuration.allowedPrefixes.contains(where: identifierToken.text.hasPrefix)
+        }
     }
 }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/TodoRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/TodoRule.swift
@@ -1,7 +1,8 @@
 import Foundation
 import SwiftSyntax
 
-struct TodoRule: SwiftSyntaxRule {
+@SwiftSyntaxRule
+struct TodoRule: Rule {
     var configuration = TodoConfiguration()
 
     static let description = RuleDescription(
@@ -24,26 +25,15 @@ struct TodoRule: SwiftSyntaxRule {
             Example("/** ↓TODO: */")
         ].skipWrappingInCommentTests()
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(todoKeywords: configuration.only)
-    }
 }
 
 private extension TodoRule {
-    final class Visitor: ViolationsSyntaxVisitor {
-        private let todoKeywords: [TodoConfiguration.TodoKeyword]
-
-        init(todoKeywords: [TodoConfiguration.TodoKeyword]) {
-            self.todoKeywords = todoKeywords
-            super.init(viewMode: .sourceAccurate)
-        }
-
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: TokenSyntax) {
             let leadingViolations = node.leadingTrivia.violations(offset: node.position,
-                                                                  for: todoKeywords)
+                                                                  for: configuration.only)
             let trailingViolations = node.trailingTrivia.violations(offset: node.endPositionBeforeTrailingTrivia,
-                                                                    for: todoKeywords)
+                                                                    for: configuration.only)
             violations.append(contentsOf: leadingViolations + trailingViolations)
         }
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnhandledThrowingTaskRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnhandledThrowingTaskRule.swift
@@ -187,7 +187,7 @@ struct UnhandledThrowingTaskRule: OptInRule {
 }
 
 private extension UnhandledThrowingTaskRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FunctionCallExprSyntax) {
             if node.hasViolation {
                 violations.append(node.calledExpression.positionAfterSkippingLeadingTrivia)

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnneededOverrideRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnneededOverrideRule.swift
@@ -58,7 +58,7 @@ private func extractFunctionCallSyntax(_ node: some SyntaxProtocol) -> FunctionC
 }
 
 private extension UnneededOverrideRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FunctionDeclSyntax) {
             if isUnneededOverride(node) {
                 self.violations.append(node.positionAfterSkippingLeadingTrivia)

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnownedVariableCaptureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnownedVariableCaptureRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct UnownedVariableCaptureRule: SwiftSyntaxRule, OptInRule {
+@SwiftSyntaxRule
+struct UnownedVariableCaptureRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(
@@ -31,14 +32,10 @@ struct UnownedVariableCaptureRule: SwiftSyntaxRule, OptInRule {
             Example("foo { [bar, ↓unowned self] in _ }")
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(viewMode: .sourceAccurate)
-    }
 }
 
 private extension UnownedVariableCaptureRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: TokenSyntax) {
             if case .keyword(.unowned) = node.tokenKind, node.parent?.is(ClosureCaptureSpecifierSyntax.self) == true {
                 violations.append(node.positionAfterSkippingLeadingTrivia)

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedCaptureListRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedCaptureListRule.swift
@@ -146,7 +146,7 @@ struct UnusedCaptureListRule: SwiftSyntaxRule, OptInRule {
 
     func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor<ConfigurationType> {
         warnDeprecatedOnce()
-        return Visitor(configuration: configuration, locationConverter: file.locationConverter)
+        return Visitor(configuration: configuration, file: file)
     }
 }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedCaptureListRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedCaptureListRule.swift
@@ -144,14 +144,14 @@ struct UnusedCaptureListRule: SwiftSyntaxRule, OptInRule {
         ]
     )
 
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor<ConfigurationType> {
         warnDeprecatedOnce()
-        return Visitor(viewMode: .sourceAccurate)
+        return Visitor(configuration: configuration, locationConverter: file.locationConverter)
     }
 }
 
 private extension UnusedCaptureListRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: ClosureExprSyntax) {
             guard let captureItems = node.signature?.capture?.items,
                   captureItems.isNotEmpty else {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedClosureParameterRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedClosureParameterRule.swift
@@ -24,7 +24,7 @@ struct UnusedClosureParameterRule: SwiftSyntaxCorrectableRule {
 }
 
 private extension UnusedClosureParameterRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: ClosureExprSyntax) {
             let namedParameters = node.namedParameters
             guard namedParameters.isNotEmpty else {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedControlFlowLabelRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedControlFlowLabelRule.swift
@@ -93,7 +93,7 @@ struct UnusedControlFlowLabelRule: SwiftSyntaxCorrectableRule {
 }
 
 private extension UnusedControlFlowLabelRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: LabeledStmtSyntax) {
             if let position = node.violationPosition {
                 violations.append(position)

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedSetterValueRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedSetterValueRule.swift
@@ -130,7 +130,7 @@ struct UnusedSetterValueRule: Rule {
 }
 
 private extension UnusedSetterValueRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
 
         override func visitPost(_ node: AccessorDeclSyntax) {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ValidIBInspectableRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ValidIBInspectableRule.swift
@@ -152,7 +152,7 @@ struct ValidIBInspectableRule: Rule {
 }
 
 private extension ValidIBInspectableRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { [FunctionDeclSyntax.self] }
 
         override func visitPost(_ node: VariableDeclSyntax) {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/WeakDelegateRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/WeakDelegateRule.swift
@@ -68,7 +68,7 @@ struct WeakDelegateRule: OptInRule {
 }
 
 private extension WeakDelegateRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
 
         override func visitPost(_ node: VariableDeclSyntax) {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/YodaConditionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/YodaConditionRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct YodaConditionRule: OptInRule, SwiftSyntaxRule {
+@SwiftSyntaxRule
+struct YodaConditionRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(
@@ -33,14 +34,10 @@ struct YodaConditionRule: OptInRule, SwiftSyntaxRule {
             Example("while ↓1 > i + 5 {}"),
             Example("if ↓200 <= i && i <= 299 || ↓600 <= i {}")
         ])
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(viewMode: .sourceAccurate)
-    }
 }
 
 private extension YodaConditionRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: IfExprSyntax) {
             visit(conditions: node.conditions)
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/ClosureBodyLengthRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/ClosureBodyLengthRule.swift
@@ -10,7 +10,7 @@ struct ClosureBodyLengthRule: OptInRule, SwiftSyntaxRule {
         triggeringExamples: ClosureBodyLengthRuleExamples.triggeringExamples
     )
 
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor<ConfigurationType> {
         BodyLengthRuleVisitor(kind: .closure, file: file, configuration: configuration)
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/EnumCaseAssociatedValuesLengthRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/EnumCaseAssociatedValuesLengthRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct EnumCaseAssociatedValuesLengthRule: SwiftSyntaxRule, OptInRule {
+@SwiftSyntaxRule
+struct EnumCaseAssociatedValuesLengthRule: OptInRule {
     var configuration = SeverityLevelsConfiguration<Self>(warning: 5, error: 6)
 
     static let description = RuleDescription(
@@ -35,21 +36,10 @@ struct EnumCaseAssociatedValuesLengthRule: SwiftSyntaxRule, OptInRule {
             """)
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(configuration: configuration)
-    }
 }
 
 private extension EnumCaseAssociatedValuesLengthRule {
-    final class Visitor: ViolationsSyntaxVisitor {
-        private let configuration: ConfigurationType
-
-        init(configuration: ConfigurationType) {
-            self.configuration = configuration
-            super.init(viewMode: .sourceAccurate)
-        }
-
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: EnumCaseElementSyntax) {
             guard let associatedValue = node.parameterClause,
                   case let enumCaseAssociatedValueCount = associatedValue.parameters.count,

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/FunctionBodyLengthRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/FunctionBodyLengthRule.swift
@@ -8,7 +8,7 @@ struct FunctionBodyLengthRule: SwiftSyntaxRule {
         kind: .metrics
     )
 
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor<ConfigurationType> {
         BodyLengthRuleVisitor(kind: .function, file: file, configuration: configuration)
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/FunctionParameterCountRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/FunctionParameterCountRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct FunctionParameterCountRule: SwiftSyntaxRule {
+@SwiftSyntaxRule
+struct FunctionParameterCountRule: Rule {
     var configuration = FunctionParameterCountConfiguration()
 
     static let description = RuleDescription(
@@ -34,21 +35,10 @@ struct FunctionParameterCountRule: SwiftSyntaxRule {
             """)
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(configuration: configuration)
-    }
 }
 
 private extension FunctionParameterCountRule {
-    final class Visitor: ViolationsSyntaxVisitor {
-        private let configuration: FunctionParameterCountConfiguration
-
-        init(configuration: FunctionParameterCountConfiguration) {
-            self.configuration = configuration
-            super.init(viewMode: .sourceAccurate)
-        }
-
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FunctionDeclSyntax) {
             guard !node.modifiers.contains(keyword: .override) else {
                 return

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/TypeBodyLengthRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/TypeBodyLengthRule.swift
@@ -31,7 +31,7 @@ struct TypeBodyLengthRule: SwiftSyntaxRule {
         })
     )
 
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor<ConfigurationType> {
         BodyLengthRuleVisitor(kind: .type, file: file, configuration: configuration)
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverFilterCountRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverFilterCountRule.swift
@@ -31,7 +31,7 @@ struct ContainsOverFilterCountRule: OptInRule {
 }
 
 private extension ContainsOverFilterCountRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: ExprListSyntax) {
             guard
                 node.count == 3,

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverFilterIsEmptyRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverFilterIsEmptyRule.swift
@@ -29,7 +29,7 @@ struct ContainsOverFilterIsEmptyRule: OptInRule {
 }
 
 private extension ContainsOverFilterIsEmptyRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: MemberAccessExprSyntax) {
             guard
                 node.declName.baseName.text == "isEmpty",

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverFirstNotNilRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverFirstNotNilRule.swift
@@ -31,7 +31,7 @@ struct ContainsOverFirstNotNilRule: OptInRule {
 }
 
 private extension ContainsOverFirstNotNilRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: InfixOperatorExprSyntax) {
             guard let operatorNode = node.operator.as(BinaryOperatorExprSyntax.self),
                   operatorNode.operator.tokenKind.isEqualityComparison,

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverRangeNilComparisonRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverRangeNilComparisonRule.swift
@@ -24,7 +24,7 @@ struct ContainsOverRangeNilComparisonRule: OptInRule {
 }
 
 private extension ContainsOverRangeNilComparisonRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: InfixOperatorExprSyntax) {
             guard
                 let operatorNode = node.operator.as(BinaryOperatorExprSyntax.self),

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/EmptyCollectionLiteralRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/EmptyCollectionLiteralRule.swift
@@ -29,7 +29,7 @@ struct EmptyCollectionLiteralRule: OptInRule {
 }
 
 private extension EmptyCollectionLiteralRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: TokenSyntax) {
             guard
                 node.tokenKind.isEqualityComparison,

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/EmptyStringRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/EmptyStringRule.swift
@@ -25,7 +25,7 @@ struct EmptyStringRule: OptInRule {
 }
 
 private extension EmptyStringRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: StringLiteralExprSyntax) {
             guard
                 // Empty string literal: `""`, `#""#`, etc.

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/FirstWhereRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/FirstWhereRule.swift
@@ -33,7 +33,7 @@ struct FirstWhereRule: OptInRule {
 }
 
 private extension FirstWhereRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: MemberAccessExprSyntax) {
             guard
                 node.declName.baseName.text == "first",

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/FlatMapOverMapReduceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/FlatMapOverMapReduceRule.swift
@@ -20,7 +20,7 @@ struct FlatMapOverMapReduceRule: OptInRule {
 }
 
 private extension FlatMapOverMapReduceRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FunctionCallExprSyntax) {
             guard
                 let memberAccess = node.calledExpression.as(MemberAccessExprSyntax.self),

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/LastWhereRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/LastWhereRule.swift
@@ -29,7 +29,7 @@ struct LastWhereRule: OptInRule {
 }
 
 private extension LastWhereRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: MemberAccessExprSyntax) {
             guard
                 node.declName.baseName.text == "last",

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/ReduceBooleanRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/ReduceBooleanRule.swift
@@ -29,7 +29,7 @@ struct ReduceBooleanRule: Rule {
 }
 
 private extension ReduceBooleanRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FunctionCallExprSyntax) {
             guard
                 let calledExpression = node.calledExpression.as(MemberAccessExprSyntax.self),

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/ReduceIntoRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/ReduceIntoRule.swift
@@ -109,7 +109,7 @@ struct ReduceIntoRule: OptInRule {
 }
 
 private extension ReduceIntoRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FunctionCallExprSyntax) {
             guard let name = node.nameToken,
                   name.text == "reduce",

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/SortedFirstLastRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/SortedFirstLastRule.swift
@@ -47,7 +47,7 @@ struct SortedFirstLastRule: OptInRule {
 }
 
 private extension SortedFirstLastRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: MemberAccessExprSyntax) {
             guard
                 node.declName.baseName.text == "first" || node.declName.baseName.text == "last",

--- a/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct AttributesRule: SwiftSyntaxRule, OptInRule {
+@SwiftSyntaxRule
+struct AttributesRule: OptInRule {
     var configuration = AttributesConfiguration()
 
     static let description = RuleDescription(
@@ -14,26 +15,10 @@ struct AttributesRule: SwiftSyntaxRule, OptInRule {
         nonTriggeringExamples: AttributesRuleExamples.nonTriggeringExamples,
         triggeringExamples: AttributesRuleExamples.triggeringExamples
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(
-            locationConverter: file.locationConverter,
-            configuration: configuration
-        )
-    }
 }
 
 private extension AttributesRule {
-    final class Visitor: ViolationsSyntaxVisitor {
-        private let locationConverter: SourceLocationConverter
-        private let configuration: AttributesConfiguration
-
-        init(locationConverter: SourceLocationConverter, configuration: AttributesConfiguration) {
-            self.locationConverter = locationConverter
-            self.configuration = configuration
-            super.init(viewMode: .sourceAccurate)
-        }
-
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: AttributeListSyntax) {
             guard let helper = node.makeHelper(locationConverter: locationConverter) else {
                 return

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ClosingBraceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ClosingBraceRule.swift
@@ -31,7 +31,7 @@ struct ClosingBraceRule: SwiftSyntaxCorrectableRule {
 }
 
 private extension ClosingBraceRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: TokenSyntax) {
             if node.hasClosingBraceViolation {
                 violations.append(node.positionAfterSkippingLeadingTrivia)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ClosureParameterPositionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ClosureParameterPositionRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct ClosureParameterPositionRule: SwiftSyntaxRule {
+@SwiftSyntaxRule
+struct ClosureParameterPositionRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(
@@ -93,21 +94,10 @@ struct ClosureParameterPositionRule: SwiftSyntaxRule {
             """)
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(locationConverter: file.locationConverter)
-    }
 }
 
 private extension ClosureParameterPositionRule {
-    final class Visitor: ViolationsSyntaxVisitor {
-        private let locationConverter: SourceLocationConverter
-
-        init(locationConverter: SourceLocationConverter) {
-            self.locationConverter = locationConverter
-            super.init(viewMode: .sourceAccurate)
-        }
-
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: ClosureExprSyntax) {
             guard let signature = node.signature else {
                 return

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ClosureSpacingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ClosureSpacingRule.swift
@@ -1,7 +1,6 @@
 import SwiftSyntax
 
-// MARK: - ClosureSpacingRule
-
+@SwiftSyntaxRule
 struct ClosureSpacingRule: SwiftSyntaxCorrectableRule, OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
@@ -46,10 +45,6 @@ struct ClosureSpacingRule: SwiftSyntaxCorrectableRule, OptInRule {
         ]
     )
 
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(locationConverter: file.locationConverter)
-    }
-
     func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             locationConverter: file.locationConverter,
@@ -59,14 +54,7 @@ struct ClosureSpacingRule: SwiftSyntaxCorrectableRule, OptInRule {
 }
 
 private extension ClosureSpacingRule {
-    final class Visitor: ViolationsSyntaxVisitor {
-        let locationConverter: SourceLocationConverter
-
-        init(locationConverter: SourceLocationConverter) {
-            self.locationConverter = locationConverter
-            super.init(viewMode: .sourceAccurate)
-        }
-
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: ClosureExprSyntax) {
             if node.shouldCheckForClosureSpacingRule(locationConverter: locationConverter),
                node.violations.hasViolations {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/CollectionAlignmentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/CollectionAlignmentRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct CollectionAlignmentRule: SwiftSyntaxRule, OptInRule {
+@SwiftSyntaxRule
+struct CollectionAlignmentRule: OptInRule {
     var configuration = CollectionAlignmentConfiguration()
 
     static var description = RuleDescription(
@@ -11,23 +12,10 @@ struct CollectionAlignmentRule: SwiftSyntaxRule, OptInRule {
         nonTriggeringExamples: Examples(alignColons: false).nonTriggeringExamples,
         triggeringExamples: Examples(alignColons: false).triggeringExamples
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(alignColons: configuration.alignColons, locationConverter: file.locationConverter)
-    }
 }
 
 private extension CollectionAlignmentRule {
-    final class Visitor: ViolationsSyntaxVisitor {
-        private let alignColons: Bool
-        private let locationConverter: SourceLocationConverter
-
-        init(alignColons: Bool, locationConverter: SourceLocationConverter) {
-            self.alignColons = alignColons
-            self.locationConverter = locationConverter
-            super.init(viewMode: .sourceAccurate)
-        }
-
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: ArrayExprSyntax) {
             let locations = node.elements.map { element in
                 locationConverter.location(for: element.positionAfterSkippingLeadingTrivia)
@@ -37,7 +25,7 @@ private extension CollectionAlignmentRule {
 
         override func visitPost(_ node: DictionaryElementListSyntax) {
             let locations = node.map { element in
-                let position = alignColons ? element.colon.positionAfterSkippingLeadingTrivia :
+                let position = configuration.alignColons ? element.colon.positionAfterSkippingLeadingTrivia :
                 element.key.positionAfterSkippingLeadingTrivia
                 let location = locationConverter.location(for: position)
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ComputedAccessorsOrderRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ComputedAccessorsOrderRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct ComputedAccessorsOrderRule: SwiftSyntaxRule {
+@SwiftSyntaxRule
+struct ComputedAccessorsOrderRule: Rule {
     var configuration = ComputedAccessorsOrderConfiguration()
 
     static let description = RuleDescription(
@@ -11,10 +12,6 @@ struct ComputedAccessorsOrderRule: SwiftSyntaxRule {
         nonTriggeringExamples: ComputedAccessorsOrderRuleExamples.nonTriggeringExamples,
         triggeringExamples: ComputedAccessorsOrderRuleExamples.triggeringExamples
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(expectedOrder: configuration.order)
-    }
 }
 
 private extension ComputedAccessorsOrderRule {
@@ -22,18 +19,11 @@ private extension ComputedAccessorsOrderRule {
         case `subscript`, property
     }
 
-    final class Visitor: ViolationsSyntaxVisitor {
-        private let expectedOrder: ComputedAccessorsOrderConfiguration.Order
-
-        init(expectedOrder: ComputedAccessorsOrderConfiguration.Order) {
-            self.expectedOrder = expectedOrder
-            super.init(viewMode: .sourceAccurate)
-        }
-
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: AccessorBlockSyntax) {
             guard let firstAccessor = node.accessorsList.first,
                   let order = node.order,
-                  order != expectedOrder else {
+                  order != configuration.order else {
                 return
             }
 
@@ -49,7 +39,7 @@ private extension ComputedAccessorsOrderRule {
         private func reason(for kind: ViolationKind) -> String {
             let kindString = kind == .subscript ? "subscripts" : "properties"
             let orderString: String
-            switch expectedOrder {
+            switch configuration.order {
             case .getSet:
                 orderString = "getter and then the setter"
             case .setGet:

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ConditionalReturnsOnNewlineRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ConditionalReturnsOnNewlineRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct ConditionalReturnsOnNewlineRule: OptInRule, SwiftSyntaxRule {
+@SwiftSyntaxRule
+struct ConditionalReturnsOnNewlineRule: OptInRule {
     var configuration = ConditionalReturnsOnNewlineConfiguration()
 
     static let description = RuleDescription(
@@ -31,26 +32,10 @@ struct ConditionalReturnsOnNewlineRule: OptInRule, SwiftSyntaxRule {
             """)
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(
-            ifOnly: configuration.ifOnly,
-            locationConverter: file.locationConverter
-        )
-    }
 }
 
 private extension ConditionalReturnsOnNewlineRule {
-    final class Visitor: ViolationsSyntaxVisitor {
-        private let ifOnly: Bool
-        private let locationConverter: SourceLocationConverter
-
-        init(ifOnly: Bool, locationConverter: SourceLocationConverter) {
-            self.ifOnly = ifOnly
-            self.locationConverter = locationConverter
-            super.init(viewMode: .sourceAccurate)
-        }
-
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: IfExprSyntax) {
             if isReturn(node.body.statements.lastReturn, onTheSameLineAs: node.ifKeyword) {
                 violations.append(node.ifKeyword.positionAfterSkippingLeadingTrivia)
@@ -64,7 +49,7 @@ private extension ConditionalReturnsOnNewlineRule {
         }
 
         override func visitPost(_ node: GuardStmtSyntax) {
-            if ifOnly {
+            if configuration.ifOnly {
                 return
             }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ControlStatementRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ControlStatementRule.swift
@@ -81,7 +81,7 @@ struct ControlStatementRule: SwiftSyntaxCorrectableRule {
 }
 
 private extension ControlStatementRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
 
         override func visitPost(_ node: CatchClauseSyntax) {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/DirectReturnRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/DirectReturnRule.swift
@@ -188,7 +188,7 @@ struct DirectReturnRule: SwiftSyntaxCorrectableRule, OptInRule {
 }
 
 private extension DirectReturnRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
 
         override func visitPost(_ statements: CodeBlockItemListSyntax) {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/EmptyEnumArgumentsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/EmptyEnumArgumentsRule.swift
@@ -121,7 +121,7 @@ struct EmptyEnumArgumentsRule: SwiftSyntaxCorrectableRule {
 }
 
 private extension EmptyEnumArgumentsRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: SwitchCaseItemSyntax) {
             if let violationPosition = node.pattern.emptyEnumArgumentsViolation(rewrite: false)?.position {
                 violations.append(violationPosition)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/EmptyParametersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/EmptyParametersRule.swift
@@ -41,7 +41,7 @@ struct EmptyParametersRule: SwiftSyntaxCorrectableRule {
 }
 
 private extension EmptyParametersRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FunctionTypeSyntax) {
             guard let violationPosition = node.emptyParametersViolationPosition else {
                 return

--- a/Source/SwiftLintBuiltInRules/Rules/Style/EmptyParenthesesWithTrailingClosureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/EmptyParenthesesWithTrailingClosureRule.swift
@@ -54,7 +54,7 @@ struct EmptyParenthesesWithTrailingClosureRule: SwiftSyntaxCorrectableRule {
 }
 
 private extension EmptyParenthesesWithTrailingClosureRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FunctionCallExprSyntax) {
             guard let position = node.violationPosition else {
                 return

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ImplicitReturnRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ImplicitReturnRule.swift
@@ -1,5 +1,6 @@
 import SwiftSyntax
 
+@SwiftSyntaxRule
 struct ImplicitReturnRule: SwiftSyntaxCorrectableRule, OptInRule {
     var configuration = ImplicitReturnConfiguration()
 
@@ -12,25 +13,14 @@ struct ImplicitReturnRule: SwiftSyntaxCorrectableRule, OptInRule {
         triggeringExamples: ImplicitReturnRuleExamples.triggeringExamples,
         corrections: ImplicitReturnRuleExamples.corrections
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(config: configuration)
-    }
 }
 
 private extension ImplicitReturnRule {
-    final class Visitor: ViolationsSyntaxVisitor {
-        private let config: ConfigurationType
-
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
 
-        init(config: ConfigurationType) {
-            self.config = config
-            super.init(viewMode: .sourceAccurate)
-        }
-
         override func visitPost(_ node: AccessorDeclSyntax) {
-            if config.isKindIncluded(.getter),
+            if configuration.isKindIncluded(.getter),
                node.accessorSpecifier.tokenKind == .keyword(.get),
                let body = node.body {
                 collectViolation(in: body.statements)
@@ -38,34 +28,34 @@ private extension ImplicitReturnRule {
         }
 
         override func visitPost(_ node: ClosureExprSyntax) {
-            if config.isKindIncluded(.closure) {
+            if configuration.isKindIncluded(.closure) {
                 collectViolation(in: node.statements)
             }
         }
 
         override func visitPost(_ node: FunctionDeclSyntax) {
-            if config.isKindIncluded(.function),
+            if configuration.isKindIncluded(.function),
                let body = node.body {
                 collectViolation(in: body.statements)
             }
         }
 
         override func visitPost(_ node: InitializerDeclSyntax) {
-            if config.isKindIncluded(.initializer),
+            if configuration.isKindIncluded(.initializer),
                let body = node.body {
                 collectViolation(in: body.statements)
             }
         }
 
         override func visitPost(_ node: PatternBindingSyntax) {
-            if config.isKindIncluded(.getter),
+            if configuration.isKindIncluded(.getter),
                case let .getter(itemList) = node.accessorBlock?.accessors {
                 collectViolation(in: itemList)
             }
         }
 
         override func visitPost(_ node: SubscriptDeclSyntax) {
-            if config.isKindIncluded(.subscript),
+            if configuration.isKindIncluded(.subscript),
                case let .getter(itemList) = node.accessorBlock?.accessors {
                 collectViolation(in: itemList)
             }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/MultilineArgumentsBracketsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/MultilineArgumentsBracketsRule.swift
@@ -159,7 +159,7 @@ struct MultilineArgumentsBracketsRule: OptInRule {
 }
 
 private extension MultilineArgumentsBracketsRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FunctionCallExprSyntax) {
             guard let firstArgument = node.arguments.first,
                   let leftParen = node.leftParen,

--- a/Source/SwiftLintBuiltInRules/Rules/Style/MultilineArgumentsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/MultilineArgumentsRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct MultilineArgumentsRule: SwiftSyntaxRule, OptInRule {
+@SwiftSyntaxRule
+struct MultilineArgumentsRule: OptInRule {
     var configuration = MultilineArgumentsConfiguration()
 
     static let description = RuleDescription(
@@ -11,31 +12,10 @@ struct MultilineArgumentsRule: SwiftSyntaxRule, OptInRule {
         nonTriggeringExamples: MultilineArgumentsRuleExamples.nonTriggeringExamples,
         triggeringExamples: MultilineArgumentsRuleExamples.triggeringExamples
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(
-            onlyEnforceAfterFirstClosureOnFirstLine: configuration.onlyEnforceAfterFirstClosureOnFirstLine,
-            firstArgumentLocation: configuration.firstArgumentLocation,
-            locationConverter: file.locationConverter
-        )
-    }
 }
 
 private extension MultilineArgumentsRule {
-    final class Visitor: ViolationsSyntaxVisitor {
-        let onlyEnforceAfterFirstClosureOnFirstLine: Bool
-        let firstArgumentLocation: MultilineArgumentsConfiguration.FirstArgumentLocation
-        let locationConverter: SourceLocationConverter
-
-        init(onlyEnforceAfterFirstClosureOnFirstLine: Bool,
-             firstArgumentLocation: MultilineArgumentsConfiguration.FirstArgumentLocation,
-             locationConverter: SourceLocationConverter) {
-            self.onlyEnforceAfterFirstClosureOnFirstLine = onlyEnforceAfterFirstClosureOnFirstLine
-            self.firstArgumentLocation = firstArgumentLocation
-            self.locationConverter = locationConverter
-            super.init(viewMode: .sourceAccurate)
-        }
-
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FunctionCallExprSyntax) {
             guard node.arguments.count > 1 else {
                 return
@@ -51,7 +31,7 @@ private extension MultilineArgumentsRule {
 
             var violatingArguments = findViolations(in: wrappedArguments, functionCallLine: functionCallLine)
 
-            if onlyEnforceAfterFirstClosureOnFirstLine {
+            if configuration.onlyEnforceAfterFirstClosureOnFirstLine {
                 violatingArguments = removeViolationsBeforeFirstClosure(arguments: wrappedArguments,
                                                                         violations: violatingArguments)
             }
@@ -65,7 +45,7 @@ private extension MultilineArgumentsRule {
                                     functionCallLine: Int) -> [Argument] {
             var visitedLines = Set<Int>()
 
-            if firstArgumentLocation == .sameLine {
+            if configuration.firstArgumentLocation == .sameLine {
                 visitedLines.insert(functionCallLine)
             }
 
@@ -73,8 +53,8 @@ private extension MultilineArgumentsRule {
                 let (line, idx) = (argument.line, argument.index)
                 let (firstVisit, _) = visitedLines.insert(line)
 
-               if idx == 0 {
-                    switch firstArgumentLocation {
+                if idx == 0 {
+                    switch configuration.firstArgumentLocation {
                     case .anyLine: return nil
                     case .nextLine: return line > functionCallLine ? nil : argument
                     case .sameLine: return line > functionCallLine ? argument : nil

--- a/Source/SwiftLintBuiltInRules/Rules/Style/MultilineParametersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/MultilineParametersRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct MultilineParametersRule: SwiftSyntaxRule, OptInRule {
+@SwiftSyntaxRule
+struct MultilineParametersRule: OptInRule {
     var configuration = MultilineParametersConfiguration()
 
     static let description = RuleDescription(
@@ -11,23 +12,10 @@ struct MultilineParametersRule: SwiftSyntaxRule, OptInRule {
         nonTriggeringExamples: MultilineParametersRuleExamples.nonTriggeringExamples,
         triggeringExamples: MultilineParametersRuleExamples.triggeringExamples
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(allowsSingleLine: configuration.allowsSingleLine, locationConverter: file.locationConverter)
-    }
 }
 
 private extension MultilineParametersRule {
-    final class Visitor: ViolationsSyntaxVisitor {
-        private let allowsSingleLine: Bool
-        private let locationConverter: SourceLocationConverter
-
-        init(allowsSingleLine: Bool, locationConverter: SourceLocationConverter) {
-            self.allowsSingleLine = allowsSingleLine
-            self.locationConverter = locationConverter
-            super.init(viewMode: .sourceAccurate)
-        }
-
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FunctionDeclSyntax) {
             if containsViolation(for: node.signature) {
                 violations.append(node.name.positionAfterSkippingLeadingTrivia)
@@ -55,7 +43,7 @@ private extension MultilineParametersRule {
                 numberOfParameters += 1
             }
 
-            guard linesWithParameters.count > (allowsSingleLine ? 1 : 0),
+            guard linesWithParameters.count > (configuration.allowsSingleLine ? 1 : 0),
                   numberOfParameters != linesWithParameters.count else {
                 return false
             }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/MultipleClosuresWithTrailingClosureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/MultipleClosuresWithTrailingClosureRule.swift
@@ -38,7 +38,7 @@ struct MultipleClosuresWithTrailingClosureRule: Rule {
 }
 
 private extension MultipleClosuresWithTrailingClosureRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FunctionCallExprSyntax) {
             guard let trailingClosure = node.trailingClosure,
                   node.hasTrailingClosureViolation else {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/NoSpaceInMethodCallRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/NoSpaceInMethodCallRule.swift
@@ -53,7 +53,7 @@ struct NoSpaceInMethodCallRule: SwiftSyntaxCorrectableRule {
 }
 
 private extension NoSpaceInMethodCallRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FunctionCallExprSyntax) {
             guard node.hasNoSpaceInMethodCallViolation else {
                 return

--- a/Source/SwiftLintBuiltInRules/Rules/Style/NonOverridableClassDeclarationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/NonOverridableClassDeclarationRule.swift
@@ -1,5 +1,6 @@
 import SwiftSyntax
 
+@SwiftSyntaxRule
 struct NonOverridableClassDeclarationRule: SwiftSyntaxCorrectableRule, OptInRule {
     var configuration = NonOverridableClassDeclarationConfiguration()
 
@@ -94,24 +95,13 @@ struct NonOverridableClassDeclarationRule: SwiftSyntaxCorrectableRule, OptInRule
                 """)
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(configuration: configuration)
-    }
 }
 
 private extension NonOverridableClassDeclarationRule {
-    final class Visitor: ViolationsSyntaxVisitor {
-        private let configuration: NonOverridableClassDeclarationConfiguration
-
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         private var finalClassScope = Stack<Bool>()
 
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
-
-        init(configuration: NonOverridableClassDeclarationConfiguration) {
-            self.configuration = configuration
-            super.init(viewMode: .sourceAccurate)
-        }
 
         override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
             finalClassScope.push(node.modifiers.contains(keyword: .final))

--- a/Source/SwiftLintBuiltInRules/Rules/Style/NumberSeparatorRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/NumberSeparatorRule.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SwiftSyntax
 
+@SwiftSyntaxRule
 struct NumberSeparatorRule: OptInRule, SwiftSyntaxCorrectableRule {
     var configuration = NumberSeparatorConfiguration()
 
@@ -25,10 +26,6 @@ struct NumberSeparatorRule: OptInRule, SwiftSyntaxCorrectableRule {
         Underscore(s) used as thousand separator(s) should be added after every 3 digits only
         """
 
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(configuration: configuration)
-    }
-
     func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             configuration: configuration,
@@ -39,14 +36,7 @@ struct NumberSeparatorRule: OptInRule, SwiftSyntaxCorrectableRule {
 }
 
 private extension NumberSeparatorRule {
-    final class Visitor: ViolationsSyntaxVisitor, NumberSeparatorValidator {
-        let configuration: NumberSeparatorConfiguration
-
-        init(configuration: NumberSeparatorConfiguration) {
-            self.configuration = configuration
-            super.init(viewMode: .sourceAccurate)
-        }
-
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType>, NumberSeparatorValidator {
         override func visitPost(_ node: FloatLiteralExprSyntax) {
             if let violation = violation(token: node.literal) {
                 violations.append(ReasonedRuleViolation(position: violation.position, reason: violation.reason))

--- a/Source/SwiftLintBuiltInRules/Rules/Style/OperatorFunctionWhitespaceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/OperatorFunctionWhitespaceRule.swift
@@ -26,7 +26,7 @@ struct OperatorFunctionWhitespaceRule: Rule {
 }
 
 private extension OperatorFunctionWhitespaceRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FunctionDeclSyntax) {
             guard node.isOperatorDeclaration, node.hasWhitespaceViolation else {
                 return

--- a/Source/SwiftLintBuiltInRules/Rules/Style/OptionalEnumCaseMatchingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/OptionalEnumCaseMatchingRule.swift
@@ -163,7 +163,7 @@ struct OptionalEnumCaseMatchingRule: SwiftSyntaxCorrectableRule, OptInRule {
 }
 
 private extension OptionalEnumCaseMatchingRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: SwitchCaseItemSyntax) {
             guard let pattern = node.pattern.as(ExpressionPatternSyntax.self) else {
                 return

--- a/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRule.swift
@@ -35,7 +35,7 @@ private extension PreferSelfInStaticReferencesRule {
         case skipReferences
     }
 
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         private var parentDeclScopes = Stack<ParentDeclBehavior>()
         private var variableDeclScopes = Stack<VariableDeclBehavior>()
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfTypeOverTypeOfSelfRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfTypeOverTypeOfSelfRule.swift
@@ -115,7 +115,7 @@ struct PreferSelfTypeOverTypeOfSelfRule: SwiftSyntaxCorrectableRule, OptInRule {
 }
 
 private extension PreferSelfTypeOverTypeOfSelfRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: MemberAccessExprSyntax) {
             if let function = node.base?.as(FunctionCallExprSyntax.self), function.hasViolation {
                 violations.append(function.positionAfterSkippingLeadingTrivia)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/PrefixedTopLevelConstantRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/PrefixedTopLevelConstantRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct PrefixedTopLevelConstantRule: SwiftSyntaxRule, OptInRule {
+@SwiftSyntaxRule
+struct PrefixedTopLevelConstantRule: OptInRule {
     var configuration = PrefixedTopLevelConstantConfiguration()
 
     static let description = RuleDescription(
@@ -78,21 +79,11 @@ struct PrefixedTopLevelConstantRule: SwiftSyntaxRule, OptInRule {
             """)
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(onlyPrivateMembers: configuration.onlyPrivateMembers)
-    }
 }
 
 private extension PrefixedTopLevelConstantRule {
-    final class Visitor: ViolationsSyntaxVisitor {
-        private let onlyPrivateMembers: Bool
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         private let topLevelPrefix = "k"
-
-        init(onlyPrivateMembers: Bool) {
-            self.onlyPrivateMembers = onlyPrivateMembers
-            super.init(viewMode: .sourceAccurate)
-        }
 
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .all }
 
@@ -101,7 +92,7 @@ private extension PrefixedTopLevelConstantRule {
                 return
             }
 
-            if onlyPrivateMembers, !node.modifiers.containsPrivateOrFileprivate() {
+            if configuration.onlyPrivateMembers, !node.modifiers.containsPrivateOrFileprivate() {
                 return
             }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ProtocolPropertyAccessorsOrderRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ProtocolPropertyAccessorsOrderRule.swift
@@ -32,7 +32,7 @@ struct ProtocolPropertyAccessorsOrderRule: SwiftSyntaxCorrectableRule {
 }
 
 private extension ProtocolPropertyAccessorsOrderRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] {
             .allExcept(ProtocolDeclSyntax.self, VariableDeclSyntax.self)
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/RedundantDiscardableLetRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/RedundantDiscardableLetRule.swift
@@ -36,7 +36,7 @@ struct RedundantDiscardableLetRule: SwiftSyntaxCorrectableRule {
 }
 
 private extension RedundantDiscardableLetRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: VariableDeclSyntax) {
             if node.hasRedundantDiscardableLetViolation {
                 violations.append(node.positionAfterSkippingLeadingTrivia)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/RedundantSelfInClosureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/RedundantSelfInClosureRule.swift
@@ -74,7 +74,7 @@ private extension RedundantSelfInClosureRule {
             }
             let localViolationCorrections = ExplicitSelfVisitor(
                 configuration: configuration,
-                locationConverter: locationConverter,
+                file: file,
                 typeDeclarationKind: activeTypeDeclarationKind,
                 functionCallType: activeFunctionCallType,
                 selfCaptureKind: activeSelfCaptureKind,
@@ -124,7 +124,7 @@ private class ExplicitSelfVisitor<Configuration: RuleConfiguration>: DeclaredIde
     private let selfCaptureKind: SelfCaptureKind
 
     init(configuration: Configuration,
-         locationConverter: SourceLocationConverter,
+         file: SwiftLintFile,
          typeDeclarationKind: TypeDeclarationKind,
          functionCallType: FunctionCallType,
          selfCaptureKind: SelfCaptureKind,
@@ -132,7 +132,7 @@ private class ExplicitSelfVisitor<Configuration: RuleConfiguration>: DeclaredIde
         self.typeDeclKind = typeDeclarationKind
         self.functionCallType = functionCallType
         self.selfCaptureKind = selfCaptureKind
-        super.init(configuration: configuration, locationConverter: locationConverter, scope: scope)
+        super.init(configuration: configuration, file: file, scope: scope)
     }
 
     override func visitPost(_ node: MemberAccessExprSyntax) {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/RedundantSelfInClosureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/RedundantSelfInClosureRule.swift
@@ -1,5 +1,6 @@
 import SwiftSyntax
 
+@SwiftSyntaxRule
 struct RedundantSelfInClosureRule: SwiftSyntaxCorrectableRule, OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
@@ -12,10 +13,6 @@ struct RedundantSelfInClosureRule: SwiftSyntaxCorrectableRule, OptInRule {
         triggeringExamples: RedundantSelfInClosureRuleExamples.triggeringExamples,
         corrections: RedundantSelfInClosureRuleExamples.corrections
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        ContextVisitor()
-    }
 }
 
 private enum TypeDeclarationKind {
@@ -35,7 +32,7 @@ private enum SelfCaptureKind {
 }
 
 private extension RedundantSelfInClosureRule {
-    final class ContextVisitor: DeclaredIdentifiersTrackingVisitor {
+    final class Visitor: DeclaredIdentifiersTrackingVisitor<ConfigurationType> {
         private var typeDeclarations = Stack<TypeDeclarationKind>()
         private var functionCalls = Stack<FunctionCallType>()
         private var selfCaptures = Stack<SelfCaptureKind>()
@@ -76,6 +73,8 @@ private extension RedundantSelfInClosureRule {
                 return
             }
             let localViolationCorrections = ExplicitSelfVisitor(
+                configuration: configuration,
+                locationConverter: locationConverter,
                 typeDeclarationKind: activeTypeDeclarationKind,
                 functionCallType: activeFunctionCallType,
                 selfCaptureKind: activeSelfCaptureKind,
@@ -119,19 +118,21 @@ private extension RedundantSelfInClosureRule {
     }
 }
 
-private class ExplicitSelfVisitor: DeclaredIdentifiersTrackingVisitor {
+private class ExplicitSelfVisitor<Configuration: RuleConfiguration>: DeclaredIdentifiersTrackingVisitor<Configuration> {
     private let typeDeclKind: TypeDeclarationKind
     private let functionCallType: FunctionCallType
     private let selfCaptureKind: SelfCaptureKind
 
-    init(typeDeclarationKind: TypeDeclarationKind,
+    init(configuration: Configuration,
+         locationConverter: SourceLocationConverter,
+         typeDeclarationKind: TypeDeclarationKind,
          functionCallType: FunctionCallType,
          selfCaptureKind: SelfCaptureKind,
          scope: Scope) {
         self.typeDeclKind = typeDeclarationKind
         self.functionCallType = functionCallType
         self.selfCaptureKind = selfCaptureKind
-        super.init(scope: scope)
+        super.init(configuration: configuration, locationConverter: locationConverter, scope: scope)
     }
 
     override func visitPost(_ node: MemberAccessExprSyntax) {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ReturnArrowWhitespaceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ReturnArrowWhitespaceRule.swift
@@ -55,7 +55,7 @@ struct ReturnArrowWhitespaceRule: SwiftSyntaxCorrectableRule {
 }
 
 private extension ReturnArrowWhitespaceRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FunctionTypeSyntax) {
             guard let violation = node.returnClause.arrow.arrowViolation else {
                 return

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ShorthandOperatorRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ShorthandOperatorRule.swift
@@ -42,7 +42,7 @@ struct ShorthandOperatorRule: Rule {
 }
 
 private extension ShorthandOperatorRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: InfixOperatorExprSyntax) {
             guard node.operator.is(AssignmentExprSyntax.self),
                   let rightExpr = node.rightOperand.as(InfixOperatorExprSyntax.self),

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SingleTestClassRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SingleTestClassRule.swift
@@ -50,7 +50,7 @@ struct SingleTestClassRule: SourceKitFreeRule, OptInRule {
     )
 
     func validate(file: SwiftLintFile) -> [StyleViolation] {
-        let classes = Visitor(configuration: configuration, locationConverter: file.locationConverter)
+        let classes = Visitor(configuration: configuration, file: file)
             .walk(tree: file.syntaxTree, handler: \.violations)
 
         guard classes.count > 1 else { return [] }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SortedEnumCasesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SortedEnumCasesRule.swift
@@ -79,7 +79,7 @@ struct SortedEnumCasesRule: OptInRule {
 }
 
 private extension SortedEnumCasesRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] {
             .allExcept(EnumDeclSyntax.self)
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SuperfluousElseRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SuperfluousElseRule.swift
@@ -97,7 +97,7 @@ struct SuperfluousElseRule: OptInRule {
 }
 
 private extension SuperfluousElseRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
 
         override func visitPost(_ node: IfExprSyntax) {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SwitchCaseOnNewlineRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SwitchCaseOnNewlineRule.swift
@@ -8,7 +8,8 @@ private func wrapInSwitch(_ str: String, file: StaticString = #file, line: UInt 
     """, file: file, line: line)
 }
 
-struct SwitchCaseOnNewlineRule: SwiftSyntaxRule, OptInRule {
+@SwiftSyntaxRule
+struct SwitchCaseOnNewlineRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(
@@ -59,21 +60,10 @@ struct SwitchCaseOnNewlineRule: SwiftSyntaxRule, OptInRule {
             wrapInSwitch("↓case .first,\n .second: return false")
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(locationConverter: file.locationConverter)
-    }
 }
 
 private extension SwitchCaseOnNewlineRule {
-    final class Visitor: ViolationsSyntaxVisitor {
-        private let locationConverter: SourceLocationConverter
-
-        init(locationConverter: SourceLocationConverter) {
-            self.locationConverter = locationConverter
-            super.init(viewMode: .sourceAccurate)
-        }
-
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: SwitchCaseSyntax) {
             let caseEndLine = locationConverter.location(for: node.label.endPositionBeforeTrailingTrivia).line
             let statementsPosition = node.statements.positionAfterSkippingLeadingTrivia

--- a/Source/SwiftLintBuiltInRules/Rules/Style/UnneededParenthesesInClosureArgumentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/UnneededParenthesesInClosureArgumentRule.swift
@@ -82,7 +82,7 @@ struct UnneededParenthesesInClosureArgumentRule: SwiftSyntaxCorrectableRule, Opt
 }
 
 private extension UnneededParenthesesInClosureArgumentRule {
-    final class Visitor: ViolationsSyntaxVisitor {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: ClosureSignatureSyntax) {
             guard let clause = node.parameterClause?.as(ClosureParameterClauseSyntax.self),
                   clause.parameters.isNotEmpty,

--- a/Source/SwiftLintBuiltInRules/Rules/Style/UnusedOptionalBindingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/UnusedOptionalBindingRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct UnusedOptionalBindingRule: SwiftSyntaxRule {
+@SwiftSyntaxRule
+struct UnusedOptionalBindingRule: Rule {
     var configuration = UnusedOptionalBindingConfiguration()
 
     static let description = RuleDescription(
@@ -28,28 +29,17 @@ struct UnusedOptionalBindingRule: SwiftSyntaxRule {
             Example("func foo() { if let ↓_ = bar {} }")
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(ignoreOptionalTry: configuration.ignoreOptionalTry)
-    }
 }
 
 private extension UnusedOptionalBindingRule {
-    final class Visitor: ViolationsSyntaxVisitor {
-        private let ignoreOptionalTry: Bool
-
-        init(ignoreOptionalTry: Bool) {
-            self.ignoreOptionalTry = ignoreOptionalTry
-            super.init(viewMode: .sourceAccurate)
-        }
-
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: OptionalBindingConditionSyntax) {
             guard let pattern = node.pattern.as(ExpressionPatternSyntax.self),
                   pattern.expression.isDiscardExpression else {
                 return
             }
 
-            if ignoreOptionalTry,
+            if configuration.ignoreOptionalTry,
                let tryExpr = node.initializer?.value.as(TryExprSyntax.self),
                tryExpr.questionOrExclamationMark?.tokenKind == .postfixQuestionMark {
                 return

--- a/Source/SwiftLintBuiltInRules/Rules/Style/VerticalParameterAlignmentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/VerticalParameterAlignmentRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct VerticalParameterAlignmentRule: SwiftSyntaxRule {
+@SwiftSyntaxRule
+struct VerticalParameterAlignmentRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(
@@ -11,21 +12,10 @@ struct VerticalParameterAlignmentRule: SwiftSyntaxRule {
         nonTriggeringExamples: VerticalParameterAlignmentRuleExamples.nonTriggeringExamples,
         triggeringExamples: VerticalParameterAlignmentRuleExamples.triggeringExamples
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(locationConverter: file.locationConverter)
-    }
 }
 
 private extension VerticalParameterAlignmentRule {
-    final class Visitor: ViolationsSyntaxVisitor {
-        private let locationConverter: SourceLocationConverter
-
-        init(locationConverter: SourceLocationConverter) {
-            self.locationConverter = locationConverter
-            super.init(viewMode: .sourceAccurate)
-        }
-
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FunctionDeclSyntax) {
             violations.append(contentsOf: violations(for: node.signature.parameterClause.parameters))
         }

--- a/Source/SwiftLintBuiltInRules/Visitors/BodyLengthRuleVisitor.swift
+++ b/Source/SwiftLintBuiltInRules/Visitors/BodyLengthRuleVisitor.swift
@@ -2,7 +2,6 @@ import SwiftSyntax
 
 final class BodyLengthRuleVisitor<Parent: Rule>: ViolationsSyntaxVisitor<SeverityLevelsConfiguration<Parent>> {
     private let kind: Kind
-    private let file: SwiftLintFile
 
     enum Kind {
         case closure
@@ -23,8 +22,7 @@ final class BodyLengthRuleVisitor<Parent: Rule>: ViolationsSyntaxVisitor<Severit
 
     init(kind: Kind, file: SwiftLintFile, configuration: SeverityLevelsConfiguration<Parent>) {
         self.kind = kind
-        self.file = file
-        super.init(configuration: configuration, locationConverter: file.locationConverter)
+        super.init(configuration: configuration, file: file)
     }
 
     override func visitPost(_ node: EnumDeclSyntax) {

--- a/Source/SwiftLintBuiltInRules/Visitors/BodyLengthRuleVisitor.swift
+++ b/Source/SwiftLintBuiltInRules/Visitors/BodyLengthRuleVisitor.swift
@@ -1,10 +1,8 @@
 import SwiftSyntax
 
-final class BodyLengthRuleVisitor<Parent: Rule>: ViolationsSyntaxVisitor {
+final class BodyLengthRuleVisitor<Parent: Rule>: ViolationsSyntaxVisitor<SeverityLevelsConfiguration<Parent>> {
     private let kind: Kind
     private let file: SwiftLintFile
-    private let configuration: SeverityLevelsConfiguration<Parent>
-    private let locationConverter: SourceLocationConverter
 
     enum Kind {
         case closure
@@ -26,9 +24,7 @@ final class BodyLengthRuleVisitor<Parent: Rule>: ViolationsSyntaxVisitor {
     init(kind: Kind, file: SwiftLintFile, configuration: SeverityLevelsConfiguration<Parent>) {
         self.kind = kind
         self.file = file
-        self.configuration = configuration
-        locationConverter = file.locationConverter
-        super.init(viewMode: .sourceAccurate)
+        super.init(configuration: configuration, locationConverter: file.locationConverter)
     }
 
     override func visitPost(_ node: EnumDeclSyntax) {

--- a/Source/SwiftLintCore/Protocols/SwiftSyntaxRule.swift
+++ b/Source/SwiftLintCore/Protocols/SwiftSyntaxRule.swift
@@ -7,7 +7,7 @@ public protocol SwiftSyntaxRule: SourceKitFreeRule {
     /// - parameter file: The file for which to produce the visitor.
     ///
     /// - returns: A `ViolationsSyntaxVisitor` for the given file.
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor<ConfigurationType>
 
     /// Produce a violation for the given file and absolute position.
     ///

--- a/Source/SwiftLintCore/Protocols/SwiftSyntaxRule.swift
+++ b/Source/SwiftLintCore/Protocols/SwiftSyntaxRule.swift
@@ -52,6 +52,7 @@ public extension SwiftSyntaxRule {
             .compactMap { $0.toSourceRange(locationConverter: locationConverter) }
     }
 
+    @inlinable
     func validate(file: SwiftLintFile) -> [StyleViolation] {
         guard let syntaxTree = preprocess(file: file) else {
             return []

--- a/Source/SwiftLintCore/Visitors/DeclaredIdentifiersTrackingVisitor.swift
+++ b/Source/SwiftLintCore/Visitors/DeclaredIdentifiersTrackingVisitor.swift
@@ -1,7 +1,8 @@
 import SwiftSyntax
 
 /// A specialized `ViolationsSyntaxVisitor` that tracks declared identifiers per scope while traversing the AST.
-open class DeclaredIdentifiersTrackingVisitor: ViolationsSyntaxVisitor {
+open class DeclaredIdentifiersTrackingVisitor<Configuration: RuleConfiguration>:
+        ViolationsSyntaxVisitor<Configuration> {
     /// A type that remembers the declared identifers (in order) up to the current position in the code.
     public typealias Scope = Stack<Set<String>>
 
@@ -11,9 +12,9 @@ open class DeclaredIdentifiersTrackingVisitor: ViolationsSyntaxVisitor {
     /// Initializer.
     ///
     /// - parameter scope: A (potentially already pre-filled) scope to collect identifers into.
-    public init(scope: Scope = Scope()) {
+    public init(configuration: Configuration, locationConverter: SourceLocationConverter, scope: Scope = Scope()) {
         self.scope = scope
-        super.init(viewMode: .sourceAccurate)
+        super.init(configuration: configuration, locationConverter: locationConverter)
     }
 
     /// Indicate whether a given identifier is in scope.

--- a/Source/SwiftLintCore/Visitors/DeclaredIdentifiersTrackingVisitor.swift
+++ b/Source/SwiftLintCore/Visitors/DeclaredIdentifiersTrackingVisitor.swift
@@ -7,7 +7,7 @@ open class DeclaredIdentifiersTrackingVisitor<Configuration: RuleConfiguration>:
     public typealias Scope = Stack<Set<String>>
 
     /// The hierarchical stack of identifiers declared up to the current position in the code.
-    public private(set) var scope: Scope
+    public var scope: Scope
 
     /// Initializer.
     ///
@@ -15,6 +15,7 @@ open class DeclaredIdentifiersTrackingVisitor<Configuration: RuleConfiguration>:
     ///   - configuration: Configuration of a rule.
     ///   - file: File from which the syntax tree stems from.
     ///   - scope: A (potentially already pre-filled) scope to collect identifers into.
+    @inlinable
     public init(configuration: Configuration, file: SwiftLintFile, scope: Scope = Scope()) {
         self.scope = scope
         super.init(configuration: configuration, file: file)

--- a/Source/SwiftLintCore/Visitors/DeclaredIdentifiersTrackingVisitor.swift
+++ b/Source/SwiftLintCore/Visitors/DeclaredIdentifiersTrackingVisitor.swift
@@ -11,10 +11,13 @@ open class DeclaredIdentifiersTrackingVisitor<Configuration: RuleConfiguration>:
 
     /// Initializer.
     ///
-    /// - parameter scope: A (potentially already pre-filled) scope to collect identifers into.
-    public init(configuration: Configuration, locationConverter: SourceLocationConverter, scope: Scope = Scope()) {
+    /// - Parameters:
+    ///   - configuration: Configuration of a rule.
+    ///   - file: File from which the syntax tree stems from.
+    ///   - scope: A (potentially already pre-filled) scope to collect identifers into.
+    public init(configuration: Configuration, file: SwiftLintFile, scope: Scope = Scope()) {
         self.scope = scope
-        super.init(configuration: configuration, locationConverter: locationConverter)
+        super.init(configuration: configuration, file: file)
     }
 
     /// Indicate whether a given identifier is in scope.

--- a/Source/SwiftLintCore/Visitors/ViolationsSyntaxVisitor.swift
+++ b/Source/SwiftLintCore/Visitors/ViolationsSyntaxVisitor.swift
@@ -15,6 +15,7 @@ open class ViolationsSyntaxVisitor<Configuration: RuleConfiguration>: SyntaxVisi
     /// - Parameters:
     ///   - configuration: Configuration of a rule.
     ///   - file: File from which the syntax tree stems from.
+    @inlinable
     public init(configuration: Configuration, file: SwiftLintFile) {
         self.configuration = configuration
         self.file = file

--- a/Source/SwiftLintCore/Visitors/ViolationsSyntaxVisitor.swift
+++ b/Source/SwiftLintCore/Visitors/ViolationsSyntaxVisitor.swift
@@ -4,17 +4,20 @@ import SwiftSyntax
 open class ViolationsSyntaxVisitor<Configuration: RuleConfiguration>: SyntaxVisitor {
     /// A rule's configuration.
     public let configuration: Configuration
+    /// The file from which the traversed syntax tree stems from.
+    public let file: SwiftLintFile
+
     /// A source location converter associated with the syntax tree being traversed.
-    public let locationConverter: SourceLocationConverter
+    public lazy var locationConverter = file.locationConverter
 
     /// Initializer for a ``ViolationsSyntaxVisitor``.
     /// 
     /// - Parameters:
     ///   - configuration: Configuration of a rule.
-    ///   - locationConverter: Location converter associated with the to be traversed syntax tree.
-    public init(configuration: Configuration, locationConverter: SourceLocationConverter) {
+    ///   - file: File from which the syntax tree stems from.
+    public init(configuration: Configuration, file: SwiftLintFile) {
         self.configuration = configuration
-        self.locationConverter = locationConverter
+        self.file = file
         super.init(viewMode: .sourceAccurate)
     }
 

--- a/Source/SwiftLintCore/Visitors/ViolationsSyntaxVisitor.swift
+++ b/Source/SwiftLintCore/Visitors/ViolationsSyntaxVisitor.swift
@@ -1,7 +1,23 @@
 import SwiftSyntax
 
 /// A SwiftSyntax `SyntaxVisitor` that produces absolute positions where violations should be reported.
-open class ViolationsSyntaxVisitor: SyntaxVisitor {
+open class ViolationsSyntaxVisitor<Configuration: RuleConfiguration>: SyntaxVisitor {
+    /// A rule's configuration.
+    public let configuration: Configuration
+    /// A source location converter associated with the syntax tree being traversed.
+    public let locationConverter: SourceLocationConverter
+
+    /// Initializer for a ``ViolationsSyntaxVisitor``.
+    /// 
+    /// - Parameters:
+    ///   - configuration: Configuration of a rule.
+    ///   - locationConverter: Location converter associated with the to be traversed syntax tree.
+    public init(configuration: Configuration, locationConverter: SourceLocationConverter) {
+        self.configuration = configuration
+        self.locationConverter = locationConverter
+        super.init(viewMode: .sourceAccurate)
+    }
+
     /// Positions in a source file where violations should be reported.
     public var violations: [ReasonedRuleViolation] = []
     /// Ranges of violations to be used in rewriting (see ``SwiftSyntaxCorrectableRule``). It is not mandatory to fill

--- a/Source/SwiftLintCoreMacros/SwiftSyntaxRule.swift
+++ b/Source/SwiftLintCoreMacros/SwiftSyntaxRule.swift
@@ -12,8 +12,8 @@ struct SwiftSyntaxRule: ExtensionMacro {
         return [
             try ExtensionDeclSyntax("""
                 extension \(type): SwiftSyntaxRule {
-                    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-                        Visitor(viewMode: .sourceAccurate)
+                    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor<ConfigurationType> {
+                        Visitor(configuration: configuration, locationConverter: file.locationConverter)
                     }
                 }
                 """),

--- a/Source/SwiftLintCoreMacros/SwiftSyntaxRule.swift
+++ b/Source/SwiftLintCoreMacros/SwiftSyntaxRule.swift
@@ -13,7 +13,7 @@ struct SwiftSyntaxRule: ExtensionMacro {
             try ExtensionDeclSyntax("""
                 extension \(type): SwiftSyntaxRule {
                     func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor<ConfigurationType> {
-                        Visitor(configuration: configuration, locationConverter: file.locationConverter)
+                        Visitor(configuration: configuration, file: file)
                     }
                 }
                 """),

--- a/Tests/MacroTests/SwiftSyntaxRuleTests.swift
+++ b/Tests/MacroTests/SwiftSyntaxRuleTests.swift
@@ -18,7 +18,7 @@ final class SwiftSyntaxRuleTests: XCTestCase {
 
             extension Hello: SwiftSyntaxRule {
                 func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor<ConfigurationType> {
-                    Visitor(configuration: configuration, locationConverter: file.locationConverter)
+                    Visitor(configuration: configuration, file: file)
                 }
             }
             """,
@@ -37,7 +37,7 @@ final class SwiftSyntaxRuleTests: XCTestCase {
 
             extension Hello: SwiftSyntaxRule {
                 func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor<ConfigurationType> {
-                    Visitor(configuration: configuration, locationConverter: file.locationConverter)
+                    Visitor(configuration: configuration, file: file)
                 }
             }
             """,
@@ -56,7 +56,7 @@ final class SwiftSyntaxRuleTests: XCTestCase {
 
             extension Hello: SwiftSyntaxRule {
                 func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor<ConfigurationType> {
-                    Visitor(configuration: configuration, locationConverter: file.locationConverter)
+                    Visitor(configuration: configuration, file: file)
                 }
             }
 
@@ -82,7 +82,7 @@ final class SwiftSyntaxRuleTests: XCTestCase {
 
             extension Hello: SwiftSyntaxRule {
                 func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor<ConfigurationType> {
-                    Visitor(configuration: configuration, locationConverter: file.locationConverter)
+                    Visitor(configuration: configuration, file: file)
                 }
             }
             """,

--- a/Tests/MacroTests/SwiftSyntaxRuleTests.swift
+++ b/Tests/MacroTests/SwiftSyntaxRuleTests.swift
@@ -17,8 +17,8 @@ final class SwiftSyntaxRuleTests: XCTestCase {
             struct Hello {}
 
             extension Hello: SwiftSyntaxRule {
-                func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-                    Visitor(viewMode: .sourceAccurate)
+                func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor<ConfigurationType> {
+                    Visitor(configuration: configuration, locationConverter: file.locationConverter)
                 }
             }
             """,
@@ -36,8 +36,8 @@ final class SwiftSyntaxRuleTests: XCTestCase {
             struct Hello {}
 
             extension Hello: SwiftSyntaxRule {
-                func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-                    Visitor(viewMode: .sourceAccurate)
+                func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor<ConfigurationType> {
+                    Visitor(configuration: configuration, locationConverter: file.locationConverter)
                 }
             }
             """,
@@ -55,8 +55,8 @@ final class SwiftSyntaxRuleTests: XCTestCase {
             struct Hello {}
 
             extension Hello: SwiftSyntaxRule {
-                func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-                    Visitor(viewMode: .sourceAccurate)
+                func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor<ConfigurationType> {
+                    Visitor(configuration: configuration, locationConverter: file.locationConverter)
                 }
             }
 
@@ -81,8 +81,8 @@ final class SwiftSyntaxRuleTests: XCTestCase {
             struct Hello {}
 
             extension Hello: SwiftSyntaxRule {
-                func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-                    Visitor(viewMode: .sourceAccurate)
+                func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor<ConfigurationType> {
+                    Visitor(configuration: configuration, locationConverter: file.locationConverter)
                 }
             }
             """,


### PR DESCRIPTION
Almost all rules based on SwiftSyntax can be set up now by just adding `@SwiftSyntaxRule` to the rule struct.