### PR TITLE
Fix implicit_getter false positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@
 
 #### Bug Fixes
 
+* Fix false positive in `implicit_getter` rule when using unknown accessors.
+  [kabiroberai](https://github.com/kabiroberai)
+  [#5300](https://github.com/realm/SwiftLint/issues/5300)
+
 * Fix correction of `explicit_init` rule by keeping significant trivia.  
   [BB9z](https://github.com/BB9z)
   [#5289](https://github.com/realm/SwiftLint/issues/5289)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@
 
 #### Bug Fixes
 
-* Fix false positive in `implicit_getter` rule when using unknown accessors.
+* Fix false positive in `implicit_getter` rule when using unknown accessors.  
   [kabiroberai](https://github.com/kabiroberai)
   [#5300](https://github.com/realm/SwiftLint/issues/5300)
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ImplicitGetterRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ImplicitGetterRule.swift
@@ -30,8 +30,8 @@ private enum ViolationKind {
 private extension ImplicitGetterRule {
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: AccessorBlockSyntax) {
-            guard let getAccessor = node.getAccessor,
-                  node.accessorsList.count == 1,
+            guard node.accessorsList.count == 1,
+                  let getAccessor = node.getAccessor,
                   getAccessor.effectSpecifiers == nil,
                   getAccessor.modifier == nil,
                   getAccessor.attributes.isEmpty == true,

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ImplicitGetterRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ImplicitGetterRule.swift
@@ -31,7 +31,7 @@ private extension ImplicitGetterRule {
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: AccessorBlockSyntax) {
             guard let getAccessor = node.getAccessor,
-                  node.setAccessor == nil,
+                  node.accessorsList.count == 1,
                   getAccessor.effectSpecifiers == nil,
                   getAccessor.modifier == nil,
                   getAccessor.attributes.isEmpty == true,

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ImplicitGetterRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ImplicitGetterRuleExamples.swift
@@ -33,6 +33,14 @@ struct ImplicitGetterRuleExamples {
         Example("""
             class Foo {
                 var foo: Int {
+                    get { _foo }
+                    _modify { yield &_foo }
+                }
+            }
+            """),
+        Example("""
+            class Foo {
+                var foo: Int {
                     @storageRestrictions(initializes: _foo)
                     init { _foo = newValue }
                     get { _foo }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ImplicitGetterRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ImplicitGetterRuleExamples.swift
@@ -32,6 +32,15 @@ struct ImplicitGetterRuleExamples {
             """),
         Example("""
             class Foo {
+                var foo: Int {
+                    @storageRestrictions(initializes: _foo)
+                    init { _foo = newValue }
+                    get { _foo }
+                }
+            }
+            """),
+        Example("""
+            class Foo {
                 var foo: Int
             }
             """),

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ImplicitGetterRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ImplicitGetterRuleExamples.swift
@@ -40,6 +40,7 @@ struct ImplicitGetterRuleExamples {
             """),
         Example("""
             class Foo {
+                var _foo: Int
                 var foo: Int {
                     @storageRestrictions(initializes: _foo)
                     init { _foo = newValue }

--- a/Source/SwiftLintCore/Models/RuleConfigurationDescription.swift
+++ b/Source/SwiftLintCore/Models/RuleConfigurationDescription.swift
@@ -397,7 +397,7 @@ public struct ConfigurationElement<T: AcceptableByConfigurationElement & Equatab
     /// The wrapper itself providing access to all its data. This field can only be accessed by the
     /// element's name prefixed with a `$`.
     public var projectedValue: ConfigurationElement {
-        get { self } // swiftlint:disable:this implicit_getter
+        get { self }
         _modify { yield &self }
     }
 


### PR DESCRIPTION
The `implicit_getter` rule wasn't aware of the `init` accessor ([SE-0400](https://github.com/apple/swift-evolution/blob/main/proposals/0400-init-accessors.md)), causing it to incorrectly trigger on the following example

```swift
var foo: String {
  init { ... }
  get { ... } // implicit_getter violation
}
```

Rather than adding a check for `initAccessor` I updated the check to bail early unless `accessorsList` has a single element, that being `get`. This allows for forwards-compatibility if another accessor variant were to be introduced in the future. Semantically, IIUC this rule should only trigger in the aforementioned case that there's one accessor and that accessor is `get` — otherwise it isn't possible to elide the keyword.