### PR TITLE
Fix CI pipeline realm.SwiftLint

### DIFF
--- a/Tests/SwiftLintFrameworkTests/SwiftVersionTests.swift
+++ b/Tests/SwiftLintFrameworkTests/SwiftVersionTests.swift
@@ -5,6 +5,8 @@ final class SwiftVersionTests: SwiftLintTestCase {
     func testDetectSwiftVersion() {
 #if compiler(>=6.0.0)
         let version = "6.0.0"
+#elseif compiler(>=5.9.1)
+        let version = "5.9.1"
 #elseif compiler(>=5.9.0)
         let version = "5.9.0"
 #elseif compiler(>=5.8.1)


### PR DESCRIPTION
Fix:

- [SwiftVersionTests.testDetectSwiftVersion : XCTAssertEqual failed: ("5.9.1") is not equal to ("5.9.0")](https://dev.azure.com/jpsim/SwiftLint/_build/results?buildId=7453&view=logs&j=e9849c8f-537d-5090-3bd0-87ae8d017b80&t=6d4902fa-2849-57db-38b5-0b5b726699a6&l=1894)
