### PR TITLE
Conform InvalidSwiftLintCommandRule to SourceKitFreeRule

### DIFF
--- a/Source/SwiftLintBuiltInRules/Rules/Lint/InvalidSwiftLintCommandRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/InvalidSwiftLintCommandRule.swift
@@ -1,4 +1,4 @@
-struct InvalidSwiftLintCommandRule: Rule {
+struct InvalidSwiftLintCommandRule: Rule, SourceKitFreeRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(


### PR DESCRIPTION
This rule doesn't use SourceKit under the hood, so it should conform to `SourceKitFreeRule`, making it easier to figure out which rules still depend on SourceKit.

(For context, in our codebase we're trying to only use rules without SourceKit to avoid paying its fixed cost) 