### PR TITLE
Rewrite `let_var_whitespace` rule with SwiftSyntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@
 * Rewrite `multiline_literal_brackets` rule using SwiftSyntax, fixing some
   false positives that would happen when comments are present.  
   [Marcelo Fabri](https://github.com/marcelofabri)
+  
+* Rewrite `let_var_whitespace` rule using SwiftSyntax, fixing false positives
+  when attributes attached to declarations were spread over multiple lines.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#4801](https://github.com/realm/SwiftLint/pull/4801)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/DeploymentTargetRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/DeploymentTargetRule.swift
@@ -3,6 +3,7 @@ import SwiftSyntax
 @SwiftSyntaxRule
 struct DeploymentTargetRule {
     fileprivate typealias Version = DeploymentTargetConfiguration.Version
+
     var configuration = DeploymentTargetConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/DiscouragedDirectInitConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/DiscouragedDirectInitConfiguration.swift
@@ -1,8 +1,5 @@
 import SwiftLintCore
 
-// swiftlint:disable:next blanket_disable_command
-// swiftlint:disable let_var_whitespace
-
 @AutoApply
 struct DiscouragedDirectInitConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = DiscouragedDirectInitRule

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/IndentationWidthConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/IndentationWidthConfiguration.swift
@@ -1,8 +1,5 @@
 import SwiftLintCore
 
-// swiftlint:disable:next blanket_disable_command
-// swiftlint:disable let_var_whitespace
-
 @AutoApply
 struct IndentationWidthConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = IndentationWidthRule

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TestCaseAccessibilityConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TestCaseAccessibilityConfiguration.swift
@@ -1,8 +1,5 @@
 import SwiftLintCore
 
-// swiftlint:disable:next blanket_disable_command
-// swiftlint:disable let_var_whitespace
-
 @AutoApply
 struct TestCaseAccessibilityConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = TestCaseAccessibilityRule

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnitTestConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnitTestConfiguration.swift
@@ -5,9 +5,6 @@ typealias EmptyXCTestMethodConfiguration = UnitTestConfiguration<EmptyXCTestMeth
 typealias SingleTestClassConfiguration = UnitTestConfiguration<SingleTestClassRule>
 typealias NoMagicNumbersConfiguration = UnitTestConfiguration<NoMagicNumbersRule>
 
-// swiftlint:disable:next blanket_disable_command
-// swiftlint:disable let_var_whitespace
-
 @AutoApply
 struct UnitTestConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration {
     @ConfigurationElement(key: "severity")

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedDeclarationConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedDeclarationConfiguration.swift
@@ -1,8 +1,5 @@
 import SwiftLintCore
 
-// swiftlint:disable:next blanket_disable_command
-// swiftlint:disable let_var_whitespace
-
 @AutoApply
 struct UnusedDeclarationConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = UnusedDeclarationRule

--- a/Source/SwiftLintBuiltInRules/Rules/Style/LetVarWhitespaceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/LetVarWhitespaceRule.swift
@@ -10,25 +10,85 @@ struct LetVarWhitespaceRule: OptInRule {
         description: "Variable declarations should be separated from other statements by a blank line",
         kind: .style,
         nonTriggeringExamples: [
-            Example("let a = 0\nvar x = 1\n\nx = 2"),
-            Example("a = 5\n\nvar x = 1"),
-            Example("struct X {\n\tvar a = 0\n}"),
-            Example("let a = 1 +\n\t2\nlet b = 5"),
-            Example("var x: Int {\n\treturn 0\n}"),
-            Example("var x: Int {\n\tlet a = 0\n\n\treturn a\n}"),
-            Example("#if os(macOS)\nlet a = 0\n#endif"),
-            Example("#warning(\"TODO: remove it\")\nlet a = 0"),
-            Example("#error(\"TODO: remove it\")\nlet a = 0"),
-            Example("@available(swift 4)\nlet a = 0"),
-            Example("class C {\n\t@objc\n\tvar s: String = \"\"\n}"),
-            Example("class C {\n\t@objc\n\tfunc a() {}\n}"),
-            Example("class C {\n\tvar x = 0\n\tlazy\n\tvar y = 0\n}"),
-            Example("@available(OSX, introduced: 10.6)\n@available(*, deprecated)\nvar x = 0"),
             Example("""
-            // swiftlint:disable superfluous_disable_command
-            // swiftlint:disable force_cast
+                let a = 0
+                var x = 1
 
-            let x = bar as! Bar
+                x = 2
+            """),
+            Example("""
+                a = 5
+
+                var x = 1
+            """),
+            Example("""
+                struct X {
+                    var a = 0
+                }
+            """),
+            Example("""
+                let a = 1 +
+                    2
+                let b = 5
+            """),
+            Example("""
+                var x: Int {
+                    return 0
+                }
+            """),
+            Example("""
+                var x: Int {
+                    let a = 0
+
+                    return a
+                }
+            """),
+            Example("""
+                #if os(macOS)
+                let a = 0
+                #endif
+            """),
+            Example("""
+                #warning("TODO: remove it")
+                let a = 0
+            """),
+            Example("""
+                #error("TODO: remove it")
+                let a = 0
+            """),
+            Example("""
+                @available(swift 4)
+                let a = 0
+            """),
+            Example("""
+                class C {
+                    @objc
+                    var s: String = ""
+                }
+            """),
+            Example("""
+                class C {
+                    @objc
+                    func a() {}
+                }
+            """),
+            Example("""
+                class C {
+                    var x = 0
+                    lazy
+                    var y = 0
+                }
+            """),
+            Example("""
+                @available(OSX, introduced: 10.6)
+                @available(*, deprecated)
+                var x = 0
+            """),
+            Example("""
+                // swiftlint:disable superfluous_disable_command
+                // swiftlint:disable force_cast
+
+                let x = bar as! Bar
             """),
             Example("""
                 @available(swift 4)
@@ -38,25 +98,54 @@ struct LetVarWhitespaceRule: OptInRule {
                 @Attribute
                 func f() {}
             """),
-            Example("var x: Int {\n\tlet a = 0\n\treturn a\n}"), // don't trigger on local vars
+            // Don't trigger on local variable declarations.
             Example("""
-            struct S {
-                static var test: String { /* Comment block */
-                    let s = "!"
-                    return "Test" + s
+                var x: Int {
+                    let a = 0
+                    return a
                 }
+            """),
+            Example("""
+                struct S {
+                    static var test: String { /* Comment block */
+                        let s = "!"
+                        return "Test" + s
+                    }
 
-                func f() {}
-            }
+                    func f() {}
+                }
             """, excludeFromDocumentation: true)
         ],
         triggeringExamples: [
-            Example("var x = 1\n↓x = 2"),
-            Example("\na = 5\n↓var x = 1"),
-            Example("struct X {\n\tlet a\n\t↓func x() {}\n}"),
-            Example("var x = 0\n↓@objc func f() {}"),
-            Example("var x = 0\n↓@objc\n\tfunc f() {}"),
-            Example("@objc func f() {\n}\n↓var x = 0"),
+            Example("""
+                var x = 1
+                ↓x = 2
+            """),
+            Example("""
+
+                a = 5
+                ↓var x = 1
+            """),
+            Example("""
+                struct X {
+                    let a
+                    ↓func x() {}
+                }
+            """),
+            Example("""
+                var x = 0
+                ↓@objc func f() {}
+            """),
+            Example("""
+                var x = 0
+                ↓@objc
+                func f() {}
+            """),
+            Example("""
+                @objc func f() {
+                }
+                ↓var x = 0
+            """),
             Example("""
                 struct S {
                     func f() {}

--- a/Source/SwiftLintCore/Extensions/SwiftLintFile+Cache.swift
+++ b/Source/SwiftLintCore/Extensions/SwiftLintFile+Cache.swift
@@ -10,6 +10,7 @@ import SwiftParserDiagnostics
 import SwiftSyntax
 
 private typealias FileCacheKey = UUID
+
 private let responseCache = Cache { file -> [String: any SourceKitRepresentable]? in
     do {
         return try Request.editorOpen(file: file.file).sendIfNotDisabled()

--- a/Source/SwiftLintCore/Models/LinterCache.swift
+++ b/Source/SwiftLintCore/Models/LinterCache.swift
@@ -20,9 +20,9 @@ private struct FileCache: Codable {
 public final class LinterCache {
     private typealias Encoder = PropertyListEncoder
     private typealias Decoder = PropertyListDecoder
-    private static let fileExtension = "plist"
-
     private typealias Cache = [String: FileCache]
+
+    private static let fileExtension = "plist"
 
     private var lazyReadCache: Cache
     private let readCacheLock = NSLock()

--- a/Source/swiftlint/Helpers/LintOrAnalyzeArguments.swift
+++ b/Source/swiftlint/Helpers/LintOrAnalyzeArguments.swift
@@ -25,7 +25,7 @@ struct LintOrAnalyzeArguments: ParsableArguments {
         Should reformat the Swift files using the same mechanism used by Xcode (via SourceKit).
         Only applied with `--fix`/`--autocorrect`.
         """)
-    var format = false // swiftlint:disable:this let_var_whitespace - the multiline @Flag breaks us
+    var format = false
     @Flag(help: "Use an alternative algorithm to exclude paths for `excluded`, which may be faster in some cases.")
     var useAlternativeExcluding = false
     @Flag(help: "Read SCRIPT_INPUT_FILE* environment variables as files.")

--- a/Tests/SwiftLintFrameworkTests/RuleConfigurationDescriptionTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleConfigurationDescriptionTests.swift
@@ -2,8 +2,6 @@
 import SwiftLintTestHelpers
 import XCTest
 
-// swiftlint:disable:next blanket_disable_command
-// swiftlint:disable let_var_whitespace
 // swiftlint:disable file_length
 
 // swiftlint:disable:next type_body_length


### PR DESCRIPTION
Fixes #4801.

What's more:

* Examples have been refactored to use multiline strings for better readability.
* Additional examples check more special cases.
* `typealias` and `#if`/`#endif` are also considered declarations to maintain a distance to.