### PR TITLE
Rename SwiftLintFile+Cache properties that use SourceKit

### DIFF
--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DuplicateImportsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DuplicateImportsRule.swift
@@ -24,7 +24,7 @@ struct DuplicateImportsRule: CorrectableRule {
     private func rangesInConditionalCompilation(file: SwiftLintFile) -> [ByteRange] {
         let contents = file.stringView
 
-        let ranges = file.syntaxMap.tokens
+        let ranges = file.sourceKitSyntaxMap.tokens
             .filter { $0.kind == .buildconfigKeyword }
             .map { $0.range }
             .filter { range in

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitACLRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitACLRule.swift
@@ -114,14 +114,14 @@ struct ExplicitACLRule: OptInRule {
             // attributeBuiltin (`final` for example) tokens between them
             let length = typeOffset - previousInternalByteRange.location
             let range = ByteRange(location: previousInternalByteRange.location, length: length)
-            let internalDoesntBelongToType = Set(file.syntaxMap.kinds(inByteRange: range)) != [.attributeBuiltin]
+            let internalDoesntBelongToType = Set(file.sourceKitSyntaxMap.kinds(inByteRange: range)) != [.attributeBuiltin]
 
             return internalDoesntBelongToType ? typeOffset : nil
         }
     }
 
     func validate(file: SwiftLintFile) -> [StyleViolation] {
-        let implicitAndExplicitInternalElements = internalTypeElements(in: file.structureDictionary)
+        let implicitAndExplicitInternalElements = internalTypeElements(in: file.sourceKitStructureDictionary)
 
         guard implicitAndExplicitInternalElements.isNotEmpty else {
             return []

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExtensionAccessModifierRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExtensionAccessModifierRule.swift
@@ -115,7 +115,7 @@ struct ExtensionAccessModifierRule: ASTRule, OptInRule {
             return []
         }
 
-        let syntaxTokens = file.syntaxMap.tokens
+        let syntaxTokens = file.sourceKitSyntaxMap.tokens
         let parts = syntaxTokens.partitioned { offset <= $0.offset }
         if let aclToken = parts.first.last, file.isACL(token: aclToken) {
             return declarationsViolations(file: file, acl: declarationsACLs[0],
@@ -155,7 +155,7 @@ struct ExtensionAccessModifierRule: ASTRule, OptInRule {
             // attributeBuiltin (`final` for example) tokens between them
             let length = typeOffset - previousInternalByteRange.location
             let range = ByteRange(location: previousInternalByteRange.location, length: length)
-            return Set(file.syntaxMap.kinds(inByteRange: range)) == [.attributeBuiltin]
+            return Set(file.sourceKitSyntaxMap.kinds(inByteRange: range)) == [.attributeBuiltin]
         }
 
         return violationOffsets.map {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NimbleOperatorRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NimbleOperatorRule.swift
@@ -112,7 +112,7 @@ struct NimbleOperatorRule: OptInRule, CorrectableRule {
                 return false
             }
 
-            return file.structureDictionary.structures(forByteOffset: byteRange.upperBound - 1)
+            return file.sourceKitStructureDictionary.structures(forByteOffset: byteRange.upperBound - 1)
                 .contains(where: { dict -> Bool in
                     return dict.expressionKind == .call && (dict.name ?? "").starts(with: "expect")
                 })

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoGroupingExtensionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoGroupingExtensionRule.swift
@@ -22,7 +22,7 @@ struct NoGroupingExtensionRule: OptInRule {
     )
 
     func validate(file: SwiftLintFile) -> [StyleViolation] {
-        let collector = NamespaceCollector(dictionary: file.structureDictionary)
+        let collector = NamespaceCollector(dictionary: file.sourceKitStructureDictionary)
         let elements = collector.findAllElements(of: [.class, .enum, .struct, .extension])
 
         let susceptibleNames = Set(elements.compactMap { $0.kind != .extension ? $0.name : nil })

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -159,7 +159,7 @@ struct RedundantTypeAnnotationRule: OptInRule, SubstitutionCorrectableRule {
     private func isIBInspectable(file: SwiftLintFile, range: NSRange) -> Bool {
         guard
             let byteRange = file.stringView.NSRangeToByteRange(start: range.location, length: range.length),
-            let dict = file.structureDictionary.structures(forByteOffset: byteRange.location).last,
+            let dict = file.sourceKitStructureDictionary.structures(forByteOffset: byteRange.location).last,
             let kind = dict.declarationKind,
             SwiftDeclarationKind.variableKinds.contains(kind)
         else { return false }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/CaptureVariableRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/CaptureVariableRule.swift
@@ -176,7 +176,7 @@ private extension SwiftLintFile {
     }
 
     func captureListVariableOffsets() -> Set<ByteCount> {
-        Self.captureListVariableOffsets(parentEntity: structureDictionary)
+        Self.captureListVariableOffsets(parentEntity: sourceKitStructureDictionary)
     }
 
     static func captureListVariableOffsets(parentEntity: SourceKittenDictionary) -> Set<ByteCount> {
@@ -220,7 +220,7 @@ private extension SwiftLintFile {
     }
 
     func declaredVariableOffsets() -> Set<ByteCount> {
-        Self.declaredVariableOffsets(parentStructure: structureDictionary)
+        Self.declaredVariableOffsets(parentStructure: sourceKitStructureDictionary)
     }
 
     static func declaredVariableOffsets(parentStructure: SourceKittenDictionary) -> Set<ByteCount> {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/MissingDocsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/MissingDocsRule.swift
@@ -122,7 +122,7 @@ struct MissingDocsRule: OptInRule {
 
     func validate(file: SwiftLintFile) -> [StyleViolation] {
         let acls = configuration.parameters.map { $0.value }
-        let dict = file.structureDictionary
+        let dict = file.sourceKitStructureDictionary
         return file.missingDocOffsets(
             in: dict,
             acls: acls,

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/QuickDiscouragedCallRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/QuickDiscouragedCallRule.swift
@@ -13,7 +13,7 @@ struct QuickDiscouragedCallRule: OptInRule {
     )
 
     func validate(file: SwiftLintFile) -> [StyleViolation] {
-        let dict = file.structureDictionary
+        let dict = file.sourceKitStructureDictionary
         let testClasses = dict.substructure.filter {
             return $0.inheritedTypes.isNotEmpty &&
                 $0.declarationKind == .class

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedImportRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedImportRule.swift
@@ -113,7 +113,7 @@ private extension SwiftLintFile {
             unusedImports.subtract(
                 operatorImports(
                     arguments: compilerArguments,
-                    processedTokenOffsets: Set(syntaxMap.tokens.map { $0.offset })
+                    processedTokenOffsets: Set(sourceKitSyntaxMap.tokens.map { $0.offset })
                 )
             )
         }
@@ -147,7 +147,7 @@ private extension SwiftLintFile {
         var imports = Set<String>()
         var usrFragments = Set<String>()
         var nextIsModuleImport = false
-        for token in syntaxMap.tokens {
+        for token in sourceKitSyntaxMap.tokens {
             guard let tokenKind = token.kind else {
                 continue
             }
@@ -292,6 +292,6 @@ private extension SwiftLintFile {
             }
         }
 
-        return containsAttributesRequiringFoundation(dict: structureDictionary)
+        return containsAttributesRequiringFoundation(dict: sourceKitStructureDictionary)
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/FileLengthRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/FileLengthRule.swift
@@ -21,7 +21,7 @@ struct FileLengthRule: Rule {
     func validate(file: SwiftLintFile) -> [StyleViolation] {
         func lineCountWithoutComments() -> Int {
             let commentKinds = SyntaxKind.commentKinds
-            return file.syntaxKindsByLines.filter { kinds in
+            return file.sourceKitSyntaxKindsByLines.filter { kinds in
                 return !Set(kinds).isSubset(of: commentKinds)
             }.count
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/NestingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/NestingRule.swift
@@ -31,7 +31,7 @@ struct NestingRule: Rule {
     }
 
     func validate(file: SwiftLintFile) -> [StyleViolation] {
-        return validate(file: file, substructure: file.structureDictionary.substructure, args: ValidationArgs())
+        return validate(file: file, substructure: file.sourceKitStructureDictionary.substructure, args: ValidationArgs())
     }
 
     private func validate(file: SwiftLintFile, substructure: [SourceKittenDictionary],

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ClosureEndIndentationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ClosureEndIndentationRule.swift
@@ -114,7 +114,7 @@ extension ClosureEndIndentationRule {
     }
 
     fileprivate func violations(in file: SwiftLintFile) -> [Violation] {
-        return file.structureDictionary.traverseDepthFirst { subDict in
+        return file.sourceKitStructureDictionary.traverseDepthFirst { subDict in
             guard let kind = subDict.expressionKind else { return nil }
             return violations(in: file, of: kind, dictionary: subDict)
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/FileHeaderRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/FileHeaderRule.swift
@@ -36,7 +36,7 @@ struct FileHeaderRule: OptInRule {
         var lastToken: SwiftLintSyntaxToken?
         var firstNonCommentToken: SwiftLintSyntaxToken?
 
-        for token in file.syntaxTokensByLines.lazy.joined() {
+        for token in file.sourceKitSyntaxTokensByLines.lazy.joined() {
             guard let kind = token.kind, kind.isFileHeaderKind else {
                 // found a token that is not a comment, which means it's not the top of the file
                 // so we can just skip the remaining tokens

--- a/Source/SwiftLintBuiltInRules/Rules/Style/FileTypesOrderRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/FileTypesOrderRule.swift
@@ -94,7 +94,7 @@ struct FileTypesOrderRule: OptInRule {
         in file: SwiftLintFile,
         mainTypeSubstructure: SourceKittenDictionary
     ) -> [SourceKittenDictionary] {
-        let dict = file.structureDictionary
+        let dict = file.sourceKitStructureDictionary
         return dict.substructure.filter { substructure in
             guard let kind = substructure.kind else { return false }
             return substructure.offset != mainTypeSubstructure.offset
@@ -109,7 +109,7 @@ struct FileTypesOrderRule: OptInRule {
         var supportingTypeKinds = SwiftDeclarationKind.typeKinds
         supportingTypeKinds.insert(SwiftDeclarationKind.protocol)
 
-        let dict = file.structureDictionary
+        let dict = file.sourceKitStructureDictionary
         return dict.substructure.filter { substructure in
             guard let declarationKind = substructure.declarationKind else { return false }
             guard !substructure.hasExcludedInheritedType else { return false }
@@ -123,13 +123,13 @@ struct FileTypesOrderRule: OptInRule {
         in file: SwiftLintFile,
         withInheritedType inheritedType: String
     ) -> [SourceKittenDictionary] {
-        file.structureDictionary.substructure.filter { substructure in
+        file.sourceKitStructureDictionary.substructure.filter { substructure in
             substructure.inheritedTypes.contains(inheritedType)
         }
     }
 
     private func mainTypeSubstructure(in file: SwiftLintFile) -> SourceKittenDictionary? {
-        let dict = file.structureDictionary
+        let dict = file.sourceKitStructureDictionary
 
         guard let filePath = file.path else {
             return self.mainTypeSubstructure(in: dict)
@@ -138,7 +138,7 @@ struct FileTypesOrderRule: OptInRule {
         let fileName = URL(fileURLWithPath: filePath, isDirectory: false)
             .lastPathComponent.replacingOccurrences(of: ".swift", with: "")
         guard let mainTypeSubstructure = dict.substructure.first(where: { $0.name == fileName }) else {
-            return self.mainTypeSubstructure(in: file.structureDictionary)
+            return self.mainTypeSubstructure(in: file.sourceKitStructureDictionary)
         }
 
         // specify type with name matching the files name as main type

--- a/Source/SwiftLintBuiltInRules/Rules/Style/IndentationWidthRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/IndentationWidthRule.swift
@@ -144,7 +144,7 @@ struct IndentationWidthRule: OptInRule {
         if configuration.includeCompilerDirectives {
             return false
         }
-        if file.syntaxMap.tokens(inByteRange: line.byteRange).kinds.first == .buildconfigKeyword {
+        if file.sourceKitSyntaxMap.tokens(inByteRange: line.byteRange).kinds.first == .buildconfigKeyword {
             return true
         }
         return false
@@ -154,7 +154,7 @@ struct IndentationWidthRule: OptInRule {
         if configuration.includeComments {
             return false
         }
-        let syntaxKindsInLine = Set(file.syntaxMap.tokens(inByteRange: line.byteRange).kinds)
+        let syntaxKindsInLine = Set(file.sourceKitSyntaxMap.tokens(inByteRange: line.byteRange).kinds)
         if syntaxKindsInLine.isNotEmpty, SyntaxKind.commentKinds.isSuperset(of: syntaxKindsInLine) {
             return true
         }
@@ -168,7 +168,7 @@ struct IndentationWidthRule: OptInRule {
 
         // A multiline string content line is characterized by beginning with a token of kind string whose range's lower
         // bound is smaller than that of the line itself.
-        let tokensInLine = file.syntaxMap.tokens(inByteRange: line.byteRange)
+        let tokensInLine = file.sourceKitSyntaxMap.tokens(inByteRange: line.byteRange)
         guard
             let firstToken = tokensInLine.first,
             firstToken.kind == .string,

--- a/Source/SwiftLintBuiltInRules/Rules/Style/LetVarWhitespaceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/LetVarWhitespaceRule.swift
@@ -71,7 +71,7 @@ struct LetVarWhitespaceRule: OptInRule {
     )
 
     func validate(file: SwiftLintFile) -> [StyleViolation] {
-        let dict = file.structureDictionary
+        let dict = file.sourceKitStructureDictionary
 
         var attributeLines = attributeLineNumbers(file: file)
         var varLines = Set<Int>()
@@ -216,7 +216,7 @@ struct LetVarWhitespaceRule: OptInRule {
     // Collects all the line numbers containing comments or #if/#endif
     private func skippedLineNumbers(file: SwiftLintFile) -> Set<Int> {
         var result = Set<Int>()
-        let syntaxMap = file.syntaxMap
+        let syntaxMap = file.sourceKitSyntaxMap
 
         for token in syntaxMap.tokens where token.kind == .comment ||
                                             token.kind == .docComment {
@@ -244,7 +244,7 @@ struct LetVarWhitespaceRule: OptInRule {
     // Collects all the line numbers containing attributes but not declarations
     // other than let/var
     private func attributeLineNumbers(file: SwiftLintFile) -> Set<Int> {
-        let lineNumbers = file.syntaxMap.tokens
+        let lineNumbers = file.sourceKitSyntaxMap.tokens
             .filter { isAttribute(token: $0, in: file) }
             .map(\.offset)
             .compactMap(file.line)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/LiteralExpressionEndIndentationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/LiteralExpressionEndIndentationRule.swift
@@ -214,7 +214,7 @@ extension LiteralExpressionEndIndentationRule {
     }
 
     fileprivate func violations(in file: SwiftLintFile) -> [Violation] {
-        return file.structureDictionary.traverseDepthFirst { subDict in
+        return file.sourceKitStructureDictionary.traverseDepthFirst { subDict in
             guard let kind = subDict.expressionKind else { return nil }
             guard let violation = violation(in: file, of: kind, dictionary: subDict) else { return nil }
             return [violation]

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ModifierOrderRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ModifierOrderRule.swift
@@ -40,7 +40,7 @@ struct ModifierOrderRule: ASTRule, OptInRule, CorrectableRule {
     }
 
     func correct(file: SwiftLintFile) -> [Correction] {
-        return file.structureDictionary.traverseDepthFirst { subDict in
+        return file.sourceKitStructureDictionary.traverseDepthFirst { subDict in
             guard subDict.declarationKind != nil else { return nil }
             return correct(file: file, dictionary: subDict)
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/MultilineParametersBracketsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/MultilineParametersBracketsRule.swift
@@ -91,7 +91,7 @@ struct MultilineParametersBracketsRule: OptInRule {
     )
 
     func validate(file: SwiftLintFile) -> [StyleViolation] {
-        return violations(in: file.structureDictionary, file: file)
+        return violations(in: file.sourceKitStructureDictionary, file: file)
     }
 
     private func violations(in substructure: SourceKittenDictionary, file: SwiftLintFile) -> [StyleViolation] {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/StatementPositionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/StatementPositionRule.swift
@@ -171,7 +171,7 @@ private extension StatementPositionRule {
 
     func uncuddledViolationRanges(in file: SwiftLintFile) -> [NSRange] {
         let contents = file.stringView
-        let syntaxMap = file.syntaxMap
+        let syntaxMap = file.sourceKitSyntaxMap
         let matches = Self.uncuddledRegex.matches(in: file)
         let validator = Self.uncuddledMatchValidator(contents: contents)
         let filterMatches = Self.uncuddledMatchFilter(contents: contents, syntaxMap: syntaxMap)
@@ -181,7 +181,7 @@ private extension StatementPositionRule {
 
     func uncuddledCorrect(file: SwiftLintFile) -> [Correction] {
         var contents = file.contents
-        let syntaxMap = file.syntaxMap
+        let syntaxMap = file.sourceKitSyntaxMap
         let matches = Self.uncuddledRegex.matches(in: file)
         let validator = Self.uncuddledMatchValidator(contents: file.stringView)
         let filterRanges = Self.uncuddledMatchFilter(contents: file.stringView, syntaxMap: syntaxMap)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/TrailingClosureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/TrailingClosureRule.swift
@@ -29,7 +29,7 @@ struct TrailingClosureRule: OptInRule {
     )
 
     func validate(file: SwiftLintFile) -> [StyleViolation] {
-        let dict = file.structureDictionary
+        let dict = file.sourceKitStructureDictionary
         return violationOffsets(for: dict, file: file).map {
             StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severityConfiguration.severity,

--- a/Source/SwiftLintBuiltInRules/Rules/Style/TrailingWhitespaceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/TrailingWhitespaceRule.swift
@@ -28,7 +28,7 @@ struct TrailingWhitespaceRule: CorrectableRule {
 
             let commentKinds = SyntaxKind.commentKinds
             if configuration.ignoresComments,
-                let lastSyntaxKind = file.syntaxKindsByLines[$0.index].last,
+                let lastSyntaxKind = file.sourceKitSyntaxKindsByLines[$0.index].last,
                 commentKinds.contains(lastSyntaxKind) {
                 return false
             }
@@ -57,7 +57,7 @@ struct TrailingWhitespaceRule: CorrectableRule {
 
             let commentKinds = SyntaxKind.commentKinds
             if configuration.ignoresComments,
-                let lastSyntaxKind = file.syntaxKindsByLines[line.index].last,
+                let lastSyntaxKind = file.sourceKitSyntaxKindsByLines[line.index].last,
                 commentKinds.contains(lastSyntaxKind) {
                 correctedLines.append(line.content)
                 continue

--- a/Source/SwiftLintBuiltInRules/Rules/Style/TypeContentsOrderRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/TypeContentsOrderRule.swift
@@ -15,7 +15,7 @@ struct TypeContentsOrderRule: OptInRule {
     )
 
     func validate(file: SwiftLintFile) -> [StyleViolation] {
-        let dict = file.structureDictionary
+        let dict = file.sourceKitStructureDictionary
         let substructures = dict.substructure
         return substructures.reduce(into: [StyleViolation]()) { violations, substructure in
             violations.append(contentsOf: validateTypeSubstructure(substructure, in: file))

--- a/Source/SwiftLintBuiltInRules/Rules/Style/VerticalWhitespaceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/VerticalWhitespaceRule.swift
@@ -68,7 +68,7 @@ struct VerticalWhitespaceRule: CorrectableRule {
 
         // filtering out violations in comments and strings
         let stringAndComments = SyntaxKind.commentAndStringKinds
-        let syntaxMap = file.syntaxMap
+        let syntaxMap = file.sourceKitSyntaxMap
         let result = blankLinesSections.compactMap { eachSection -> (lastLine: Line, linesToRemove: Int)? in
             guard let lastLine = eachSection.last else {
                 return nil

--- a/Source/SwiftLintCore/Extensions/SwiftLintFile+Regex.swift
+++ b/Source/SwiftLintCore/Extensions/SwiftLintFile+Regex.swift
@@ -103,7 +103,7 @@ extension SwiftLintFile {
                                  range: NSRange? = nil) -> [(NSTextCheckingResult, [SwiftLintSyntaxToken])] {
         let contents = stringView
         let range = range ?? contents.range
-        let syntax = syntaxMap
+        let syntax = sourceKitSyntaxMap
         return regex(pattern).matches(in: contents, options: [], range: range).compactMap { match in
             let matchByteRange = contents.NSRangeToByteRange(start: match.range.location, length: match.range.length)
             return matchByteRange.map { (match, syntax.tokens(inByteRange: $0)) }
@@ -134,7 +134,7 @@ extension SwiftLintFile {
         }
         var results = [[SwiftDeclarationKind]](repeating: [], count: lines.count + 1)
         var lineIterator = lines.makeIterator()
-        var structureIterator = structureDictionary.kinds().makeIterator()
+        var structureIterator = sourceKitStructureDictionary.kinds().makeIterator()
         var maybeLine = lineIterator.next()
         var maybeStructure = structureIterator.next()
         while let line = maybeLine, let structure = maybeStructure {
@@ -156,7 +156,7 @@ extension SwiftLintFile {
             return nil
         }
         var results = [[SwiftLintSyntaxToken]](repeating: [], count: lines.count + 1)
-        var tokenGenerator = syntaxMap.tokens.makeIterator()
+        var tokenGenerator = sourceKitSyntaxMap.tokens.makeIterator()
         var lineGenerator = lines.makeIterator()
         var maybeLine = lineGenerator.next()
         var maybeToken = tokenGenerator.next()

--- a/Source/SwiftLintCore/Protocols/ASTRule.swift
+++ b/Source/SwiftLintCore/Protocols/ASTRule.swift
@@ -27,7 +27,7 @@ public protocol ASTRule: Rule {
 
 public extension ASTRule {
     func validate(file: SwiftLintFile) -> [StyleViolation] {
-        return validate(file: file, dictionary: file.structureDictionary)
+        return validate(file: file, dictionary: file.sourceKitStructureDictionary)
     }
 
     /// Executes the rule on a file and a subset of its AST structure, returning any violations to the rule's

--- a/Source/SwiftLintCore/Protocols/Rule.swift
+++ b/Source/SwiftLintCore/Protocols/Rule.swift
@@ -213,7 +213,7 @@ public protocol SubstitutionCorrectableASTRule: SubstitutionCorrectableRule, AST
 
 public extension SubstitutionCorrectableASTRule {
     func violationRanges(in file: SwiftLintFile) -> [NSRange] {
-        return file.structureDictionary.traverseDepthFirst { subDict in
+        return file.sourceKitStructureDictionary.traverseDepthFirst { subDict in
             guard let kind = self.kind(from: subDict) else { return nil }
             return violationRanges(in: file, kind: kind, dictionary: subDict)
         }

--- a/Tests/SwiftLintFrameworkTests/SourceKitCrashTests.swift
+++ b/Tests/SwiftLintFrameworkTests/SourceKitCrashTests.swift
@@ -10,17 +10,17 @@ class SourceKitCrashTests: SwiftLintTestCase {
         var assertHandlerCalled = false
         file.assertHandler = { assertHandlerCalled = true }
 
-        _ = file.syntaxMap
+        _ = file.sourceKitSyntaxMap
         XCTAssertFalse(assertHandlerCalled,
                        "Expects assert handler was not called on accessing SwiftLintFile.syntaxMap")
 
         assertHandlerCalled = false
-        _ = file.syntaxKindsByLines
+        _ = file.sourceKitSyntaxKindsByLines
         XCTAssertFalse(assertHandlerCalled,
                        "Expects assert handler was not called on accessing SwiftLintFile.syntaxKindsByLines")
 
         assertHandlerCalled = false
-        _ = file.syntaxTokensByLines
+        _ = file.sourceKitSyntaxTokensByLines
         XCTAssertFalse(assertHandlerCalled,
                        "Expects assert handler was not called on accessing SwiftLintFile.syntaxTokensByLines")
     }
@@ -32,17 +32,17 @@ class SourceKitCrashTests: SwiftLintTestCase {
         var assertHandlerCalled = false
         file.assertHandler = { assertHandlerCalled = true }
 
-        _ = file.syntaxMap
+        _ = file.sourceKitSyntaxMap
         XCTAssertTrue(assertHandlerCalled,
                       "Expects assert handler was called on accessing SwiftLintFile.syntaxMap")
 
         assertHandlerCalled = false
-        _ = file.syntaxKindsByLines
+        _ = file.sourceKitSyntaxKindsByLines
         XCTAssertTrue(assertHandlerCalled,
                       "Expects assert handler was called on accessing SwiftLintFile.syntaxKindsByLines")
 
         assertHandlerCalled = false
-        _ = file.syntaxTokensByLines
+        _ = file.sourceKitSyntaxTokensByLines
         XCTAssertTrue(assertHandlerCalled,
                       "Expects assert handler was not called on accessing SwiftLintFile.syntaxTokensByLines")
     }


### PR DESCRIPTION
This makes it easier to identify what's coming from SourceKit or not, as we work towards completely removing all of its usage