### PR TITLE
Fix custom_rules regression introduced in #4755

### DIFF
--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -102,8 +102,13 @@ private extension Rule {
 
         let (disabledViolationsAndRegions, enabledViolationsAndRegions) = violations.map { violation in
             return (violation, regions.first { $0.contains(violation.location) })
-        }.partitioned { _, region in
-            return region?.isRuleEnabled(self) ?? true
+        }.partitioned { violation, region in
+            if self is CustomRules {
+                let disabled = region?.isRuleDisabled(customRuleIdentifier: violation.ruleIdentifier) ?? false
+                return !disabled
+            } else {
+                return region?.isRuleEnabled(self) ?? true
+            }
         }
 
         let customRulesIDs: [String] = {

--- a/Source/SwiftLintCore/Rules/CustomRules.swift
+++ b/Source/SwiftLintCore/Rules/CustomRules.swift
@@ -79,13 +79,7 @@ struct CustomRules: Rule, CacheDescriptionProvider {
                                severity: configuration.severity,
                                location: Location(file: file, characterOffset: $0.location),
                                reason: configuration.message)
-            }).filter { violation in
-                guard let region = file.regions().first(where: { $0.contains(violation.location) }) else {
-                    return true
-                }
-
-                return !region.isRuleDisabled(customRuleIdentifier: configuration.identifier)
-            }
+            })
         }
     }
 }

--- a/Source/SwiftLintCore/Rules/CustomRules.swift
+++ b/Source/SwiftLintCore/Rules/CustomRules.swift
@@ -86,6 +86,10 @@ struct CustomRules: Rule, CacheDescriptionProvider {
 
 extension Region {
     func isRuleDisabled(customRuleIdentifier: String) -> Bool {
+        if disabledRuleIdentifiers.contains(.all) {
+            return true
+        }
+
         return disabledRuleIdentifiers.contains(RuleIdentifier(customRuleIdentifier))
     }
 }

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -216,6 +216,27 @@ class CustomRulesTests: SwiftLintTestCase {
         XCTAssertEqual(violations.count, 0)
     }
 
+    func testSuperfluousDisableCommandDoesntTriggerWithCustomRulesDisableAll() throws {
+        let customRulesConfiguration: [String: Any] = [
+            "custom1": [
+                "regex": "pattern",
+                "match_kinds": "comment"
+            ]
+        ]
+
+        let example = Example(
+            """
+            // swiftlint:disable:next all
+            // this pattern is prohibited
+            """,
+            configuration: customRulesConfiguration
+        ).skipWrappingInCommentTest()
+        let configuration = try XCTUnwrap(makeConfig(["custom_rules": customRulesConfiguration], "custom_rules"))
+        let violations = violations(example, config: configuration)
+
+        XCTAssertEqual(violations.count, 0)
+    }
+
     func testSuperfluousDisableCommandWithMultipleCustomRules() throws {
         let customRulesConfiguration: [String: Any] = [
             "custom1": [


### PR DESCRIPTION
Here's what was happening:

- `CustomRules.swift` filters out violations outside of disabled regions
- This means that we won't get that violation in `Linter` so we'll always trigger `superfluous_disable_command`
- `Region.isRuleEnabled` doesn't understand custom rules

We can change the logic a little bit to make it work for custom rules. I don't love this, but I _think_ it works (and we already special case `CustomRules` in a few places).