### PR TITLE
Skip checking tuples for magic numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,20 +50,25 @@
   [BB9z](https://github.com/BB9z)
   [#5289](https://github.com/realm/SwiftLint/issues/5289)
 
-* Fix invalid corrections for opaque and existential optionals in 
+* Fix invalid corrections for opaque and existential optionals in
   `syntactic_sugar` rule.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#5277](https://github.com/realm/SwiftLint/issues/5277)
 
-* Fix false positive in `unused_import` rule that triggered on 
+* Fix false positive in `unused_import` rule that triggered on
   `@_exported` imports which could break downstream modules if removed.  
   [jszumski](https://github.com/jszumski)
   [#5242](https://github.com/realm/SwiftLint/pull/5242)
 
-* Fix false positive in `unused_import` rule when using a constructor 
+* Fix false positive in `unused_import` rule when using a constructor
   defined in a transitive module.  
   [jszumski](https://github.com/jszumski)
   [#5246](https://github.com/realm/SwiftLint/pull/5246)
+
+* Fixed false positives for the `no_magic_numbers` rule, when they
+  are defined in a tuple like `let (a, b) = (5, 10)`.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#5305](https://github.com/realm/SwiftLint/pull/5305)
 
 ## 0.53.0: Laundry List
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -76,6 +76,7 @@ struct NoMagicNumbersRule: OptInRule {
             Example("let foo = 2 << 2"),
             Example("let a = b / 100.0"),
             Example("let (httpStatusCodeErrorLowerBound, httpStatusCodeErrorUpperBound) = (400, 599)")
+//            Example("let b = UnsafeMutableRawPointer.allocate(byteCount: 4, alignment: 4)").focused()
         ],
         triggeringExamples: [
             Example("foo(↓321)"),
@@ -124,9 +125,9 @@ private extension NoMagicNumbersRule {
             collectViolation(forNode: node)
         }
 
-        override func visit(_ node: TupleExprSyntax) -> SyntaxVisitorContinueKind {
-            .skipChildren
-        }
+//        override func visit(_ node: TupleExprSyntax) -> SyntaxVisitorContinueKind {
+//            .skipChildren
+//        }
 
         private func collectViolation(forNode node: some ExprSyntaxProtocol) {
             if node.isMemberOfATestClass(configuration.testParentClasses) {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -75,7 +75,7 @@ struct NoMagicNumbersRule: OptInRule {
             Example("let foo = 2 >> 2"),
             Example("let foo = 2 << 2"),
             Example("let a = b / 100.0")
-//            Example("let (httpStatusCodeErrorLowerBound, httpStatusCodeErrorUpperBound) = (400, 599)")
+            Example("let (httpStatusCodeErrorLowerBound, httpStatusCodeErrorUpperBound) = (400, 599)")
 //            Example("let b = UnsafeMutableRawPointer.allocate(byteCount: 4, alignment: 4)").focused()
         ],
         triggeringExamples: [
@@ -125,9 +125,9 @@ private extension NoMagicNumbersRule {
             collectViolation(forNode: node)
         }
 
-//        override func visit(_ node: TupleExprSyntax) -> SyntaxVisitorContinueKind {
-//            .skipChildren
-//        }
+        override func visit(_ node: TupleExprSyntax) -> SyntaxVisitorContinueKind {
+            .skipChildren
+        }
 
         private func collectViolation(forNode node: some ExprSyntaxProtocol) {
             if node.isMemberOfATestClass(configuration.testParentClasses) {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -76,7 +76,6 @@ struct NoMagicNumbersRule: OptInRule {
             Example("let foo = 2 << 2"),
             Example("let a = b / 100.0"),
             Example("let (httpStatusCodeErrorLowerBound, httpStatusCodeErrorUpperBound) = (400, 599)")
-//            Example("let b = UnsafeMutableRawPointer.allocate(byteCount: 4, alignment: 4)").focused()
         ],
         triggeringExamples: [
             Example("foo(↓321)"),

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -74,8 +74,8 @@ struct NoMagicNumbersRule: OptInRule {
             Example("let foo = 1 >> 2"),
             Example("let foo = 2 >> 2"),
             Example("let foo = 2 << 2"),
-            Example("let a = b / 100.0"),
-            Example("let (httpStatusCodeErrorLowerBound, httpStatusCodeErrorUpperBound) = (400, 599)")
+            Example("let a = b / 100.0")
+//            Example("let (httpStatusCodeErrorLowerBound, httpStatusCodeErrorUpperBound) = (400, 599)")
 //            Example("let b = UnsafeMutableRawPointer.allocate(byteCount: 4, alignment: 4)").focused()
         ],
         triggeringExamples: [

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -74,7 +74,8 @@ struct NoMagicNumbersRule: OptInRule {
             Example("let foo = 1 >> 2"),
             Example("let foo = 2 >> 2"),
             Example("let foo = 2 << 2"),
-            Example("let a = b / 100.0")
+            Example("let a = b / 100.0"),
+            Example("let (httpStatusCodeErrorLowerBound, httpStatusCodeErrorUpperBound) = (400, 599)")
         ],
         triggeringExamples: [
             Example("foo(↓321)"),
@@ -121,6 +122,10 @@ private extension NoMagicNumbersRule {
                 return
             }
             collectViolation(forNode: node)
+        }
+
+        override func visit(_ node: TupleExprSyntax) -> SyntaxVisitorContinueKind {
+            .skipChildren
         }
 
         private func collectViolation(forNode node: some ExprSyntaxProtocol) {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -74,7 +74,7 @@ struct NoMagicNumbersRule: OptInRule {
             Example("let foo = 1 >> 2"),
             Example("let foo = 2 >> 2"),
             Example("let foo = 2 << 2"),
-            Example("let a = b / 100.0")
+            Example("let a = b / 100.0"),
             Example("let (httpStatusCodeErrorLowerBound, httpStatusCodeErrorUpperBound) = (400, 599)")
 //            Example("let b = UnsafeMutableRawPointer.allocate(byteCount: 4, alignment: 4)").focused()
         ],

--- a/tools/oss-check
+++ b/tools/oss-check
@@ -260,8 +260,7 @@ def set_globals
   @effective_main_commitish = `git merge-base origin/main #{@options[:branch]}`.chomp
   @changed_swift_files = `git diff --diff-filter=AMRCU #{@effective_main_commitish} --name-only | grep "\.swift$" || true`.split("\n")
   @changed_rule_files = @changed_swift_files.select do |file|
-    file.start_with? 'Source/SwiftLintFramework/Rules/'
-#    file.start_with? 'Source/SwiftLintBuiltInRules/Rules/'
+    file.start_with? 'Source/SwiftLintBuiltInRules/Rules/'
   end
   @rules_changed = @changed_rule_files.map do |path|
     if File.read(path) =~ /^\s+identifier: "(\w+)",$/

--- a/tools/oss-check
+++ b/tools/oss-check
@@ -260,7 +260,8 @@ def set_globals
   @effective_main_commitish = `git merge-base origin/main #{@options[:branch]}`.chomp
   @changed_swift_files = `git diff --diff-filter=AMRCU #{@effective_main_commitish} --name-only | grep "\.swift$" || true`.split("\n")
   @changed_rule_files = @changed_swift_files.select do |file|
-    file.start_with? 'Source/SwiftLintBuiltInRules/Rules/'
+    file.start_with? 'Source/SwiftLintFramework/Rules/'
+#    file.start_with? 'Source/SwiftLintBuiltInRules/Rules/'
   end
   @rules_changed = @changed_rule_files.map do |path|
     if File.read(path) =~ /^\s+identifier: "(\w+)",$/


### PR DESCRIPTION

Resolves #5305 by skipping magic numbers in tuple expressions altogether.

I'm not sure if there are some cases where we would still want to check.
