### PR TITLE
Port more rules to the `@SwiftSyntaxRule` macro

### DIFF
--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/AnonymousArgumentInMultilineClosureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/AnonymousArgumentInMultilineClosureRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct AnonymousArgumentInMultilineClosureRule: SwiftSyntaxRule, OptInRule {
+@SwiftSyntaxRule(needsLocationConverter: true)
+struct AnonymousArgumentInMultilineClosureRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(
@@ -30,10 +31,6 @@ struct AnonymousArgumentInMultilineClosureRule: SwiftSyntaxRule, OptInRule {
             """)
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(locationConverter: file.locationConverter)
-    }
 }
 
 private extension AnonymousArgumentInMultilineClosureRule {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedObjectLiteralRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedObjectLiteralRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct DiscouragedObjectLiteralRule: SwiftSyntaxRule, OptInRule {
+@SwiftSyntaxRule(needsConfiguration: true)
+struct DiscouragedObjectLiteralRule: OptInRule {
     var configuration = DiscouragedObjectLiteralConfiguration()
 
     static let description = RuleDescription(
@@ -21,10 +22,6 @@ struct DiscouragedObjectLiteralRule: SwiftSyntaxRule, OptInRule {
             Example("let color = ↓#colorLiteral(red: 0.9607843161, green: 0.7058823705, blue: 0.200000003, alpha: 1)")
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(configuration: configuration)
-    }
 }
 
 private extension DiscouragedObjectLiteralRule {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitInitRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 import SwiftSyntaxBuilder
 
+@SwiftSyntaxRule(needsConfiguration: true)
 struct ExplicitInitRule: SwiftSyntaxCorrectableRule, OptInRule {
     var configuration = ExplicitInitConfiguration()
 
@@ -169,10 +170,6 @@ struct ExplicitInitRule: SwiftSyntaxCorrectableRule, OptInRule {
         ]
     )
 
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(viewMode: .sourceAccurate, includeBareInit: configuration.includeBareInit)
-    }
-
     func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(locationConverter: file.locationConverter, disabledRegions: disabledRegions(file: file))
     }
@@ -180,10 +177,10 @@ struct ExplicitInitRule: SwiftSyntaxCorrectableRule, OptInRule {
 
 private extension ExplicitInitRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        private let includeBareInit: Bool
+        let configuration: ConfigurationType
 
-        init(viewMode: SyntaxTreeViewMode, includeBareInit: Bool) {
-            self.includeBareInit = includeBareInit
+        init(configuration: ConfigurationType) {
+            self.configuration = configuration
             super.init(viewMode: .sourceAccurate)
         }
 
@@ -196,7 +193,8 @@ private extension ExplicitInitRule {
                 violations.append(violationPosition)
             }
 
-            if includeBareInit, let violationPosition = calledExpression.bareInitPosition {
+            if configuration.includeBareInit,
+               let violationPosition = calledExpression.bareInitPosition {
                 let reason = "Prefer named constructors over .init and type inference"
                 violations.append(ReasonedRuleViolation(position: violationPosition, reason: reason))
             }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitTypeInterfaceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitTypeInterfaceRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct ExplicitTypeInterfaceRule: OptInRule, SwiftSyntaxRule {
+@SwiftSyntaxRule(needsConfiguration: true)
+struct ExplicitTypeInterfaceRule: OptInRule {
     var configuration = ExplicitTypeInterfaceConfiguration()
 
     static let description = RuleDescription(
@@ -68,19 +69,15 @@ struct ExplicitTypeInterfaceRule: OptInRule, SwiftSyntaxRule {
             """)
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(configuration: configuration)
-    }
 }
 
 private extension ExplicitTypeInterfaceRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        let configuration: ExplicitTypeInterfaceConfiguration
+        let configuration: ConfigurationType
 
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
 
