### PR TITLE
Set the excluded files list once when getting lint files

### DIFF
--- a/Source/swiftlint/Extensions/Configuration+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Configuration+CommandLine.swift
@@ -243,13 +243,14 @@ extension Configuration {
 
             queuedPrintError("\(visitor.action) Swift files \(filesInfo)")
         }
+        let excludeLintableFilesBy = visitor.useExcludingByPrefix
+                    ? Configuration.ExcludeBy.prefix
+                    : .paths(excludedPaths: excludedPaths())
         return visitor.paths.flatMap {
             self.lintableFiles(
                 inPath: $0,
                 forceExclude: visitor.forceExclude,
-                excludeBy: visitor.useExcludingByPrefix
-                    ? .prefix
-                    : .paths(excludedPaths: excludedPaths()))
+                excludeBy: excludeLintableFilesBy)
         }
     }
 


### PR DESCRIPTION
Fixes #5329 

### Issue

The SPM plugin is much slower than the regular SwiftLint.

### Analysis

The plugin specifies not just an input folder but a list of all the project files. `getFiles()` resolves the excluded files for each of the specified files.

### Solution

No need to resolve the excluded files for each input file. Let's set them before iterating lint files.