### PR TITLE
Trigger on both first and second name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 #### Enhancements
 
+* Given a function `f(a b: Int)`, the `identifier_name` rule now warns on both
+  parameter names `a` and `b` for being too short (in this case).  
+  [SimplyDanny](https://github.com/SimplyDanny)
+
 * Rewrite the following rules with SwiftSyntax:
   * `identifier_name`
   * `void_return`

--- a/Source/SwiftLintBuiltInRules/Rules/Style/IdentifierNameRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/IdentifierNameRule.swift
@@ -35,11 +35,16 @@ private extension IdentifierNameRule {
             if node.modifiers.contains(keyword: .override) {
                 return
             }
-            let name = node.secondName ?? node.firstName
             collectViolations(
-                from: .variable(name: name.text.leadingDollarStripped, isStatic: false, isPrivate: false),
-                on: name
+                from: .variable(name: node.firstName.text.leadingDollarStripped, isStatic: false, isPrivate: false),
+                on: node.firstName
             )
+            if let name = node.secondName {
+                collectViolations(
+                    from: .variable(name: name.text.leadingDollarStripped, isStatic: false, isPrivate: false),
+                    on: name
+                )
+            }
         }
 
         override func visitPost(_ node: ClosureShorthandParameterSyntax) {
@@ -54,7 +59,10 @@ private extension IdentifierNameRule {
         }
 
         override func visitPost(_ node: EnumCaseParameterSyntax) {
-            if let name = node.secondName ?? node.firstName {
+            if let name = node.firstName {
+                collectViolations(from: .variable(name: name.text, isStatic: false, isPrivate: false), on: name)
+            }
+            if let name = node.secondName {
                 collectViolations(from: .variable(name: name.text, isStatic: false, isPrivate: false), on: name)
             }
         }
@@ -76,11 +84,13 @@ private extension IdentifierNameRule {
             if node.modifiers.contains(keyword: .override) {
                 return
             }
-            let name = (node.secondName ?? node.firstName)
             collectViolations(
-                from: .variable(name: name.text, isStatic: false, isPrivate: false),
-                on: name
+                from: .variable(name: node.firstName.text, isStatic: false, isPrivate: false),
+                on: node.firstName
             )
+            if let name = node.secondName {
+                collectViolations(from: .variable(name: name.text, isStatic: false, isPrivate: false), on: name)
+            }
         }
 
         override func visitPost(_ node: IdentifierPatternSyntax) {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/IdentifierNameRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/IdentifierNameRuleExamples.swift
@@ -63,7 +63,7 @@ internal struct IdentifierNameRuleExamples {
         Example("""
             func myFunc(
                 _ ↓s: String,
-                i ↓j: Int,
+                ↓i ↓j: Int,
                 _ goodName: Double,
                 name ↓n: String,
                 ↓x: Int,
@@ -77,13 +77,14 @@ internal struct IdentifierNameRuleExamples {
         Example("for ↓i in [] {}"),
         Example("f { ↓x in }"),
         Example("f { ↓$x in }"),
-        Example("f { (x abc: Int, _ ↓x: Int) in }"),
+        Example("f { (↓x abc: Int, _ ↓x: Int) in }"),
         Example("""
             enum E {
                 case ↓c
                 case case1(Int)
                 case case2(↓a: Int)
                 case case3(_ ↓a: Int)
+                case case4(↓b ↓a: Int)
             }
             """),
         Example("""


### PR DESCRIPTION
Not sure I like this. While the first argument name is actually the user-visible one, it's often used to create a descriptive overall function name like `doSomething(if condition: Bool)`. This often leads to relatively short prepositions like `as`, `if`, `on`, `by`, ... which would now all trigger the rule.

If added, it should probably be hidden behind an option.