### PR TITLE
- rule added for avoiding redundant extensions resolve #5359

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -42,6 +42,7 @@ disabled_rules:
   - prefer_nimble
   - prefer_self_in_static_references
   - prefixed_toplevel_constant
+  - redundant_extension
   - redundant_self_in_closure
   - required_deinit
   - self_binding

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 #### Enhancements
 
+* Add new `redundant_extension` rule that detect redundant extensions.
+  [Muhammad Zeeshan](https://github.com/mzeeshanid)
+  [#5359](https://github.com/realm/SwiftLint/issues/5359)
+
 * Add new `one_declaration_per_file` rule that allows only a
   single class/struct/enum/protocol declaration per file.
   Extensions are an exception; more than one is allowed.  

--- a/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
+++ b/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
@@ -166,6 +166,7 @@ public let builtInRules: [any Rule.Type] = [
     ReduceBooleanRule.self,
     ReduceIntoRule.self,
     RedundantDiscardableLetRule.self,
+    RedundantExtensionRule.self,
     RedundantNilCoalescingRule.self,
     RedundantObjcAttributeRule.self,
     RedundantOptionalInitializationRule.self,

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantExtensionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantExtensionRule.swift
@@ -1,0 +1,62 @@
+import SwiftSyntax
+
+@SwiftSyntaxRule
+struct RedundantExtensionRule: OptInRule {
+    var configuration = SeverityConfiguration<Self>(.warning)
+
+    static let description = RuleDescription(
+        identifier: "redundant_extension",
+        name: "Redundant Extension",
+        description: "Avoid redundant extensions",
+        kind: .idiomatic,
+        nonTriggeringExamples: [
+            Example("""
+                    extension Foo {
+                        func something() {}
+                    }
+                    """),
+            Example("""
+                    extension Foo {
+                        var a: Int { 1 }
+                    }
+                    """)
+        ],
+        triggeringExamples: [
+            Example("""
+                    ↓extension Bar {}
+                    """)
+        ]
+    )
+}
+
+private extension RedundantExtensionRule {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
+        private var isRedundantExtension = false
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] {
+            return .allExcept(VariableDeclSyntax.self, FunctionDeclSyntax.self)
+        }
+
+        override func visitPost(_ node: VariableDeclSyntax) {
+            isRedundantExtension = false
+        }
+
+        override func visitPost(_ node: FunctionDeclSyntax) {
+            isRedundantExtension = false
+        }
+
+        override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
+            isRedundantExtension = true
+            return .visitChildren
+        }
+
+        override func visitPost(_ node: ExtensionDeclSyntax) {
+            appendViolationIfNeeded(node: node.extensionKeyword)
+        }
+
+        func appendViolationIfNeeded(node: TokenSyntax) {
+            if isRedundantExtension {
+                violations.append(node.positionAfterSkippingLeadingTrivia)
+            }
+        }
+    }
+}

--- a/Tests/GeneratedTests/GeneratedTests.swift
+++ b/Tests/GeneratedTests/GeneratedTests.swift
@@ -986,6 +986,12 @@ class RedundantDiscardableLetRuleGeneratedTests: SwiftLintTestCase {
     }
 }
 
+class RedundantExtensionRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(RedundantExtensionRule.description)
+    }
+}
+
 class RedundantNilCoalescingRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(RedundantNilCoalescingRule.description)


### PR DESCRIPTION
New rule added for avoiding redundant extensions based on:
- Extensions can't be nested
- Opt-In rule
- Severity is configurable