### PR TITLE
Update SwiftSyntax to version 509.0.2

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,7 +10,7 @@ bazel_dep(name = "platforms", version = "0.0.7")
 bazel_dep(name = "rules_apple", version = "3.0.0", repo_name = "build_bazel_rules_apple")
 bazel_dep(name = "rules_swift", version = "1.12.0", repo_name = "build_bazel_rules_swift")
 bazel_dep(name = "sourcekitten", version = "0.34.1", repo_name = "com_github_jpsim_sourcekitten")
-bazel_dep(name = "swift-syntax", version = "509.0.0.1", repo_name = "SwiftSyntax")
+bazel_dep(name = "swift-syntax", version = "509.0.2", repo_name = "SwiftSyntax")
 bazel_dep(name = "swift_argument_parser", version = "1.2.1", repo_name = "sourcekitten_com_github_apple_swift_argument_parser")
 bazel_dep(name = "yams", version = "5.0.6", repo_name = "sourcekitten_com_github_jpsim_yams")
 


### PR DESCRIPTION
~Requires https://github.com/bazelbuild/bazel-central-registry/pull/1049.~