### PR TITLE
Improve Danger comment when CI jobs are canceled

### DIFF
--- a/tools/oss-check
+++ b/tools/oss-check
@@ -13,8 +13,6 @@ require 'erb'
 # Options
 ################################
 
-# Touch
-
 @options = {
   branch: 'HEAD',
   iterations: 5,

--- a/tools/oss-check
+++ b/tools/oss-check
@@ -13,6 +13,8 @@ require 'erb'
 # Options
 ################################
 
+# Touch
+
 @options = {
   branch: 'HEAD',
   iterations: 5,


### PR DESCRIPTION
This often happens when pushing a new commit to a PR while the Danger job for a previous commit is still running.

|Before|After|
|-|-|
|<img width="450" src="https://github.com/realm/SwiftLint/assets/474794/ba705e7f-dbb0-4885-85ea-432fb37fea63">|<img width="450" src="https://github.com/realm/SwiftLint/assets/474794/56b64230-83ce-400a-a47f-0859573c9a37">|