### PR TITLE
Fix CocoaPods job + Swift 5.9.1

### DIFF
--- a/Tests/SwiftLintFrameworkTests/SwiftVersionTests.swift
+++ b/Tests/SwiftLintFrameworkTests/SwiftVersionTests.swift
@@ -5,6 +5,8 @@ final class SwiftVersionTests: SwiftLintTestCase {
     func testDetectSwiftVersion() {
 #if compiler(>=6.0.0)
         let version = "6.0.0"
+#elseif compiler(>=5.9.1)
+        let version = "5.9.1"
 #elseif compiler(>=5.9.0)
         let version = "5.9.0"
 #elseif compiler(>=5.8.1)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,7 +41,7 @@ jobs:
       displayName: bundle install
     - script: bundle exec pod repo update
       displayName: pod repo update
-    - script: bundle exec pod lib lint --verbose
+    - script: bundle exec pod lib lint --platforms=macos --verbose
       displayName: pod lib lint
 
 - job: jazzy


### PR DESCRIPTION
We don't really need to test `pod lib lint` against an iOS simulator, so let's just use `macos` to make CI happy again