-        init(configuration: ExplicitTypeInterfaceConfiguration) {
+        init(configuration: ConfigurationType) {
             self.configuration = configuration
             super.init(viewMode: .sourceAccurate)
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ForWhereRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ForWhereRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct ForWhereRule: SwiftSyntaxRule {
+@SwiftSyntaxRule(needsConfiguration: true)
+struct ForWhereRule: Rule {
     var configuration = ForWhereConfiguration()
 
     static let description = RuleDescription(
@@ -115,18 +116,14 @@ struct ForWhereRule: SwiftSyntaxRule {
             """, configuration: ["allow_for_as_filter": true])
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(allowForAsFilter: configuration.allowForAsFilter)
-    }
 }
 
 private extension ForWhereRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        private let allowForAsFilter: Bool
+        let configuration: ConfigurationType
 
-        init(allowForAsFilter: Bool) {
-            self.allowForAsFilter = allowForAsFilter
+        init(configuration: ConfigurationType) {
+            self.configuration = configuration
             super.init(viewMode: .sourceAccurate)
         }
 
@@ -142,7 +139,7 @@ private extension ForWhereRule {
                 return
             }
 
-            if allowForAsFilter, ifExpr.containsReturnStatement {
+            if configuration.allowForAsFilter, ifExpr.containsReturnStatement {
                 return
             }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ForceCastRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ForceCastRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct ForceCastRule: SwiftSyntaxRule {
+@SwiftSyntaxRule
+struct ForceCastRule: Rule {
     var configuration = SeverityConfiguration<Self>(.error)
 
     static let description = RuleDescription(
@@ -13,10 +14,6 @@ struct ForceCastRule: SwiftSyntaxRule {
         ],
         triggeringExamples: [ Example("NSNumber() ↓as! Int") ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(viewMode: .sourceAccurate)
-    }
 }
 
 private extension ForceCastRule {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ForceUnwrappingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ForceUnwrappingRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct ForceUnwrappingRule: OptInRule, SwiftSyntaxRule {
+@SwiftSyntaxRule
+struct ForceUnwrappingRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(
@@ -64,10 +65,6 @@ struct ForceUnwrappingRule: OptInRule, SwiftSyntaxRule {
             Example("map[\"a\"]↓!↓!")
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(viewMode: .sourceAccurate)
-    }
 }
 
 private extension ForceUnwrappingRule {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/GenericTypeNameRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/GenericTypeNameRule.swift
@@ -1,7 +1,8 @@
 import Foundation
 import SwiftSyntax
 
-struct GenericTypeNameRule: SwiftSyntaxRule {
+@SwiftSyntaxRule(needsConfiguration: true)
+struct GenericTypeNameRule: Rule {
     var configuration = NameConfiguration<Self>(minLengthWarning: 1,
                                                 minLengthError: 0,
                                                 maxLengthWarning: 20,
@@ -47,10 +48,6 @@ struct GenericTypeNameRule: SwiftSyntaxRule {
             ]
         }
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(configuration: configuration)
-    }
 }
 
 private extension GenericTypeNameRule {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ImplicitlyUnwrappedOptionalRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ImplicitlyUnwrappedOptionalRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct ImplicitlyUnwrappedOptionalRule: SwiftSyntaxRule, OptInRule {
+@SwiftSyntaxRule(needsConfiguration: true)
+struct ImplicitlyUnwrappedOptionalRule: OptInRule {
     var configuration = ImplicitlyUnwrappedOptionalConfiguration()
 
     static let description = RuleDescription(
@@ -40,18 +41,14 @@ struct ImplicitlyUnwrappedOptionalRule: SwiftSyntaxRule, OptInRule {
             """)
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(mode: configuration.mode)
-    }
 }
 
 private extension ImplicitlyUnwrappedOptionalRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        private let mode: ConfigurationType.ImplicitlyUnwrappedOptionalModeConfiguration
+        private let configuration: ConfigurationType
 
-        init(mode: ConfigurationType.ImplicitlyUnwrappedOptionalModeConfiguration) {
-            self.mode = mode
+        init(configuration: ConfigurationType) {
+            self.configuration = configuration
             super.init(viewMode: .sourceAccurate)
         }
 
@@ -60,7 +57,7 @@ private extension ImplicitlyUnwrappedOptionalRule {
         }
 
         override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
-            switch mode {
+            switch configuration.mode {
             case .all:
                 return .visitChildren
             case .allExceptIBOutlets:

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ObjectLiteralRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ObjectLiteralRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct ObjectLiteralRule: SwiftSyntaxRule, OptInRule {
+@SwiftSyntaxRule(needsConfiguration: true)
+struct ObjectLiteralRule: OptInRule {
     var configuration = ObjectLiteralConfiguration<Self>()
 
     static let description = RuleDescription(
@@ -30,32 +31,26 @@ struct ObjectLiteralRule: SwiftSyntaxRule, OptInRule {
             }
         }
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(validateImageLiteral: configuration.imageLiteral, validateColorLiteral: configuration.colorLiteral)
-    }
 }
 
 private extension ObjectLiteralRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        private let validateImageLiteral: Bool
-        private let validateColorLiteral: Bool
+        private let configuration: ConfigurationType
 
-        init(validateImageLiteral: Bool, validateColorLiteral: Bool) {
-            self.validateImageLiteral = validateImageLiteral
-            self.validateColorLiteral = validateColorLiteral
+        init(configuration: ConfigurationType) {
+            self.configuration = configuration
             super.init(viewMode: .sourceAccurate)
         }
 
         override func visitPost(_ node: FunctionCallExprSyntax) {
-            guard validateColorLiteral || validateImageLiteral else {
+            guard configuration.colorLiteral || configuration.imageLiteral else {
                 return
             }
 
             let name = node.calledExpression.trimmedDescription
-            if validateImageLiteral, isImageNamedInit(node: node, name: name) {
+            if configuration.imageLiteral, isImageNamedInit(node: node, name: name) {
                 violations.append(node.positionAfterSkippingLeadingTrivia)
-            } else if validateColorLiteral, isColorInit(node: node, name: name) {
+            } else if configuration.colorLiteral, isColorInit(node: node, name: name) {
                 violations.append(node.positionAfterSkippingLeadingTrivia)
             }
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PrivateOverFilePrivateRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PrivateOverFilePrivateRule.swift
@@ -1,5 +1,6 @@
 import SwiftSyntax
 
+@SwiftSyntaxRule(needsConfiguration: true)
 struct PrivateOverFilePrivateRule: SwiftSyntaxCorrectableRule {
     var configuration = PrivateOverFilePrivateConfiguration()
 
@@ -54,10 +55,6 @@ struct PrivateOverFilePrivateRule: SwiftSyntaxCorrectableRule {
         ]
     )
 
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(validateExtensions: configuration.validateExtensions)
-    }
-
     func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             validateExtensions: configuration.validateExtensions,
@@ -69,10 +66,10 @@ struct PrivateOverFilePrivateRule: SwiftSyntaxCorrectableRule {
 
 private extension PrivateOverFilePrivateRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        private let validateExtensions: Bool
+        private let configuration: ConfigurationType
 
-        init(validateExtensions: Bool) {
-            self.validateExtensions = validateExtensions
+        init(configuration: ConfigurationType) {
+            self.configuration = configuration
             super.init(viewMode: .sourceAccurate)
         }
 
@@ -84,7 +81,7 @@ private extension PrivateOverFilePrivateRule {
         }
 
         override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
-            if validateExtensions, let privateModifier = node.modifiers.fileprivateModifier {
+            if configuration.validateExtensions, let privateModifier = node.modifiers.fileprivateModifier {
                 violations.append(privateModifier.positionAfterSkippingLeadingTrivia)
             }
             return .skipChildren

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantObjcAttributeRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantObjcAttributeRule.swift
@@ -5,7 +5,8 @@ private let attributeNamesImplyingObjc: Set<String> = [
     "IBAction", "IBOutlet", "IBInspectable", "GKInspectable", "IBDesignable", "NSManaged"
 ]
 
-struct RedundantObjcAttributeRule: SwiftSyntaxRule, SubstitutionCorrectableRule {
+@SwiftSyntaxRule
+struct RedundantObjcAttributeRule: SubstitutionCorrectableRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(
@@ -17,17 +18,6 @@ struct RedundantObjcAttributeRule: SwiftSyntaxRule, SubstitutionCorrectableRule 
         triggeringExamples: RedundantObjcAttributeRuleExamples.triggeringExamples,
         corrections: RedundantObjcAttributeRuleExamples.corrections
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        final class Visitor: ViolationsSyntaxVisitor {
-            override func visitPost(_ node: AttributeListSyntax) {
-                if let objcAttribute = node.violatingObjCAttribute {
-                    violations.append(objcAttribute.positionAfterSkippingLeadingTrivia)
-                }
-            }
-        }
-        return Visitor(viewMode: .sourceAccurate)
-    }
 
     func violationRanges(in file: SwiftLintFile) -> [NSRange] {
         makeVisitor(file: file)
@@ -115,5 +105,15 @@ extension RedundantObjcAttributeRule {
         let withTrailingWhitespaceAndNewlineRange = NSRange(location: violationRange.location,
                                                             length: violationRange.length + whitespaceAndNewlineOffset)
         return (withTrailingWhitespaceAndNewlineRange, "")
+    }
+}
+
+private extension RedundantObjcAttributeRule {
+    final class Visitor: ViolationsSyntaxVisitor {
+        override func visitPost(_ node: AttributeListSyntax) {
+            if let objcAttribute = node.violatingObjCAttribute {
+                violations.append(objcAttribute.positionAfterSkippingLeadingTrivia)
+            }
+        }
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ReturnValueFromVoidFunctionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ReturnValueFromVoidFunctionRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct ReturnValueFromVoidFunctionRule: OptInRule, SwiftSyntaxRule {
+@SwiftSyntaxRule
+struct ReturnValueFromVoidFunctionRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(
@@ -12,10 +13,6 @@ struct ReturnValueFromVoidFunctionRule: OptInRule, SwiftSyntaxRule {
         nonTriggeringExamples: ReturnValueFromVoidFunctionRuleExamples.nonTriggeringExamples,
         triggeringExamples: ReturnValueFromVoidFunctionRuleExamples.triggeringExamples
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(viewMode: .sourceAccurate)
-    }
 }
 
 private extension ReturnValueFromVoidFunctionRule {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/TypeNameRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/TypeNameRule.swift
@@ -1,7 +1,8 @@
 import Foundation
 import SwiftSyntax
 
-struct TypeNameRule: SwiftSyntaxRule {
+@SwiftSyntaxRule(needsConfiguration: true)
+struct TypeNameRule: Rule {
     var configuration = TypeNameConfiguration()
 
     static let description = RuleDescription(
@@ -16,17 +17,13 @@ struct TypeNameRule: SwiftSyntaxRule {
         nonTriggeringExamples: TypeNameRuleExamples.nonTriggeringExamples,
         triggeringExamples: TypeNameRuleExamples.triggeringExamples
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(configuration: configuration)
-    }
 }
 
 private extension TypeNameRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        private let configuration: TypeNameConfiguration
+        private let configuration: ConfigurationType
 
-        init(configuration: TypeNameConfiguration) {
+        init(configuration: ConfigurationType) {
             self.configuration = configuration
             super.init(viewMode: .sourceAccurate)
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnavailableConditionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnavailableConditionRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct UnavailableConditionRule: SwiftSyntaxRule {
+@SwiftSyntaxRule
+struct UnavailableConditionRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(
@@ -68,10 +69,6 @@ struct UnavailableConditionRule: SwiftSyntaxRule {
             """)
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(viewMode: .sourceAccurate)
-    }
 }
 
 private extension UnavailableConditionRule {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
@@ -12,6 +12,7 @@ private func embedInSwitch(
         """, file: file, line: line)
 }
 
+@SwiftSyntaxRule
 struct UnneededBreakInSwitchRule: SwiftSyntaxCorrectableRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
@@ -85,10 +86,6 @@ struct UnneededBreakInSwitchRule: SwiftSyntaxCorrectableRule {
             : embedInSwitch("something()", case: "case .foo, .foo2 where condition")
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(viewMode: .sourceAccurate)
-    }
 
     func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UntypedErrorInCatchRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UntypedErrorInCatchRule.swift
@@ -1,5 +1,6 @@
 import SwiftSyntax
 
+@SwiftSyntaxRule
 struct UntypedErrorInCatchRule: OptInRule, SwiftSyntaxCorrectableRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
@@ -84,10 +85,6 @@ struct UntypedErrorInCatchRule: OptInRule, SwiftSyntaxCorrectableRule {
             Example("do {\n    try foo() \n} ↓catch(let error) {}"): Example("do {\n    try foo() \n} catch {}"),
             Example("do {\n    try foo() \n} ↓catch (let error) {}"): Example("do {\n    try foo() \n} catch {}")
         ])
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(viewMode: .sourceAccurate)
-    }
 
     func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/VoidFunctionInTernaryConditionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/VoidFunctionInTernaryConditionRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct VoidFunctionInTernaryConditionRule: SwiftSyntaxRule {
+@SwiftSyntaxRule
+struct VoidFunctionInTernaryConditionRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(
@@ -105,10 +106,6 @@ struct VoidFunctionInTernaryConditionRule: SwiftSyntaxRule {
             """)
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(viewMode: .sourceAccurate)
-    }
 }
 
 private extension VoidFunctionInTernaryConditionRule {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/XCTSpecificMatcherRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/XCTSpecificMatcherRule.swift
@@ -1,7 +1,8 @@
 import SwiftOperators
 import SwiftSyntax
 
-struct XCTSpecificMatcherRule: SwiftSyntaxRule, OptInRule {
+@SwiftSyntaxRule(needsConfiguration: true)
+struct XCTSpecificMatcherRule: OptInRule {
     var configuration = XCTSpecificMatcherConfiguration()
 
     static let description = RuleDescription(
@@ -12,17 +13,13 @@ struct XCTSpecificMatcherRule: SwiftSyntaxRule, OptInRule {
         nonTriggeringExamples: XCTSpecificMatcherRuleExamples.nonTriggeringExamples,
         triggeringExamples: XCTSpecificMatcherRuleExamples.triggeringExamples
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(configuration: configuration)
-    }
 }
 
 private extension XCTSpecificMatcherRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        let configuration: XCTSpecificMatcherConfiguration
+        let configuration: ConfigurationType
 
-        init(configuration: XCTSpecificMatcherConfiguration) {
+        init(configuration: ConfigurationType) {
             self.configuration = configuration
             super.init(viewMode: .sourceAccurate)
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AnyObjectProtocolRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AnyObjectProtocolRule.swift
@@ -9,6 +9,7 @@ private func warnDeprecatedOnce() {
     _ = warnDeprecatedOnceImpl
 }
 
+@SwiftSyntaxRule(deprecated: true)
 struct AnyObjectProtocolRule: SwiftSyntaxCorrectableRule, OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
@@ -37,11 +38,6 @@ struct AnyObjectProtocolRule: SwiftSyntaxCorrectableRule, OptInRule {
                 Example("@objc protocol SomeClassOnlyProtocol: AnyObject, SomeInheritedProtocol {}")
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        warnDeprecatedOnce()
-        return Visitor(viewMode: .sourceAccurate)
-    }
 
     func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/BalancedXCTestLifecycleRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/BalancedXCTestLifecycleRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct BalancedXCTestLifecycleRule: SwiftSyntaxRule, OptInRule {
+@SwiftSyntaxRule(needsConfiguration: true)
+struct BalancedXCTestLifecycleRule: OptInRule {
     var configuration = BalancedXCTestLifecycleConfiguration()
 
     static let description = RuleDescription(
@@ -103,26 +104,22 @@ struct BalancedXCTestLifecycleRule: SwiftSyntaxRule, OptInRule {
             """#)
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(viewMode: .sourceAccurate, testParentClasses: configuration.testParentClasses)
-    }
 }
 
 // MARK: - Private
 
 private extension BalancedXCTestLifecycleRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        private let testParentClasses: Set<String>
+        private let configuration: ConfigurationType
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .all }
 
-        init(viewMode: SyntaxTreeViewMode, testParentClasses: Set<String>) {
-            self.testParentClasses = testParentClasses
-            super.init(viewMode: viewMode)
+        init(configuration: ConfigurationType) {
+            self.configuration = configuration
+            super.init(viewMode: .sourceAccurate)
         }
 
         override func visitPost(_ node: ClassDeclSyntax) {
-            guard node.isXCTestCase(testParentClasses) else {
+            guard node.isXCTestCase(configuration.testParentClasses) else {
                 return
             }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/DeploymentTargetRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/DeploymentTargetRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct DeploymentTargetRule: SwiftSyntaxRule {
+@SwiftSyntaxRule(needsConfiguration: true)
+struct DeploymentTargetRule: Rule {
     fileprivate typealias Version = DeploymentTargetConfiguration.Version
     var configuration = DeploymentTargetConfiguration()
 
@@ -13,26 +14,10 @@ struct DeploymentTargetRule: SwiftSyntaxRule {
         nonTriggeringExamples: DeploymentTargetRuleExamples.nonTriggeringExamples,
         triggeringExamples: DeploymentTargetRuleExamples.triggeringExamples
     )
+}
 
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(platformToConfiguredMinVersion: platformToConfiguredMinVersion)
-    }
-
-    private var platformToConfiguredMinVersion: [String: Version] {
-        return [
-            "iOS": configuration.iOSDeploymentTarget,
-            "iOSApplicationExtension": configuration.iOSAppExtensionDeploymentTarget,
-            "macOS": configuration.macOSDeploymentTarget,
-            "macOSApplicationExtension": configuration.macOSAppExtensionDeploymentTarget,
-            "OSX": configuration.macOSDeploymentTarget,
-            "tvOS": configuration.tvOSDeploymentTarget,
-            "tvOSApplicationExtension": configuration.tvOSAppExtensionDeploymentTarget,
-            "watchOS": configuration.watchOSDeploymentTarget,
-            "watchOSApplicationExtension": configuration.watchOSAppExtensionDeploymentTarget
-        ]
-    }
-
-    private enum AvailabilityType {
+private extension DeploymentTargetRule {
+    enum AvailabilityType {
         case condition
         case attribute
         case negativeCondition
@@ -48,14 +33,26 @@ struct DeploymentTargetRule: SwiftSyntaxRule {
             }
         }
     }
-}
 
-private extension DeploymentTargetRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        private let platformToConfiguredMinVersion: [String: Version]
+        private let configuration: ConfigurationType
 
-        init(platformToConfiguredMinVersion: [String: Version]) {
-            self.platformToConfiguredMinVersion = platformToConfiguredMinVersion
+        private var platformToConfiguredMinVersion: [String: Version] {
+            [
+                "iOS": configuration.iOSDeploymentTarget,
+                "iOSApplicationExtension": configuration.iOSAppExtensionDeploymentTarget,
+                "macOS": configuration.macOSDeploymentTarget,
+                "macOSApplicationExtension": configuration.macOSAppExtensionDeploymentTarget,
+                "OSX": configuration.macOSDeploymentTarget,
+                "tvOS": configuration.tvOSDeploymentTarget,
+                "tvOSApplicationExtension": configuration.tvOSAppExtensionDeploymentTarget,
+                "watchOS": configuration.watchOSDeploymentTarget,
+                "watchOSApplicationExtension": configuration.watchOSAppExtensionDeploymentTarget
+            ]
+        }
+
+        init(configuration: ConfigurationType) {
+            self.configuration = configuration
             super.init(viewMode: .sourceAccurate)
         }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/DiscouragedDirectInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/DiscouragedDirectInitRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct DiscouragedDirectInitRule: SwiftSyntaxRule {
+@SwiftSyntaxRule(needsConfiguration: true)
+struct DiscouragedDirectInitRule: Rule {
     var configuration = DiscouragedDirectInitConfiguration()
 
     static let description = RuleDescription(
@@ -34,24 +35,21 @@ struct DiscouragedDirectInitRule: SwiftSyntaxRule {
             Example("let foo = bar(bundle: ↓Bundle.init(), device: ↓UIDevice.init(), error: ↓NSError.init())")
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(discouragedInits: configuration.discouragedInits)
-    }
 }
 
 private extension DiscouragedDirectInitRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        private let discouragedInits: Set<String>
+        private let configuration: ConfigurationType
 
-        init(discouragedInits: Set<String>) {
-            self.discouragedInits = discouragedInits
+        init(configuration: ConfigurationType) {
+            self.configuration = configuration
             super.init(viewMode: .sourceAccurate)
         }
 
         override func visitPost(_ node: FunctionCallExprSyntax) {
             guard node.arguments.isEmpty, node.trailingClosure == nil,
-                discouragedInits.contains(node.calledExpression.trimmedDescription) else {
+                  configuration.discouragedInits.contains(node.calledExpression.trimmedDescription)
+            else {
                 return
             }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/EmptyXCTestMethodRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/EmptyXCTestMethodRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct EmptyXCTestMethodRule: OptInRule, SwiftSyntaxRule {
+@SwiftSyntaxRule(needsConfiguration: true)
+struct EmptyXCTestMethodRule: OptInRule {
     var configuration = EmptyXCTestMethodConfiguration()
 
     static let description = RuleDescription(
@@ -11,24 +12,20 @@ struct EmptyXCTestMethodRule: OptInRule, SwiftSyntaxRule {
         nonTriggeringExamples: EmptyXCTestMethodRuleExamples.nonTriggeringExamples,
         triggeringExamples: EmptyXCTestMethodRuleExamples.triggeringExamples
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(testParentClasses: configuration.testParentClasses)
-    }
 }
 
 private extension EmptyXCTestMethodRule {
     final class Visitor: ViolationsSyntaxVisitor {
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .all }
-        private let testParentClasses: Set<String>
+        private let configuration: ConfigurationType
 
-        init(testParentClasses: Set<String>) {
-            self.testParentClasses = testParentClasses
+        init(configuration: ConfigurationType) {
+            self.configuration = configuration
             super.init(viewMode: .sourceAccurate)
         }
 
         override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
-            node.isXCTestCase(testParentClasses) ? .visitChildren : .skipChildren
+            node.isXCTestCase(configuration.testParentClasses) ? .visitChildren : .skipChildren
         }
 
         override func visitPost(_ node: FunctionDeclSyntax) {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/InertDeferRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/InertDeferRule.swift
@@ -9,7 +9,8 @@ private func warnDeprecatedOnce() {
     _ = warnDeprecatedOnceImpl
 }
 
-struct InertDeferRule: SwiftSyntaxRule, OptInRule {
+@SwiftSyntaxRule(deprecated: true)
+struct InertDeferRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(
@@ -82,11 +83,6 @@ struct InertDeferRule: SwiftSyntaxRule, OptInRule {
             """, excludeFromDocumentation: true)
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        warnDeprecatedOnce()
-        return Visitor(viewMode: .sourceAccurate)
-    }
 }
 
 private extension InertDeferRule {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/OverriddenSuperCallRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/OverriddenSuperCallRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct OverriddenSuperCallRule: SwiftSyntaxRule, OptInRule {
+@SwiftSyntaxRule(needsConfiguration: true)
+struct OverriddenSuperCallRule: OptInRule {
     var configuration = OverriddenSuperCallConfiguration()
 
     static let description = RuleDescription(
@@ -73,22 +74,18 @@ struct OverriddenSuperCallRule: SwiftSyntaxRule, OptInRule {
             """)
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(resolvedMethodNames: configuration.resolvedMethodNames)
-    }
 }
 
 private extension OverriddenSuperCallRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        private let resolvedMethodNames: [String]
+        private let configuration: ConfigurationType
 
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] {
             [ProtocolDeclSyntax.self]
         }
 
-        init(resolvedMethodNames: [String]) {
-            self.resolvedMethodNames = resolvedMethodNames
+        init(configuration: ConfigurationType) {
+            self.configuration = configuration
             super.init(viewMode: .sourceAccurate)
         }
 
@@ -97,7 +94,7 @@ private extension OverriddenSuperCallRule {
                   node.modifiers.contains(keyword: .override),
                   !node.modifiers.containsStaticOrClass,
                   case let name = node.resolvedName(),
-                  resolvedMethodNames.contains(name) else {
+                  configuration.resolvedMethodNames.contains(name) else {
                 return
             }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateOutletRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateOutletRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct PrivateOutletRule: SwiftSyntaxRule, OptInRule {
+@SwiftSyntaxRule(needsConfiguration: true)
+struct PrivateOutletRule: OptInRule {
     var configuration = PrivateOutletConfiguration()
 
     static let description = RuleDescription(
@@ -75,18 +76,14 @@ struct PrivateOutletRule: SwiftSyntaxRule, OptInRule {
             """, configuration: ["allow_private_set": false], excludeFromDocumentation: true)
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(allowPrivateSet: configuration.allowPrivateSet)
-    }
 }
 
 private extension PrivateOutletRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        private let allowPrivateSet: Bool
+        private let configuration: ConfigurationType
 
-        init(allowPrivateSet: Bool) {
-            self.allowPrivateSet = allowPrivateSet
+        init(configuration: ConfigurationType) {
+            self.configuration = configuration
             super.init(viewMode: .sourceAccurate)
         }
 
@@ -99,7 +96,7 @@ private extension PrivateOutletRule {
                 return
             }
 
-            if allowPrivateSet && decl.modifiers.containsPrivateOrFileprivate(setOnly: true) {
+            if configuration.allowPrivateSet && decl.modifiers.containsPrivateOrFileprivate(setOnly: true) {
                 return
             }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateUnitTestRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateUnitTestRule.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SwiftSyntax
 
+@SwiftSyntaxRule(needsConfiguration: true)
 struct PrivateUnitTestRule: SwiftSyntaxCorrectableRule {
     var configuration = PrivateUnitTestConfiguration()
 
@@ -125,10 +126,6 @@ struct PrivateUnitTestRule: SwiftSyntaxCorrectableRule {
         ]
     )
 
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(configuration: configuration)
-    }
-
     func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             configuration: configuration,
@@ -140,11 +137,11 @@ struct PrivateUnitTestRule: SwiftSyntaxCorrectableRule {
 
 private extension PrivateUnitTestRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        private let configuration: PrivateUnitTestConfiguration
+        private let configuration: ConfigurationType
 
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { .all }
 
-        init(configuration: PrivateUnitTestConfiguration) {
+        init(configuration: ConfigurationType) {
             self.configuration = configuration
             super.init(viewMode: .sourceAccurate)
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ProhibitedSuperRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ProhibitedSuperRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct ProhibitedSuperRule: SwiftSyntaxRule, OptInRule {
+@SwiftSyntaxRule(needsConfiguration: true)
+struct ProhibitedSuperRule: OptInRule {
     var configuration = ProhibitedSuperConfiguration()
 
     static let description = RuleDescription(
@@ -69,22 +70,18 @@ struct ProhibitedSuperRule: SwiftSyntaxRule, OptInRule {
             """)
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(resolvedMethodNames: configuration.resolvedMethodNames)
-    }
 }
 
 private extension ProhibitedSuperRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        private let resolvedMethodNames: [String]
+        private let configuration: ConfigurationType
 
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] {
             [ProtocolDeclSyntax.self]
         }
 
-        init(resolvedMethodNames: [String]) {
-            self.resolvedMethodNames = resolvedMethodNames
+        init(configuration: ConfigurationType) {
+            self.configuration = configuration
             super.init(viewMode: .sourceAccurate)
         }
 
@@ -93,7 +90,7 @@ private extension ProhibitedSuperRule {
                   node.modifiers.contains(keyword: .override),
                   !node.modifiers.containsStaticOrClass,
                   case let name = node.resolvedName(),
-                  resolvedMethodNames.contains(name),
+                  configuration.resolvedMethodNames.contains(name),
                   node.numberOfCallsToSuper() > 0 else {
                 return
             }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/RequiredEnumCaseRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/RequiredEnumCaseRule.swift
@@ -67,7 +67,8 @@ import SwiftSyntax
 ///     case accountCreated
 /// }
 /// ````
-struct RequiredEnumCaseRule: SwiftSyntaxRule, OptInRule {
+@SwiftSyntaxRule(needsConfiguration: true)
+struct RequiredEnumCaseRule: OptInRule {
     var configuration = RequiredEnumCaseConfiguration()
 
     private static let exampleConfiguration = [
@@ -130,17 +131,13 @@ struct RequiredEnumCaseRule: SwiftSyntaxRule, OptInRule {
             """, configuration: exampleConfiguration)
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(configuration: configuration)
-    }
 }
 
 private extension RequiredEnumCaseRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        private let configuration: RequiredEnumCaseConfiguration
+        private let configuration: ConfigurationType
 
-        init(configuration: RequiredEnumCaseConfiguration) {
+        init(configuration: ConfigurationType) {
             self.configuration = configuration
             super.init(viewMode: .sourceAccurate)
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/TodoRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/TodoRule.swift
@@ -1,7 +1,8 @@
 import Foundation
 import SwiftSyntax
 
-struct TodoRule: SwiftSyntaxRule {
+@SwiftSyntaxRule(needsConfiguration: true)
+struct TodoRule: Rule {
     var configuration = TodoConfiguration()
 
     static let description = RuleDescription(
@@ -24,26 +25,22 @@ struct TodoRule: SwiftSyntaxRule {
             Example("/** ↓TODO: */")
         ].skipWrappingInCommentTests()
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(todoKeywords: configuration.only)
-    }
 }
 
 private extension TodoRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        private let todoKeywords: [TodoConfiguration.TodoKeyword]
+        private let configuration: ConfigurationType
 
-        init(todoKeywords: [TodoConfiguration.TodoKeyword]) {
-            self.todoKeywords = todoKeywords
+        init(configuration: ConfigurationType) {
+            self.configuration = configuration
             super.init(viewMode: .sourceAccurate)
         }
 
         override func visitPost(_ node: TokenSyntax) {
             let leadingViolations = node.leadingTrivia.violations(offset: node.position,
-                                                                  for: todoKeywords)
+                                                                  for: configuration.only)
             let trailingViolations = node.trailingTrivia.violations(offset: node.endPositionBeforeTrailingTrivia,
-                                                                    for: todoKeywords)
+                                                                    for: configuration.only)
             violations.append(contentsOf: leadingViolations + trailingViolations)
         }
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnownedVariableCaptureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnownedVariableCaptureRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct UnownedVariableCaptureRule: SwiftSyntaxRule, OptInRule {
+@SwiftSyntaxRule
+struct UnownedVariableCaptureRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(
@@ -31,10 +32,6 @@ struct UnownedVariableCaptureRule: SwiftSyntaxRule, OptInRule {
             Example("foo { [bar, ↓unowned self] in _ }")
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(viewMode: .sourceAccurate)
-    }
 }
 
 private extension UnownedVariableCaptureRule {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedCaptureListRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedCaptureListRule.swift
@@ -9,7 +9,8 @@ private func warnDeprecatedOnce() {
     _ = warnDeprecatedOnceImpl
 }
 
-struct UnusedCaptureListRule: SwiftSyntaxRule, OptInRule {
+@SwiftSyntaxRule(deprecated: true)
+struct UnusedCaptureListRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static var description = RuleDescription(
@@ -143,11 +144,6 @@ struct UnusedCaptureListRule: SwiftSyntaxRule, OptInRule {
             """)
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        warnDeprecatedOnce()
-        return Visitor(viewMode: .sourceAccurate)
-    }
 }
 
 private extension UnusedCaptureListRule {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/YodaConditionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/YodaConditionRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct YodaConditionRule: OptInRule, SwiftSyntaxRule {
+@SwiftSyntaxRule
+struct YodaConditionRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(
@@ -32,11 +33,8 @@ struct YodaConditionRule: OptInRule, SwiftSyntaxRule {
             Example("if ↓nil == foo {}"),
             Example("while ↓1 > i + 5 {}"),
             Example("if ↓200 <= i && i <= 299 || ↓600 <= i {}")
-        ])
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(viewMode: .sourceAccurate)
-    }
+        ]
+    )
 }
 
 private extension YodaConditionRule {

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/EnumCaseAssociatedValuesLengthRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/EnumCaseAssociatedValuesLengthRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct EnumCaseAssociatedValuesLengthRule: SwiftSyntaxRule, OptInRule {
+@SwiftSyntaxRule(needsConfiguration: true)
+struct EnumCaseAssociatedValuesLengthRule: OptInRule {
     var configuration = SeverityLevelsConfiguration<Self>(warning: 5, error: 6)
 
     static let description = RuleDescription(
@@ -35,10 +36,6 @@ struct EnumCaseAssociatedValuesLengthRule: SwiftSyntaxRule, OptInRule {
             """)
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(configuration: configuration)
-    }
 }
 
 private extension EnumCaseAssociatedValuesLengthRule {

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/FunctionParameterCountRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/FunctionParameterCountRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct FunctionParameterCountRule: SwiftSyntaxRule {
+@SwiftSyntaxRule(needsConfiguration: true)
+struct FunctionParameterCountRule: Rule {
     var configuration = FunctionParameterCountConfiguration()
 
     static let description = RuleDescription(
@@ -34,17 +35,13 @@ struct FunctionParameterCountRule: SwiftSyntaxRule {
             """)
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(configuration: configuration)
-    }
 }
 
 private extension FunctionParameterCountRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        private let configuration: FunctionParameterCountConfiguration
+        private let configuration: ConfigurationType
 
-        init(configuration: FunctionParameterCountConfiguration) {
+        init(configuration: ConfigurationType) {
             self.configuration = configuration
             super.init(viewMode: .sourceAccurate)
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/EmptyCountRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/EmptyCountRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct EmptyCountRule: OptInRule, SwiftSyntaxRule {
+@SwiftSyntaxRule(needsConfiguration: true)
+struct EmptyCountRule: OptInRule {
     var configuration = EmptyCountConfiguration()
 
     static let description = RuleDescription(
@@ -33,10 +34,6 @@ struct EmptyCountRule: OptInRule, SwiftSyntaxRule {
         ]
     )
 
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(onlyAfterDot: configuration.onlyAfterDot)
-    }
-
     func preprocess(file: SwiftLintFile) -> SourceFileSyntax? {
         file.foldedSyntaxTree
     }
@@ -44,10 +41,10 @@ struct EmptyCountRule: OptInRule, SwiftSyntaxRule {
 
 private extension EmptyCountRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        private let onlyAfterDot: Bool
+        private let configuration: ConfigurationType
 
-        init(onlyAfterDot: Bool) {
-            self.onlyAfterDot = onlyAfterDot
+        init(configuration: ConfigurationType) {
+            self.configuration = configuration
             super.init(viewMode: .sourceAccurate)
         }
 
@@ -61,13 +58,13 @@ private extension EmptyCountRule {
             }
 
             if let intExpr = node.rightOperand.as(IntegerLiteralExprSyntax.self), intExpr.isZero,
-               let position = node.leftOperand.countCallPosition(onlyAfterDot: onlyAfterDot) {
+               let position = node.leftOperand.countCallPosition(onlyAfterDot: configuration.onlyAfterDot) {
                 violations.append(position)
                 return
             }
 
             if let intExpr = node.leftOperand.as(IntegerLiteralExprSyntax.self), intExpr.isZero,
-               let position = node.rightOperand.countCallPosition(onlyAfterDot: onlyAfterDot) {
+               let position = node.rightOperand.countCallPosition(onlyAfterDot: configuration.onlyAfterDot) {
                 violations.append(position)
                 return
             }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct AttributesRule: SwiftSyntaxRule, OptInRule {
+@SwiftSyntaxRule(needsLocationConverter: true, needsConfiguration: true)
+struct AttributesRule: OptInRule {
     var configuration = AttributesConfiguration()
 
     static let description = RuleDescription(
@@ -14,21 +15,14 @@ struct AttributesRule: SwiftSyntaxRule, OptInRule {
         nonTriggeringExamples: AttributesRuleExamples.nonTriggeringExamples,
         triggeringExamples: AttributesRuleExamples.triggeringExamples
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(
-            locationConverter: file.locationConverter,
-            configuration: configuration
-        )
-    }
 }
 
 private extension AttributesRule {
     final class Visitor: ViolationsSyntaxVisitor {
         private let locationConverter: SourceLocationConverter
-        private let configuration: AttributesConfiguration
+        private let configuration: ConfigurationType
 
-        init(locationConverter: SourceLocationConverter, configuration: AttributesConfiguration) {
+        init(locationConverter: SourceLocationConverter, configuration: ConfigurationType) {
             self.locationConverter = locationConverter
             self.configuration = configuration
             super.init(viewMode: .sourceAccurate)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ClosureParameterPositionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ClosureParameterPositionRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct ClosureParameterPositionRule: SwiftSyntaxRule {
+@SwiftSyntaxRule(needsLocationConverter: true)
+struct ClosureParameterPositionRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(
@@ -93,10 +94,6 @@ struct ClosureParameterPositionRule: SwiftSyntaxRule {
             """)
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(locationConverter: file.locationConverter)
-    }
 }
 
 private extension ClosureParameterPositionRule {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ClosureSpacingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ClosureSpacingRule.swift
@@ -2,6 +2,7 @@ import SwiftSyntax
 
 // MARK: - ClosureSpacingRule
 
+@SwiftSyntaxRule(needsLocationConverter: true)
 struct ClosureSpacingRule: SwiftSyntaxCorrectableRule, OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
@@ -45,10 +46,6 @@ struct ClosureSpacingRule: SwiftSyntaxCorrectableRule, OptInRule {
                 Example("({ each in return result.contains(where: { e in return 0 }) }).count")
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(locationConverter: file.locationConverter)
-    }
 
     func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ComputedAccessorsOrderRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ComputedAccessorsOrderRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct ComputedAccessorsOrderRule: SwiftSyntaxRule {
+@SwiftSyntaxRule(needsConfiguration: true)
+struct ComputedAccessorsOrderRule: Rule {
     var configuration = ComputedAccessorsOrderConfiguration()
 
     static let description = RuleDescription(
@@ -11,10 +12,6 @@ struct ComputedAccessorsOrderRule: SwiftSyntaxRule {
         nonTriggeringExamples: ComputedAccessorsOrderRuleExamples.nonTriggeringExamples,
         triggeringExamples: ComputedAccessorsOrderRuleExamples.triggeringExamples
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(expectedOrder: configuration.order)
-    }
 }
 
 private extension ComputedAccessorsOrderRule {
@@ -23,17 +20,17 @@ private extension ComputedAccessorsOrderRule {
     }
 
     final class Visitor: ViolationsSyntaxVisitor {
-        private let expectedOrder: ComputedAccessorsOrderConfiguration.Order
+        private let configuration: ConfigurationType
 
-        init(expectedOrder: ComputedAccessorsOrderConfiguration.Order) {
-            self.expectedOrder = expectedOrder
+        init(configuration: ConfigurationType) {
+            self.configuration = configuration
             super.init(viewMode: .sourceAccurate)
         }
 
         override func visitPost(_ node: AccessorBlockSyntax) {
             guard let firstAccessor = node.accessorsList.first,
                   let order = node.order,
-                  order != expectedOrder else {
+                  order != configuration.order else {
                 return
             }
 
@@ -49,7 +46,7 @@ private extension ComputedAccessorsOrderRule {
         private func reason(for kind: ViolationKind) -> String {
             let kindString = kind == .subscript ? "subscripts" : "properties"
             let orderString: String
-            switch expectedOrder {
+            switch configuration.order {
             case .getSet:
                 orderString = "getter and then the setter"
             case .setGet:

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ConditionalReturnsOnNewlineRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ConditionalReturnsOnNewlineRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct ConditionalReturnsOnNewlineRule: OptInRule, SwiftSyntaxRule {
+@SwiftSyntaxRule(needsLocationConverter: true, needsConfiguration: true)
+struct ConditionalReturnsOnNewlineRule: OptInRule {
     var configuration = ConditionalReturnsOnNewlineConfiguration()
 
     static let description = RuleDescription(
@@ -31,23 +32,16 @@ struct ConditionalReturnsOnNewlineRule: OptInRule, SwiftSyntaxRule {
             """)
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(
-            ifOnly: configuration.ifOnly,
-            locationConverter: file.locationConverter
-        )
-    }
 }
 
 private extension ConditionalReturnsOnNewlineRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        private let ifOnly: Bool
         private let locationConverter: SourceLocationConverter
+        private let configuration: ConfigurationType
 
-        init(ifOnly: Bool, locationConverter: SourceLocationConverter) {
-            self.ifOnly = ifOnly
+        init(locationConverter: SourceLocationConverter, configuration: ConfigurationType) {
             self.locationConverter = locationConverter
+            self.configuration = configuration
             super.init(viewMode: .sourceAccurate)
         }
 
@@ -64,7 +58,7 @@ private extension ConditionalReturnsOnNewlineRule {
         }
 
         override func visitPost(_ node: GuardStmtSyntax) {
-            if ifOnly {
+            if configuration.ifOnly {
                 return
             }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ImplicitGetterRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ImplicitGetterRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct ImplicitGetterRule: SwiftSyntaxRule {
+@SwiftSyntaxRule
+struct ImplicitGetterRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(
@@ -11,10 +12,6 @@ struct ImplicitGetterRule: SwiftSyntaxRule {
         nonTriggeringExamples: ImplicitGetterRuleExamples.nonTriggeringExamples,
         triggeringExamples: ImplicitGetterRuleExamples.triggeringExamples
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(viewMode: .sourceAccurate)
-    }
 }
 
 private extension ImplicitGetterRule {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ImplicitReturnRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ImplicitReturnRule.swift
@@ -1,5 +1,6 @@
 import SwiftSyntax
 
+@SwiftSyntaxRule(needsConfiguration: true)
 struct ImplicitReturnRule: SwiftSyntaxCorrectableRule, OptInRule {
     var configuration = ImplicitReturnConfiguration()
 
@@ -12,25 +13,21 @@ struct ImplicitReturnRule: SwiftSyntaxCorrectableRule, OptInRule {
         triggeringExamples: ImplicitReturnRuleExamples.triggeringExamples,
         corrections: ImplicitReturnRuleExamples.corrections
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(config: configuration)
-    }
 }
 
 private extension ImplicitReturnRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        private let config: ConfigurationType
+        private let configuration: ConfigurationType
 
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
 
-        init(config: ConfigurationType) {
-            self.config = config
+        init(configuration: ConfigurationType) {
+            self.configuration = configuration
             super.init(viewMode: .sourceAccurate)
         }
 
         override func visitPost(_ node: AccessorDeclSyntax) {
-            if config.isKindIncluded(.getter),
+            if configuration.isKindIncluded(.getter),
                node.accessorSpecifier.tokenKind == .keyword(.get),
                let body = node.body {
                 collectViolation(in: body.statements)
@@ -38,34 +35,34 @@ private extension ImplicitReturnRule {
         }
 
         override func visitPost(_ node: ClosureExprSyntax) {
-            if config.isKindIncluded(.closure) {
+            if configuration.isKindIncluded(.closure) {
                 collectViolation(in: node.statements)
             }
         }
 
         override func visitPost(_ node: FunctionDeclSyntax) {
-            if config.isKindIncluded(.function),
+            if configuration.isKindIncluded(.function),
                let body = node.body {
                 collectViolation(in: body.statements)
             }
         }
 
         override func visitPost(_ node: InitializerDeclSyntax) {
-            if config.isKindIncluded(.initializer),
+            if configuration.isKindIncluded(.initializer),
                let body = node.body {
                 collectViolation(in: body.statements)
             }
         }
 
         override func visitPost(_ node: PatternBindingSyntax) {
-            if config.isKindIncluded(.getter),
+            if configuration.isKindIncluded(.getter),
                case let .getter(itemList) = node.accessorBlock?.accessors {
                 collectViolation(in: itemList)
             }
         }
 
         override func visitPost(_ node: SubscriptDeclSyntax) {
-            if config.isKindIncluded(.subscript),
+            if configuration.isKindIncluded(.subscript),
                case let .getter(itemList) = node.accessorBlock?.accessors {
                 collectViolation(in: itemList)
             }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/InclusiveLanguageRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/InclusiveLanguageRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct InclusiveLanguageRule: SwiftSyntaxRule {
+@SwiftSyntaxRule(needsConfiguration: true)
+struct InclusiveLanguageRule: Rule {
     var configuration = InclusiveLanguageConfiguration()
 
     static let description = RuleDescription(
@@ -14,20 +15,14 @@ struct InclusiveLanguageRule: SwiftSyntaxRule {
         nonTriggeringExamples: InclusiveLanguageRuleExamples.nonTriggeringExamples,
         triggeringExamples: InclusiveLanguageRuleExamples.triggeringExamples
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(allTerms: configuration.allTerms, allAllowedTerms: configuration.allAllowedTerms)
-    }
 }
 
 private extension InclusiveLanguageRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        private let allTerms: [String]
-        private let allAllowedTerms: Set<String>
+        private let configuration: ConfigurationType
 
-        init(allTerms: [String], allAllowedTerms: Set<String>) {
-            self.allTerms = allTerms
-            self.allAllowedTerms = allAllowedTerms
+        init(configuration: ConfigurationType) {
+            self.configuration = configuration
             super.init(viewMode: .sourceAccurate)
         }
 
@@ -131,9 +126,9 @@ private extension InclusiveLanguageRule {
         private func violationTerm(for node: TokenSyntax) -> (violationTerm: String, name: String)? {
             let name = node.text
             let lowercased = name.lowercased()
-            let violationTerm = allTerms.first { term in
+            let violationTerm = configuration.allTerms.first { term in
                 guard let range = lowercased.range(of: term) else { return false }
-                let overlapsAllowedTerm = allAllowedTerms.contains { allowedTerm in
+                let overlapsAllowedTerm = configuration.allAllowedTerms.contains { allowedTerm in
                     guard let allowedRange = lowercased.range(of: allowedTerm) else { return false }
                     return range.overlaps(allowedRange)
                 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/MultilineParametersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/MultilineParametersRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct MultilineParametersRule: SwiftSyntaxRule, OptInRule {
+@SwiftSyntaxRule(needsLocationConverter: true, needsConfiguration: true)
+struct MultilineParametersRule: OptInRule {
     var configuration = MultilineParametersConfiguration()
 
     static let description = RuleDescription(
@@ -11,20 +12,16 @@ struct MultilineParametersRule: SwiftSyntaxRule, OptInRule {
         nonTriggeringExamples: MultilineParametersRuleExamples.nonTriggeringExamples,
         triggeringExamples: MultilineParametersRuleExamples.triggeringExamples
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(allowsSingleLine: configuration.allowsSingleLine, locationConverter: file.locationConverter)
-    }
 }
 
 private extension MultilineParametersRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        private let allowsSingleLine: Bool
         private let locationConverter: SourceLocationConverter
+        private let configuration: ConfigurationType
 
-        init(allowsSingleLine: Bool, locationConverter: SourceLocationConverter) {
-            self.allowsSingleLine = allowsSingleLine
+        init(locationConverter: SourceLocationConverter, configuration: ConfigurationType) {
             self.locationConverter = locationConverter
+            self.configuration = configuration
             super.init(viewMode: .sourceAccurate)
         }
 
@@ -55,7 +52,7 @@ private extension MultilineParametersRule {
                 numberOfParameters += 1
             }
 
-            guard linesWithParameters.count > (allowsSingleLine ? 1 : 0),
+            guard linesWithParameters.count > (configuration.allowsSingleLine ? 1 : 0),
                   numberOfParameters != linesWithParameters.count else {
                 return false
             }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/NonOverridableClassDeclarationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/NonOverridableClassDeclarationRule.swift
@@ -1,5 +1,6 @@
 import SwiftSyntax
 
+@SwiftSyntaxRule(needsConfiguration: true)
 struct NonOverridableClassDeclarationRule: SwiftSyntaxCorrectableRule, OptInRule {
     var configuration = NonOverridableClassDeclarationConfiguration()
 
@@ -94,21 +95,17 @@ struct NonOverridableClassDeclarationRule: SwiftSyntaxCorrectableRule, OptInRule
                 """)
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(configuration: configuration)
-    }
 }
 
 private extension NonOverridableClassDeclarationRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        private let configuration: NonOverridableClassDeclarationConfiguration
+        private let configuration: ConfigurationType
 
         private var finalClassScope = Stack<Bool>()
 
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
 
-        init(configuration: NonOverridableClassDeclarationConfiguration) {
+        init(configuration: ConfigurationType) {
             self.configuration = configuration
             super.init(viewMode: .sourceAccurate)
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/NumberSeparatorRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/NumberSeparatorRule.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SwiftSyntax
 
+@SwiftSyntaxRule(needsConfiguration: true)
 struct NumberSeparatorRule: OptInRule, SwiftSyntaxCorrectableRule {
     var configuration = NumberSeparatorConfiguration()
 
@@ -25,10 +26,6 @@ struct NumberSeparatorRule: OptInRule, SwiftSyntaxCorrectableRule {
         Underscore(s) used as thousand separator(s) should be added after every 3 digits only
         """
 
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(configuration: configuration)
-    }
-
     func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             configuration: configuration,
@@ -40,9 +37,9 @@ struct NumberSeparatorRule: OptInRule, SwiftSyntaxCorrectableRule {
 
 private extension NumberSeparatorRule {
     final class Visitor: ViolationsSyntaxVisitor, NumberSeparatorValidator {
-        let configuration: NumberSeparatorConfiguration
+        let configuration: ConfigurationType
 
-        init(configuration: NumberSeparatorConfiguration) {
+        init(configuration: ConfigurationType) {
             self.configuration = configuration
             super.init(viewMode: .sourceAccurate)
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/PrefixedTopLevelConstantRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/PrefixedTopLevelConstantRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct PrefixedTopLevelConstantRule: SwiftSyntaxRule, OptInRule {
+@SwiftSyntaxRule(needsConfiguration: true)
+struct PrefixedTopLevelConstantRule: OptInRule {
     var configuration = PrefixedTopLevelConstantConfiguration()
 
     static let description = RuleDescription(
@@ -78,19 +79,15 @@ struct PrefixedTopLevelConstantRule: SwiftSyntaxRule, OptInRule {
             """)
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(onlyPrivateMembers: configuration.onlyPrivateMembers)
-    }
 }
 
 private extension PrefixedTopLevelConstantRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        private let onlyPrivateMembers: Bool
+        private let configuration: ConfigurationType
         private let topLevelPrefix = "k"
 
-        init(onlyPrivateMembers: Bool) {
-            self.onlyPrivateMembers = onlyPrivateMembers
+        init(configuration: ConfigurationType) {
+            self.configuration = configuration
             super.init(viewMode: .sourceAccurate)
         }
 
@@ -101,7 +98,7 @@ private extension PrefixedTopLevelConstantRule {
                 return
             }
 
-            if onlyPrivateMembers, !node.modifiers.containsPrivateOrFileprivate() {
+            if configuration.onlyPrivateMembers, !node.modifiers.containsPrivateOrFileprivate() {
                 return
             }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/RedundantSelfInClosureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/RedundantSelfInClosureRule.swift
@@ -1,5 +1,6 @@
 import SwiftSyntax
 
+@SwiftSyntaxRule
 struct RedundantSelfInClosureRule: SwiftSyntaxCorrectableRule, OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
@@ -12,10 +13,6 @@ struct RedundantSelfInClosureRule: SwiftSyntaxCorrectableRule, OptInRule {
         triggeringExamples: RedundantSelfInClosureRuleExamples.triggeringExamples,
         corrections: RedundantSelfInClosureRuleExamples.corrections
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        ContextVisitor()
-    }
 }
 
 private enum TypeDeclarationKind {
@@ -35,6 +32,7 @@ private enum SelfCaptureKind {
 }
 
 private extension RedundantSelfInClosureRule {
+    typealias Visitor = ContextVisitor
     final class ContextVisitor: DeclaredIdentifiersTrackingVisitor {
         private var typeDeclarations = Stack<TypeDeclarationKind>()
         private var functionCalls = Stack<FunctionCallType>()

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SelfBindingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SelfBindingRule.swift
@@ -2,6 +2,7 @@ import SwiftSyntax
 
 // MARK: - SelfBindingRule
 
+@SwiftSyntaxRule(needsConfiguration: true)
 struct SelfBindingRule: SwiftSyntaxCorrectableRule, OptInRule {
     var configuration = SelfBindingConfiguration()
 
@@ -46,10 +47,6 @@ struct SelfBindingRule: SwiftSyntaxCorrectableRule, OptInRule {
         ]
     )
 
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(bindIdentifier: configuration.bindIdentifier)
-    }
-
     func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             bindIdentifier: configuration.bindIdentifier,
@@ -61,14 +58,15 @@ struct SelfBindingRule: SwiftSyntaxCorrectableRule, OptInRule {
 
 private extension SelfBindingRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        private let bindIdentifier: String
+        private let configuration: ConfigurationType
 
-        init(bindIdentifier: String) {
-            self.bindIdentifier = bindIdentifier
+        init(configuration: ConfigurationType) {
+            self.configuration = configuration
             super.init(viewMode: .sourceAccurate)
         }
 
         override func visitPost(_ node: OptionalBindingConditionSyntax) {
+            let bindIdentifier = configuration.bindIdentifier
             if let identifierPattern = node.pattern.as(IdentifierPatternSyntax.self),
                identifierPattern.identifier.text != bindIdentifier {
                 var hasViolation = false

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SwitchCaseAlignmentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SwitchCaseAlignmentRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct SwitchCaseAlignmentRule: SwiftSyntaxRule {
+@SwiftSyntaxRule(needsLocationConverter: true, needsConfiguration: true)
+struct SwitchCaseAlignmentRule: Rule {
     var configuration = SwitchCaseAlignmentConfiguration()
 
     static let description = RuleDescription(
@@ -37,20 +38,16 @@ struct SwitchCaseAlignmentRule: SwiftSyntaxRule {
         ],
         triggeringExamples: Examples(indentedCases: false).triggeringExamples
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(locationConverter: file.locationConverter, indentedCases: configuration.indentedCases)
-    }
 }
 
 extension SwitchCaseAlignmentRule {
     final class Visitor: ViolationsSyntaxVisitor {
         private let locationConverter: SourceLocationConverter
-        private let indentedCases: Bool
+        private let configuration: ConfigurationType
 
-        init(locationConverter: SourceLocationConverter, indentedCases: Bool) {
+        init(locationConverter: SourceLocationConverter, configuration: ConfigurationType) {
             self.locationConverter = locationConverter
-            self.indentedCases = indentedCases
+            self.configuration = configuration
             super.init(viewMode: .sourceAccurate)
         }
 
@@ -64,6 +61,7 @@ extension SwitchCaseAlignmentRule {
             }
 
             let firstCaseColumn = locationConverter.location(for: firstCasePosition).column
+            let indentedCases = configuration.indentedCases
 
             for `case` in node.cases where `case`.is(SwitchCaseSyntax.self) {
                 let casePosition = `case`.positionAfterSkippingLeadingTrivia

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SwitchCaseOnNewlineRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SwitchCaseOnNewlineRule.swift
@@ -8,7 +8,8 @@ private func wrapInSwitch(_ str: String, file: StaticString = #file, line: UInt 
     """, file: file, line: line)
 }
 
-struct SwitchCaseOnNewlineRule: SwiftSyntaxRule, OptInRule {
+@SwiftSyntaxRule(needsLocationConverter: true)
+struct SwitchCaseOnNewlineRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(
@@ -59,10 +60,6 @@ struct SwitchCaseOnNewlineRule: SwiftSyntaxRule, OptInRule {
             wrapInSwitch("↓case .first,\n .second: return false")
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(locationConverter: file.locationConverter)
-    }
 }
 
 private extension SwitchCaseOnNewlineRule {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/TrailingCommaRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/TrailingCommaRule.swift
@@ -1,5 +1,6 @@
 import SwiftSyntax
 
+@SwiftSyntaxRule(needsLocationConverter: true, needsConfiguration: true)
 struct TrailingCommaRule: SwiftSyntaxCorrectableRule {
     var configuration = TrailingCommaConfiguration()
 
@@ -47,13 +48,6 @@ struct TrailingCommaRule: SwiftSyntaxCorrectableRule {
         corrections: Self.corrections
     )
 
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(
-            mandatoryComma: configuration.mandatoryComma,
-            locationConverter: file.locationConverter
-        )
-    }
-
     func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             mandatoryComma: configuration.mandatoryComma,
@@ -65,12 +59,12 @@ struct TrailingCommaRule: SwiftSyntaxCorrectableRule {
 
 private extension TrailingCommaRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        private let mandatoryComma: Bool
         private let locationConverter: SourceLocationConverter
+        private let configuration: ConfigurationType
 
-        init(mandatoryComma: Bool, locationConverter: SourceLocationConverter) {
-            self.mandatoryComma = mandatoryComma
+        init(locationConverter: SourceLocationConverter, configuration: ConfigurationType) {
             self.locationConverter = locationConverter
+            self.configuration = configuration
             super.init(viewMode: .sourceAccurate)
         }
 
@@ -79,7 +73,7 @@ private extension TrailingCommaRule {
                 return
             }
 
-            switch (lastElement.trailingComma, mandatoryComma) {
+            switch (lastElement.trailingComma, configuration.mandatoryComma) {
             case (let commaToken?, false):
                 violations.append(violation(for: commaToken.positionAfterSkippingLeadingTrivia))
             case (nil, true) where !locationConverter.isSingleLine(node: node):
@@ -94,7 +88,7 @@ private extension TrailingCommaRule {
                 return
             }
 
-            switch (lastElement.trailingComma, mandatoryComma) {
+            switch (lastElement.trailingComma, configuration.mandatoryComma) {
             case (let commaToken?, false):
                 violations.append(violation(for: commaToken.positionAfterSkippingLeadingTrivia))
             case (nil, true) where !locationConverter.isSingleLine(node: node):
@@ -105,7 +99,7 @@ private extension TrailingCommaRule {
         }
 
         private func violation(for position: AbsolutePosition) -> ReasonedRuleViolation {
-            let reason = mandatoryComma
+            let reason = configuration.mandatoryComma
                 ? "Multi-line collection literals should have trailing commas"
                 : "Collection literals should not have trailing commas"
             return ReasonedRuleViolation(position: position, reason: reason)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/UnusedOptionalBindingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/UnusedOptionalBindingRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct UnusedOptionalBindingRule: SwiftSyntaxRule {
+@SwiftSyntaxRule(needsConfiguration: true)
+struct UnusedOptionalBindingRule: Rule {
     var configuration = UnusedOptionalBindingConfiguration()
 
     static let description = RuleDescription(
@@ -28,18 +29,14 @@ struct UnusedOptionalBindingRule: SwiftSyntaxRule {
             Example("func foo() { if let ↓_ = bar {} }")
         ]
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(ignoreOptionalTry: configuration.ignoreOptionalTry)
-    }
 }
 
 private extension UnusedOptionalBindingRule {
     final class Visitor: ViolationsSyntaxVisitor {
-        private let ignoreOptionalTry: Bool
+        private let configuration: ConfigurationType
 
-        init(ignoreOptionalTry: Bool) {
-            self.ignoreOptionalTry = ignoreOptionalTry
+        init(configuration: ConfigurationType) {
+            self.configuration = configuration
             super.init(viewMode: .sourceAccurate)
         }
 
@@ -49,7 +46,7 @@ private extension UnusedOptionalBindingRule {
                 return
             }
 
-            if ignoreOptionalTry,
+            if configuration.ignoreOptionalTry,
                let tryExpr = node.initializer?.value.as(TryExprSyntax.self),
                tryExpr.questionOrExclamationMark?.tokenKind == .postfixQuestionMark {
                 return

--- a/Source/SwiftLintBuiltInRules/Rules/Style/VerticalParameterAlignmentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/VerticalParameterAlignmentRule.swift
@@ -1,6 +1,7 @@
 import SwiftSyntax
 
-struct VerticalParameterAlignmentRule: SwiftSyntaxRule {
+@SwiftSyntaxRule(needsLocationConverter: true)
+struct VerticalParameterAlignmentRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(
@@ -11,10 +12,6 @@ struct VerticalParameterAlignmentRule: SwiftSyntaxRule {
         nonTriggeringExamples: VerticalParameterAlignmentRuleExamples.nonTriggeringExamples,
         triggeringExamples: VerticalParameterAlignmentRuleExamples.triggeringExamples
     )
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-        Visitor(locationConverter: file.locationConverter)
-    }
 }
 
 private extension VerticalParameterAlignmentRule {

--- a/Source/SwiftLintCore/Helpers/Macros.swift
+++ b/Source/SwiftLintCore/Helpers/Macros.swift
@@ -20,7 +20,8 @@ public macro MakeAcceptableByConfigurationElement() = #externalMacro(
 public macro SwiftSyntaxRule(
     foldExpressions: Bool = false,
     needsLocationConverter: Bool = false,
-    needsConfiguration: Bool = false
+    needsConfiguration: Bool = false,
+    deprecated: Bool = false
 ) = #externalMacro(
     module: "SwiftLintCoreMacros",
     type: "SwiftSyntaxRule"

--- a/Source/SwiftLintCore/Helpers/Macros.swift
+++ b/Source/SwiftLintCore/Helpers/Macros.swift
@@ -17,7 +17,11 @@ public macro MakeAcceptableByConfigurationElement() = #externalMacro(
 /// that creates a visitor defined in the same file. It also adds an implementation of `preprocess(file:)` which folds
 /// expressions if the `foldExpressions` argument is set.
 @attached(extension, conformances: SwiftSyntaxRule, names: named(makeVisitor(file:)), named(preprocess(file:)))
-public macro SwiftSyntaxRule(foldExpressions: Bool = false) = #externalMacro(
+public macro SwiftSyntaxRule(
+    foldExpressions: Bool = false,
+    needsLocationConverter: Bool = false,
+    needsConfiguration: Bool = false
+) = #externalMacro(
     module: "SwiftLintCoreMacros",
     type: "SwiftSyntaxRule"
 )

--- a/Source/SwiftLintCore/Visitors/DeclaredIdentifiersTrackingVisitor.swift
+++ b/Source/SwiftLintCore/Visitors/DeclaredIdentifiersTrackingVisitor.swift
@@ -10,10 +10,11 @@ open class DeclaredIdentifiersTrackingVisitor: ViolationsSyntaxVisitor {
 
     /// Initializer.
     ///
-    /// - parameter scope: A (potentially already pre-filled) scope to collect identifers into.
-    public init(scope: Scope = Scope()) {
+    /// - parameter viewMode: How missing and unexpected nodes should be handled when traversing a syntax tree.
+    /// - parameter scope:    A (potentially already pre-filled) scope to collect identifers into.
+    public init(viewMode: SyntaxTreeViewMode = .sourceAccurate, scope: Scope = Scope()) {
         self.scope = scope
-        super.init(viewMode: .sourceAccurate)
+        super.init(viewMode: viewMode)
     }
 
     /// Indicate whether a given identifier is in scope.

--- a/Source/SwiftLintCoreMacros/SwiftSyntaxRule.swift
+++ b/Source/SwiftLintCoreMacros/SwiftSyntaxRule.swift
@@ -23,11 +23,19 @@ struct SwiftSyntaxRule: ExtensionMacro {
         }
 
         let visitorExpr = "Visitor(\(args.joined(separator: ", ")))"
+        let makeVisitorBody = if node.deprecated {
+            """
+            warnDeprecatedOnce()
+            return \(visitorExpr)
+            """
+        } else {
+            visitorExpr
+        }
         return [
             try ExtensionDeclSyntax("""
                 extension \(type): SwiftSyntaxRule {
                     func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
-                        \(raw: visitorExpr)
+                        \(raw: makeVisitorBody)
                     }
                 }
                 """),
@@ -57,6 +65,7 @@ private extension AttributeSyntax {
     var foldExpressions: Bool { hasTrueArgument(labeled: "foldExpressions") }
     var needsLocationConverter: Bool { hasTrueArgument(labeled: "needsLocationConverter") }
     var needsConfiguration: Bool { hasTrueArgument(labeled: "needsConfiguration") }
+    var deprecated: Bool { hasTrueArgument(labeled: "deprecated") }
 
     func hasTrueArgument(labeled label: String) -> Bool {
         if

--- a/Tests/MacroTests/SwiftSyntaxRuleTests.swift
+++ b/Tests/MacroTests/SwiftSyntaxRuleTests.swift
@@ -89,4 +89,23 @@ final class SwiftSyntaxRuleTests: XCTestCase {
             macros: macros
         )
     }
+
+    func testNeedsLocationConverter() {
+        assertMacroExpansion(
+            """
+            @SwiftSyntaxRule(needsLocationConverter: true)
+            struct Hello {}
+            """,
+            expandedSource: """
+            struct Hello {}
+
+            extension Hello: SwiftSyntaxRule {
+                func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+                    Visitor(locationConverter: file.locationConverter)
+                }
+            }
+            """,
+            macros: macros
+        )
+    }
 }

--- a/Tests/MacroTests/SwiftSyntaxRuleTests.swift
+++ b/Tests/MacroTests/SwiftSyntaxRuleTests.swift
@@ -108,4 +108,62 @@ final class SwiftSyntaxRuleTests: XCTestCase {
             macros: macros
         )
     }
+
+    func testNeedsConfiguration() {
+        assertMacroExpansion(
+            """
+            @SwiftSyntaxRule(needsConfiguration: true)
+            struct Hello {}
+            """,
+            expandedSource: """
+            struct Hello {}
+
+            extension Hello: SwiftSyntaxRule {
+                func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+                    Visitor(configuration: configuration)
+                }
+            }
+            """,
+            macros: macros
+        )
+    }
+
+    func testNeedsLocationConverterAndConfiguration() {
+        assertMacroExpansion(
+            """
+            @SwiftSyntaxRule(needsLocationConverter: true, needsConfiguration: true)
+            struct Hello {}
+            """,
+            expandedSource: """
+            struct Hello {}
+
+            extension Hello: SwiftSyntaxRule {
+                func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+                    Visitor(locationConverter: file.locationConverter, configuration: configuration)
+                }
+            }
+            """,
+            macros: macros
+        )
+    }
+
+    func testDeprecated() {
+        assertMacroExpansion(
+            """
+            @SwiftSyntaxRule(deprecated: true)
+            struct Hello {}
+            """,
+            expandedSource: """
+            struct Hello {}
+
+            extension Hello: SwiftSyntaxRule {
+                func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor {
+                    warnDeprecatedOnce()
+                    return Visitor(viewMode: .sourceAccurate)
+                }
+            }
+            """,
+            macros: macros
+        )
+    }
 }


### PR DESCRIPTION
By adding `needsLocationConverter` and `needsConfiguration` parameters. An alternative to #5275.