### PR TITLE
Allow to configure more operators in `identifier_name` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@
 * Print invalid keys when configuration parsing fails.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#5347](https://github.com/realm/SwiftLint/pull/5347)
+  
+* Allow to configure more operators in `identifier_name` rule. The new option
+  is named `additional_operators`. Use it to add more operators to the list
+  of default operators known to the rule.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#1762](https://github.com/realm/SwiftLint/pull/1762)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/GenericTypeNameRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/GenericTypeNameRule.swift
@@ -56,7 +56,7 @@ private extension GenericTypeNameRule {
             let name = node.name.text
             guard !name.isEmpty, !configuration.shouldExclude(name: name) else { return }
 
-            if !configuration.allowedSymbolsAndAlphanumerics.isSuperset(of: CharacterSet(charactersIn: name)) {
+            if !configuration.containsOnlyAllowedCharacters(name: name) {
                 violations.append(
                     ReasonedRuleViolation(
                         position: node.positionAfterSkippingLeadingTrivia,

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/TypeNameRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/TypeNameRule.swift
@@ -82,7 +82,7 @@ private extension TypeNameRule {
                 .strippingBackticks()
                 .strippingLeadingUnderscoreIfPrivate(modifiers: modifiers)
                 .strippingTrailingSwiftUIPreviewProvider(inheritedTypes: inheritedTypes)
-            if !nameConfiguration.allowedSymbolsAndAlphanumerics.isSuperset(of: CharacterSet(charactersIn: name)) {
+            if !nameConfiguration.containsOnlyAllowedCharacters(name: name) {
                 return ReasonedRuleViolation(
                     position: identifier.positionAfterSkippingLeadingTrivia,
                     reason: "Type name '\(name)' should only contain alphanumeric and other allowed characters",

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/IdentifierNameConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/IdentifierNameConfiguration.swift
@@ -1,0 +1,18 @@
+import SwiftLintCore
+
+@AutoApply
+struct IdentifierNameConfiguration: RuleConfiguration {
+    typealias Parent = IdentifierNameRule
+
+    private static let defaultOperators = ["/", "=", "-", "+", "!", "*", "|", "^", "~", "?", ".", "%", "<", ">", "&"]
+
+    @ConfigurationElement
+    private(set) var nameConfiguration = NameConfiguration<Parent>(minLengthWarning: 3,
+                                                                   minLengthError: 2,
+                                                                   maxLengthWarning: 40,
+                                                                   maxLengthError: 60,
+                                                                   excluded: ["id"])
+
+    @ConfigurationElement(key: "additional_operators", postprocessor: { $0.formUnion(Self.defaultOperators) })
+    private(set) var additionalOperators = Set<String>()
+}

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NameConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NameConfiguration.swift
@@ -99,6 +99,10 @@ extension NameConfiguration {
         }
         return nil
     }
+
+    func containsOnlyAllowedCharacters(name: String) -> Bool {
+        allowedSymbolsAndAlphanumerics.isSuperset(of: CharacterSet(charactersIn: name))
+    }
 }
 
 // MARK: - `exclude` option extensions

--- a/Source/SwiftLintBuiltInRules/Rules/Style/IdentifierNameRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/IdentifierNameRuleExamples.swift
@@ -28,7 +28,8 @@ internal struct IdentifierNameRuleExamples {
                 class Foo {
                    static var Bar = 0
                 }
-                """)
+                """),
+        Example("func √ (arg: Double) -> Double { arg }", configuration: ["additional_operators": "√"])
     ]
 
     static let triggeringExamples = [
@@ -93,6 +94,7 @@ internal struct IdentifierNameRuleExamples {
                     set(↓y) { x = y }
                 }
             }
-            """)
+            """),
+        Example("func ↓√ (arg: Double) -> Double { arg }")
     ]
 }

--- a/Tests/SwiftLintFrameworkTests/IdentifierNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IdentifierNameRuleTests.swift
@@ -50,7 +50,8 @@ class IdentifierNameRuleTests: SwiftLintTestCase {
             Example("func ↓IsOperator(name: String) -> Bool"),
             Example("class C { class let ↓MyLet = 0 }"),
             Example("class C { static func ↓MyFunc() {} }"),
-            Example("class C { class func ↓MyFunc() {} }")
+            Example("class C { class func ↓MyFunc() {} }"),
+            Example("func ↓√ (arg: Double) -> Double { arg }")
         ]
         let nonTriggeringExamples = baseDescription.nonTriggeringExamples +
             triggeringExamplesToRemove.removingViolationMarkers()


### PR DESCRIPTION
Resolves #1762.