### PR TITLE
skip tuples for `no_magic_numbers` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Trigger `nsobject_prefer_isequal` and `redundant_self_in_closure` even in case
   the surrounding declaration is nested in an extension.  
   [SimplyDanny](https://github.com/SimplyDanny)
+
 * Fixed false positives for the `no_magic_numbers` rule, when they
   are defined in a tuple like `let (a, b) = (5, 10)` or `let a = (2, 3)`.  
   [Martin Redington](https://github.com/mildm8nnered)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@
 * `superfluous_disable_command` violations are now triggered for
   custom rules.  
   [Marcelo Fabri](https://github.com/marcelofabri)
+  [Martin Redington](https://github.com/mildm8nnered)
   [#4754](https://github.com/realm/SwiftLint/issues/4754)
 
 * Fixed false positives for the `no_magic_numbers` rule, when they

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,20 +82,30 @@
   [BB9z](https://github.com/BB9z)
   [#5289](https://github.com/realm/SwiftLint/issues/5289)
 
-* Fix invalid corrections for opaque and existential optionals in 
+* Fix invalid corrections for opaque and existential optionals in
   `syntactic_sugar` rule.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#5277](https://github.com/realm/SwiftLint/issues/5277)
 
-* Fix false positive in `unused_import` rule that triggered on 
+* Fix false positive in `unused_import` rule that triggered on
   `@_exported` imports which could break downstream modules if removed.  
   [jszumski](https://github.com/jszumski)
   [#5242](https://github.com/realm/SwiftLint/pull/5242)
 
-* Fix false positive in `unused_import` rule when using a constructor 
+* Fix false positive in `unused_import` rule when using a constructor
   defined in a transitive module.  
   [jszumski](https://github.com/jszumski)
   [#5246](https://github.com/realm/SwiftLint/pull/5246)
+
+* `superfluous_disable_command` violations are now triggered for
+  custom rules.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4754](https://github.com/realm/SwiftLint/issues/4754)
+* Fixed false positives for the `no_magic_numbers` rule, when they
+  are defined in a tuple like `let (a, b) = (5, 10)`.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#5305](https://github.com/realm/SwiftLint/pull/5305)
 
 ## 0.53.0: Laundry List
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
 * Trigger `nsobject_prefer_isequal` and `redundant_self_in_closure` even in case
   the surrounding declaration is nested in an extension.  
   [SimplyDanny](https://github.com/SimplyDanny)
+* Fixed false positives for the `no_magic_numbers` rule, when they
+  are defined in a tuple like `let (a, b) = (5, 10)` or `let a = (2, 3)`.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#5305](https://github.com/realm/SwiftLint/pull/5305)
 
 ## 0.54.0: Macro-Economic Forces
 
@@ -96,17 +100,6 @@
   defined in a transitive module.  
   [jszumski](https://github.com/jszumski)
   [#5246](https://github.com/realm/SwiftLint/pull/5246)
-
-* `superfluous_disable_command` violations are now triggered for
-  custom rules.  
-  [Marcelo Fabri](https://github.com/marcelofabri)
-  [Martin Redington](https://github.com/mildm8nnered)
-  [#4754](https://github.com/realm/SwiftLint/issues/4754)
-
-* Fixed false positives for the `no_magic_numbers` rule, when they
-  are defined in a tuple like `let (a, b) = (5, 10)` or `let a = (2, 3)`.  
-  [Martin Redington](https://github.com/mildm8nnered)
-  [#5305](https://github.com/realm/SwiftLint/pull/5305)
 
 ## 0.53.0: Laundry List
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,10 +100,10 @@
 * `superfluous_disable_command` violations are now triggered for
   custom rules.  
   [Marcelo Fabri](https://github.com/marcelofabri)
-  [Martin Redington](https://github.com/mildm8nnered)
   [#4754](https://github.com/realm/SwiftLint/issues/4754)
+
 * Fixed false positives for the `no_magic_numbers` rule, when they
-  are defined in a tuple like `let (a, b) = (5, 10)`.  
+  are defined in a tuple like `let (a, b) = (5, 10)` or `let a = (2, 3)`.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#5305](https://github.com/realm/SwiftLint/pull/5305)
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -75,7 +75,8 @@ struct NoMagicNumbersRule: OptInRule {
             Example("let foo = 2 >> 2"),
             Example("let foo = 2 << 2"),
             Example("let a = b / 100.0"),
-            Example("let (lowerBound, upperBound) = (400, 599)")
+            Example("let (lowerBound, upperBound) = (400, 599)"),
+            Example("let a = (5, 10)")
         ],
         triggeringExamples: [
             Example("foo(↓321)"),
@@ -232,11 +233,9 @@ private extension PatternBindingSyntax {
         }
         let secondChildIndex = children.index(after: children.startIndex)
 
-        guard
-            let firstChild = children.first, firstChild.is(TuplePatternSyntax.self),
-            let secondChild = children[secondChildIndex].as(InitializerClauseSyntax.self),
-            secondChild.value.is(TupleExprSyntax.self)
-        else {
+        guard let secondChild = children[secondChildIndex].as(InitializerClauseSyntax.self),
+              let tupleExpression = secondChild.value.as(TupleExprSyntax.self),
+              tupleExpression.elements.count > 1  else {
             return false
         }
         return true

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -89,6 +89,11 @@ struct NoMagicNumbersRule: OptInRule {
                     extension NSObject {
                         let a = Int(↓3)
                     }
+            """),
+            Example("""
+            if (fileSize > ↓1000000) {
+                try FileManager.default.removeItem(at: cacheFileUrl)
+            }
             """)
         ]
     )
@@ -101,7 +106,13 @@ private extension NoMagicNumbersRule {
         private var possibleViolations: [String: Set<AbsolutePosition>] = [:]
 
         override func visit(_ node: TupleExprSyntax) -> SyntaxVisitorContinueKind {
-            .skipChildren
+            guard let parent = node.parent else {
+                return .visitChildren
+            }
+            if parent.is(InitializerClauseSyntax.self) {
+                return .skipChildren
+            }
+            return .visitChildren
         }
 
         override func visitPost(_ node: ClassDeclSyntax) {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -76,7 +76,11 @@ struct NoMagicNumbersRule: OptInRule {
             Example("let foo = 2 << 2"),
             Example("let a = b / 100.0"),
             Example("let (lowerBound, upperBound) = (400, 599)"),
-            Example("let a = (5, 10)")
+            Example("let a = (5, 10)"),
+            Example("let size = (width: 4, height: 3)"),
+            Example("""
+                    let notFound = (404, "Not Found")
+                    """)
         ],
         triggeringExamples: [
             Example("foo(↓321)"),
@@ -96,7 +100,8 @@ struct NoMagicNumbersRule: OptInRule {
                 return
             }
             """),
-            Example("let imageHeight = (width - ↓24)")
+            Example("let imageHeight = (width - ↓24)"),
+            Example("return (↓5, ↓10, ↓15)")
         ]
     )
 }
@@ -228,7 +233,9 @@ private extension ExprSyntaxProtocol {
 private extension PatternBindingSyntax {
     var isSimpleTupleAssignment: Bool {
         initializer?.value.as(TupleExprSyntax.self)?.elements.allSatisfy {
-            $0.expression.is(IntegerLiteralExprSyntax.self) || $0.expression.is(FloatLiteralExprSyntax.self)
+            $0.expression.is(IntegerLiteralExprSyntax.self) ||
+            $0.expression.is(FloatLiteralExprSyntax.self) ||
+            $0.expression.is(StringLiteralExprSyntax.self)
         } ?? false
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -74,7 +74,8 @@ struct NoMagicNumbersRule: OptInRule {
             Example("let foo = 1 >> 2"),
             Example("let foo = 2 >> 2"),
             Example("let foo = 2 << 2"),
-            Example("let a = b / 100.0")
+            Example("let a = b / 100.0"),
+            Example("let (httpStatusCodeErrorLowerBound, httpStatusCodeErrorUpperBound) = (400, 599)")
         ],
         triggeringExamples: [
             Example("foo(↓321)"),
@@ -98,6 +99,10 @@ private extension NoMagicNumbersRule {
         private var testClasses: Set<String> = []
         private var nonTestClasses: Set<String> = []
         private var possibleViolations: [String: Set<AbsolutePosition>] = [:]
+
+        override func visit(_ node: TupleExprSyntax) -> SyntaxVisitorContinueKind {
+            .skipChildren
+        }
 
         override func visitPost(_ node: ClassDeclSyntax) {
             let className = node.name.text

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -94,7 +94,8 @@ struct NoMagicNumbersRule: OptInRule {
             if (fileSize > ↓1000000) {
                 try FileManager.default.removeItem(at: cacheFileUrl)
             }
-            """)
+            """),
+            Example("let imageHeight = (width - ↓24)")
         ]
     )
 }
@@ -110,7 +111,17 @@ private extension NoMagicNumbersRule {
                 return .visitChildren
             }
             if parent.is(InitializerClauseSyntax.self) {
-                return .skipChildren
+                guard let grandParent = parent.parent else {
+                    return .visitChildren
+                }
+                if grandParent.is(PatternBindingSyntax.self) {
+                    if let firstSibling = grandParent.children(viewMode: .sourceAccurate).first {
+                        if firstSibling.is(TuplePatternSyntax.self) {
+                            return .skipChildren
+                        }
+                    }
+                }
+                return .visitChildren
             }
             return .visitChildren
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -227,17 +227,6 @@ private extension ExprSyntaxProtocol {
 
 private extension PatternBindingSyntax {
     var isTupleAssignment: Bool {
-        let children = children(viewMode: .sourceAccurate)
-        guard children.count > 1 else {
-            return false
-        }
-        let secondChildIndex = children.index(after: children.startIndex)
-
-        guard let secondChild = children[secondChildIndex].as(InitializerClauseSyntax.self),
-              let tupleExpression = secondChild.value.as(TupleExprSyntax.self),
-              tupleExpression.elements.count > 1  else {
-            return false
-        }
-        return true
+        initializer?.value.as(TupleExprSyntax.self)?.elements.count ?? 0 > 1
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -77,9 +77,8 @@ struct NoMagicNumbersRule: OptInRule {
             Example("let a = b / 100.0"),
             Example("let (lowerBound, upperBound) = (400, 599)"),
             Example("let a = (5, 10)"),
-            Example("let size = (width: 4, height: 3)"),
             Example("""
-                    let notFound = (404, "Not Found")
+                    let notFound = (statusCode: 404, description: "Not Found", isError: true)
                     """)
         ],
         triggeringExamples: [
@@ -235,7 +234,8 @@ private extension PatternBindingSyntax {
         initializer?.value.as(TupleExprSyntax.self)?.elements.allSatisfy {
             $0.expression.is(IntegerLiteralExprSyntax.self) ||
             $0.expression.is(FloatLiteralExprSyntax.self) ||
-            $0.expression.is(StringLiteralExprSyntax.self)
+            $0.expression.is(StringLiteralExprSyntax.self) ||
+            $0.expression.is(BooleanLiteralExprSyntax.self)
         } ?? false
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -75,7 +75,7 @@ struct NoMagicNumbersRule: OptInRule {
             Example("let foo = 2 >> 2"),
             Example("let foo = 2 << 2"),
             Example("let a = b / 100.0"),
-            Example("let (httpStatusCodeErrorLowerBound, httpStatusCodeErrorUpperBound) = (400, 599)")
+            Example("let (lowerBound, upperBound) = (400, 599)")
         ],
         triggeringExamples: [
             Example("foo(↓321)"),
@@ -92,7 +92,7 @@ struct NoMagicNumbersRule: OptInRule {
             """),
             Example("""
             if (fileSize > ↓1000000) {
-                try FileManager.default.removeItem(at: cacheFileUrl)
+                return
             }
             """),
             Example("let imageHeight = (width - ↓24)")

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -108,7 +108,7 @@ private extension NoMagicNumbersRule {
         private var possibleViolations: [String: Set<AbsolutePosition>] = [:]
 
         override func visit(_ node: PatternBindingSyntax) -> SyntaxVisitorContinueKind {
-            node.isTupleAssignment ? .skipChildren : .visitChildren
+            node.isSimpleTupleAssignment ? .skipChildren : .visitChildren
         }
 
         override func visitPost(_ node: ClassDeclSyntax) {
@@ -226,7 +226,9 @@ private extension ExprSyntaxProtocol {
 }
 
 private extension PatternBindingSyntax {
-    var isTupleAssignment: Bool {
-        initializer?.value.as(TupleExprSyntax.self)?.elements.count ?? 0 > 1
+    var isSimpleTupleAssignment: Bool {
+        initializer?.value.as(TupleExprSyntax.self)?.elements.allSatisfy {
+            $0.expression.is(IntegerLiteralExprSyntax.self) || $0.expression.is(FloatLiteralExprSyntax.self)
+        } ?? false
     }
 }


### PR DESCRIPTION
Now ignores magic numbers in tuple assignments like

`let (httpStatusCodeErrorLowerBound, httpStatusCodeErrorUpperBound) = (400, 599)`

OSS checks look good to me.

Resolves https://github.com/realm/SwiftLint/issues/5305 by skipping magic numbers in tuple expressions altogether.