### PR TITLE
Fix more strict concurrency warnings

### DIFF
--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedImportRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedImportRuleExamples.swift
@@ -160,9 +160,9 @@ struct UnusedImportRuleExamples {
                 [
                     "module": "Foundation",
                     "allowed_transitive_imports": ["CoreFoundation"]
-                ] as [String: Any]
+                ] as [String: any Sendable]
             ]
-        ] as [String: Any], testMultiByteOffsets: false, testOnLinux: false):
+        ] as [String: any Sendable], testMultiByteOffsets: false, testOnLinux: false):
             Example("""
             import CoreFoundation
             typealias Foo = CFArray
@@ -188,9 +188,9 @@ struct UnusedImportRuleExamples {
                 [
                     "module": "Foundation",
                     "allowed_transitive_imports": ["CoreFoundation"]
-                ] as [String: Any]
+                ] as [String: any Sendable]
             ]
-        ] as [String: Any]):
+        ] as [String: any Sendable]):
             Example("""
             import Foundation
             typealias Foo = CFData

--- a/Source/SwiftLintCore/Extensions/Configuration+Cache.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Cache.swift
@@ -6,7 +6,7 @@ import Foundation
 extension Configuration {
     // MARK: Caching Configurations By Identifier (In-Memory)
     private static var cachedConfigurationsByIdentifier = [String: Configuration]()
-    private static var cachedConfigurationsByIdentifierLock = NSLock()
+    private static let cachedConfigurationsByIdentifierLock = NSLock()
 
     /// Since the cache is stored in a static var, this function is used to reset the cache during tests
     internal static func resetCache() {
@@ -39,7 +39,7 @@ extension Configuration {
 
     // MARK: Nested Config Is Self Cache
     private static var nestedConfigIsSelfByIdentifier = [String: Bool]()
-    private static var nestedConfigIsSelfByIdentifierLock = NSLock()
+    private static let nestedConfigIsSelfByIdentifierLock = NSLock()
 
     internal static func setIsNestedConfigurationSelf(forIdentifier identifier: String, value: Bool) {
         Self.nestedConfigIsSelfByIdentifierLock.lock()

--- a/Source/SwiftLintCore/Extensions/Configuration+IndentationStyle.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+IndentationStyle.swift
@@ -8,7 +8,7 @@ public extension Configuration {
 
         /// The default indentation style if none is explicitly provided.
         @_spi(TestHelper)
-        public static var `default` = spaces(count: 4)
+        public static let `default` = spaces(count: 4)
 
         /// Creates an indentation style based on an untyped configuration value.
         ///

--- a/Source/SwiftLintCore/Extensions/QueuedPrint.swift
+++ b/Source/SwiftLintCore/Extensions/QueuedPrint.swift
@@ -26,7 +26,7 @@ private func setupAtExitHandler() {
 
  - parameter object: Object to print.
  */
-public func queuedPrint<T>(_ object: T) {
+public func queuedPrint<T: Sendable>(_ object: T) {
     outputQueue.async {
         print(object)
     }

--- a/Source/SwiftLintCore/Models/Correction.swift
+++ b/Source/SwiftLintCore/Models/Correction.swift
@@ -1,5 +1,5 @@
 /// A value describing a SwiftLint violation that was corrected.
-public struct Correction: Equatable {
+public struct Correction: Equatable, Sendable {
     /// The description of the rule for which this correction was applied.
     public let ruleDescription: RuleDescription
     /// The location of the original violation that was corrected.

--- a/Source/SwiftLintCore/Models/Example.swift
+++ b/Source/SwiftLintCore/Models/Example.swift
@@ -1,6 +1,6 @@
 /// Captures code and context information for an example of a triggering or
 /// non-triggering style
-public struct Example {
+public struct Example: Sendable {
     /// The contents of the example
     public private(set) var code: String
     /// The untyped configuration to apply to the rule, if deviating from the default configuration.
@@ -13,7 +13,7 @@ public struct Example {
     /// ```
     ///
     /// Then the equivalent configuration value would be `["severity": "warning"]`.
-    public private(set) var configuration: Any?
+    public private(set) var configuration: [String: any Sendable]?
     /// Whether the example should be tested by prepending multibyte grapheme clusters
     ///
     /// - SeeAlso: addEmoji(_:)
@@ -63,7 +63,7 @@ public extension Example {
     ///                           Defaults to the file where this initializer is called.
     ///   - line:                 The line in the file where the example is located.
     ///                           Defaults to the line where this initializer is called.
-    init(_ code: String, configuration: Any? = nil, testMultiByteOffsets: Bool = true,
+    init(_ code: String, configuration: [String: any Sendable]? = nil, testMultiByteOffsets: Bool = true,
          testWrappingInComment: Bool = true, testWrappingInString: Bool = true, testDisableCommand: Bool = true,
          testOnLinux: Bool = true, file: StaticString = #file, line: UInt = #line,
          excludeFromDocumentation: Bool = false) {

--- a/Source/SwiftLintCore/Models/Location.swift
+++ b/Source/SwiftLintCore/Models/Location.swift
@@ -3,7 +3,7 @@ import SourceKittenFramework
 import SwiftSyntax
 
 /// The placement of a segment of Swift in a collection of source files.
-public struct Location: CustomStringConvertible, Comparable, Codable {
+public struct Location: CustomStringConvertible, Comparable, Codable, Sendable {
     /// The file path on disk for this location.
     public let file: String?
     /// The line offset in the file for this location. 1-indexed.

--- a/Source/SwiftLintCore/Models/RuleDescription.swift
+++ b/Source/SwiftLintCore/Models/RuleDescription.swift
@@ -1,5 +1,5 @@
 /// A detailed description for a SwiftLint rule. Used for both documentation and testing purposes.
-public struct RuleDescription: Equatable {
+public struct RuleDescription: Equatable, Sendable {
     /// The rule's unique identifier, to be used in configuration files and SwiftLint commands.
     /// Should be short and only comprised of lowercase latin alphabet letters and underscores formatted in snake case.
     public let identifier: String

--- a/Source/SwiftLintCore/Models/RuleKind.swift
+++ b/Source/SwiftLintCore/Models/RuleKind.swift
@@ -1,5 +1,5 @@
 /// All the possible rule kinds (categories).
-public enum RuleKind: String, Codable {
+public enum RuleKind: String, Codable, Sendable {
     /// Describes rules that validate Swift source conventions.
     case lint
     /// Describes rules that validate common practices in the Swift community.

--- a/Source/SwiftLintCore/Models/SwiftVersion.swift
+++ b/Source/SwiftLintCore/Models/SwiftVersion.swift
@@ -2,7 +2,7 @@ import Foundation
 import SourceKittenFramework
 
 /// A value describing the version of the Swift compiler.
-public struct SwiftVersion: RawRepresentable, Codable, Comparable {
+public struct SwiftVersion: RawRepresentable, Codable, Comparable, Sendable {
     public typealias RawValue = String
 
     public let rawValue: String

--- a/Source/SwiftLintCore/Reporters/SummaryReporter.swift
+++ b/Source/SwiftLintCore/Reporters/SummaryReporter.swift
@@ -114,7 +114,7 @@ private extension String {
 }
 
 private extension Int {
-    private static var numberFormatter: NumberFormatter = {
+    private static let numberFormatter: NumberFormatter = {
         let numberFormatter = NumberFormatter()
         numberFormatter.numberStyle = .decimal
         return numberFormatter

--- a/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceConfigurationTests.swift
@@ -13,7 +13,7 @@ class ExplicitTypeInterfaceConfigurationTests: SwiftLintTestCase {
         var config = ExplicitTypeInterfaceConfiguration()
         try config.apply(configuration: ["severity": "error",
                                          "excluded": ["local"],
-                                         "allow_redundancy": true] as [String: Any])
+                                         "allow_redundancy": true] as [String: any Sendable])
         XCTAssertEqual(config.severityConfiguration.severity, .error)
         XCTAssertEqual(config.allowedKinds, Set([.instance, .class, .static]))
         XCTAssertTrue(config.allowRedundancy)

--- a/Tests/SwiftLintFrameworkTests/IdentifierNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IdentifierNameRuleTests.swift
@@ -99,7 +99,7 @@ class IdentifierNameRuleTests: SwiftLintTestCase {
             ruleConfiguration: [
                 "validates_start_with_lowercase": true,
                 "allowed_symbols": ["M"]
-            ] as [String: Any]
+            ] as [String: any Sendable]
         )
     }
 

--- a/Tests/SwiftLintFrameworkTests/ImplicitReturnConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ImplicitReturnConfigurationTests.swift
@@ -29,7 +29,7 @@ class ImplicitReturnConfigurationTests: SwiftLintTestCase {
 
     func testImplicitReturnConfigurationThrowsOnUnrecognizedModifierGroup() {
         var configuration = ImplicitReturnConfiguration()
-        let config = ["included": ["foreach"]] as [String: Any]
+        let config = ["included": ["foreach"]] as [String: any Sendable]
 
         checkError(Issue.unknownConfiguration(ruleID: ImplicitReturnRule.description.identifier)) {
             try configuration.apply(configuration: config)

--- a/Tests/SwiftLintFrameworkTests/MissingDocsRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/MissingDocsRuleTests.swift
@@ -177,7 +177,7 @@ class MissingDocsRuleTests: SwiftLintTestCase {
                 "excludes_extensions": true,
                 "excludes_inherited_types": false,
                 "error": ["public"]
-            ] as [String: Any]
+            ] as [String: any Sendable]
         )
 
         XCTAssertTrue(configuration.excludesExtensions)

--- a/Tests/SwiftLintFrameworkTests/NameConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/NameConfigurationTests.swift
@@ -9,7 +9,7 @@ class NameConfigurationTests: SwiftLintTestCase {
                        "max_length": ["warning": 170, "error": 700],
                        "excluded": "id",
                        "allowed_symbols": ["$"],
-                       "validates_start_with_lowercase": "warning"] as [String: Any]
+                       "validates_start_with_lowercase": "warning"] as [String: any Sendable]
         var nameConfig = TesteeType(minLengthWarning: 0,
                                     minLengthError: 0,
                                     maxLengthWarning: 0,

--- a/Tests/SwiftLintFrameworkTests/RuleConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleConfigurationTests.swift
@@ -19,7 +19,7 @@ class RuleConfigurationTests: SwiftLintTestCase {
             ],
             "check_nesting_in_closures_and_statements": false,
             "always_allow_one_type_in_functions": true
-        ] as [String: Any]
+        ] as [String: any Sendable]
         var nestingConfig = defaultNestingConfiguration
         do {
             try nestingConfig.apply(configuration: config)
@@ -233,7 +233,7 @@ class RuleConfigurationTests: SwiftLintTestCase {
             "severity": "error",
             "excluded": "viewWillAppear(_:)",
             "included": ["*", "testMethod1()", "testMethod2(_:)"]
-        ] as [String: Any]
+        ] as [String: any Sendable]
         do {
             try configuration.apply(configuration: conf2)
             XCTAssertEqual(configuration.severityConfiguration.severity, .error)
@@ -250,7 +250,7 @@ class RuleConfigurationTests: SwiftLintTestCase {
             "severity": "warning",
             "excluded": "*",
             "included": ["testMethod1()", "testMethod2(_:)"]
-        ] as [String: Any]
+        ] as [String: any Sendable]
         do {
             try configuration.apply(configuration: conf3)
             XCTAssertEqual(configuration.severityConfiguration.severity, .warning)
@@ -302,7 +302,7 @@ class RuleConfigurationTests: SwiftLintTestCase {
 
     func testModifierOrderConfigurationThrowsOnUnrecognizedModifierGroup() {
         var configuration = ModifierOrderConfiguration()
-        let config = ["severity": "warning", "preferred_modifier_order": ["specialize"]]  as [String: Any]
+        let config = ["severity": "warning", "preferred_modifier_order": ["specialize"]]  as [String: any Sendable]
 
         checkError(Issue.unknownConfiguration(ruleID: ModifierOrderRule.description.identifier)) {
             try configuration.apply(configuration: config)
@@ -311,7 +311,7 @@ class RuleConfigurationTests: SwiftLintTestCase {
 
     func testModifierOrderConfigurationThrowsOnNonModifiableGroup() {
         var configuration = ModifierOrderConfiguration()
-        let config = ["severity": "warning", "preferred_modifier_order": ["atPrefixed"]]  as [String: Any]
+        let config = ["severity": "warning", "preferred_modifier_order": ["atPrefixed"]]  as [String: any Sendable]
         checkError(Issue.unknownConfiguration(ruleID: ModifierOrderRule.description.identifier)) {
             try configuration.apply(configuration: config)
         }

--- a/Tests/SwiftLintFrameworkTests/TrailingClosureConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TrailingClosureConfigurationTests.swift
@@ -11,7 +11,7 @@ class TrailingClosureConfigurationTests: SwiftLintTestCase {
     func testApplyingCustomConfiguration() throws {
         var config = TrailingClosureConfiguration()
         try config.apply(configuration: ["severity": "error",
-                                         "only_single_muted_parameter": true] as [String: Any])
+                                         "only_single_muted_parameter": true] as [String: any Sendable])
         XCTAssertEqual(config.severityConfiguration.severity, .error)
         XCTAssertTrue(config.onlySingleMutedParameter)
     }

--- a/Tests/SwiftLintFrameworkTests/UnusedDeclarationConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/UnusedDeclarationConfigurationTests.swift
@@ -8,7 +8,7 @@ class UnusedDeclarationConfigurationTests: XCTestCase {
             "severity": "warning",
             "include_public_and_open": true,
             "related_usrs_to_skip": ["a", "b"]
-        ] as [String: Any]
+        ] as [String: any Sendable]
 
         try testee.apply(configuration: config)
 

--- a/Tests/SwiftLintTestHelpers/TestHelpers.swift
+++ b/Tests/SwiftLintTestHelpers/TestHelpers.swift
@@ -55,7 +55,7 @@ public extension Configuration {
         guard let exampleConfiguration = example.configuration,
            case let .only(onlyRules) = self.rulesMode,
            let firstRule = (onlyRules.first { $0 != "superfluous_disable_command" }),
-           case let configDict = ["only_rules": onlyRules, firstRule: exampleConfiguration],
+           case let configDict: [_: any Sendable] = ["only_rules": onlyRules, firstRule: exampleConfiguration],
            let typedConfiguration = try? Configuration(dict: configDict) else { return self }
         return merged(withChild: typedConfiguration, rootDirectory: rootDirectory)
     }
@@ -297,7 +297,7 @@ private func testCorrection(_ correction: (Example, Example),
     if let correctionConfiguration = correction.0.configuration,
         case let .only(onlyRules) = configuration.rulesMode,
         let ruleToConfigure = (onlyRules.first { $0 != SuperfluousDisableCommandRule.description.identifier }),
-        case let configDict = ["only_rules": onlyRules, ruleToConfigure: correctionConfiguration],
+        case let configDict: [_: any Sendable] = ["only_rules": onlyRules, ruleToConfigure: correctionConfiguration],
         let typedConfiguration = try? Configuration(dict: configDict) {
         config = configuration.merged(withChild: typedConfiguration, rootDirectory: configuration.rootDirectory)
     }


### PR DESCRIPTION
These aren't enough to enable `-strict-concurrency=complete` for more modules, but they address some warnings with that flag on and reduces the scope of what remains to be migrated.