### PR TITLE
#5205 Explicitely disable cache for SwiftLintPlugin runs on Xcode Cloud

### DIFF
--- a/Plugins/SwiftLintPlugin/SwiftLintPlugin.swift
+++ b/Plugins/SwiftLintPlugin/SwiftLintPlugin.swift
@@ -32,9 +32,16 @@ struct SwiftLintPlugin: BuildToolPlugin {
             // We always pass all of the Swift source files in the target to the tool,
             // so we need to ensure that any exclusion rules in the configuration are
             // respected.
-            "--force-exclude",
-            "--cache-path", "\(workingDirectory)"
+            "--force-exclude"
         ]
+
+        // Determine whether we need to enable cache or not (for Xcode Cloud we don't)
+        if ProcessInfo.processInfo.environment["CI_XCODE_CLOUD"] == "TRUE" {
+            arguments.append("--no-cache")
+        } else {
+            arguments.append("--cache-path")
+            arguments.append("\(workingDirectory)")
+        }
 
         // Manually look for configuration files, to avoid issues when the plugin does not execute our tool from the
         // package source directory.


### PR DESCRIPTION
In Xcode Cloud environment, SwiftLint’s cache cannot be written.

When using the SwiftLinkPlugin, there is no way to disable the cache. Previously, a solution was made for the SwiftLint CLI itself where it looks at a set of environment variables (#4485).

This solution offers a cleaner approach where the plugin itself decides whether it needs to enable or disable the cache based on the `CI_XCODE_CLOUD` environment variable.