### PR TITLE
RedundantTypeAnnotationRule: Rewrite with SwiftSyntax and allow ignoring certain attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,10 @@
   Extensions are an exception; more than one is allowed.  
   [Muhammad Zeeshan](https://github.com/mzeeshanid)
   [#2802](https://github.com/realm/SwiftLint/issues/2802)
-* Rewrite `redundant_type_annotation` rule with SwiftSyntax and add a new `ignored_attributes` option that allows disabling the rule for properties that are marked with at least one of the configured attributes
+
+* Add new `ignored_attributes` option to `redundant_type_annotation` rule
+  that allows disabling the rule for properties that are marked with at least
+  one of the configured attributes
   [tonell-m](https://github.com/tonell-m)
   [#5366](https://github.com/realm/SwiftLint/issues/5366)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@
 
 * Add new `ignore_attributes` option to `redundant_type_annotation` rule
   that allows disabling the rule for properties that are marked with at least
-  one of the configured attributes.
+  one of the configured attributes.  
   [tonell-m](https://github.com/tonell-m)
   [#5366](https://github.com/realm/SwiftLint/issues/5366)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,9 +89,8 @@
   * `nimble_operator`
   * `opening_brace`
   * `orphaned_doc_comment`
-  * `trailing_closure`
-  * `void_return`
   * `redundant_type_annotation`
+  * `trailing_closure`
   * `void_return`
 
   [SimplyDanny](https://github.com/SimplyDanny)  
@@ -99,7 +98,6 @@
   [Marcelo Fabri](https://github.com/marcelofabri)  
   [swiftty](https://github.com/swiftty)  
   [KS1019](https://github.com/KS1019)  
-  [Marcelo Fabri](https://github.com/marcelofabri)
   [tonell-m](https://github.com/tonell-m)
 
 * Print invalid keys when configuration parsing fails.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@
 
 * Add new `ignore_attributes` option to `redundant_type_annotation` rule
   that allows disabling the rule for properties that are marked with at least
-  one of the configured attributes
+  one of the configured attributes.
   [tonell-m](https://github.com/tonell-m)
   [#5366](https://github.com/realm/SwiftLint/issues/5366)
 
@@ -92,6 +92,7 @@
   * `trailing_closure`
   * `void_return`
   * `redundant_type_annotation`
+  * `void_return`
 
   [SimplyDanny](https://github.com/SimplyDanny)  
   [kishikawakatsumi](https://github.com/kishikawakatsumi)  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,9 @@
   Extensions are an exception; more than one is allowed.  
   [Muhammad Zeeshan](https://github.com/mzeeshanid)
   [#2802](https://github.com/realm/SwiftLint/issues/2802)
+* Rewrite `redundant_type_annotation` rule with SwiftSyntax and add a new `ignored_attributes` option that allows disabling the rule for properties that are marked with at least one of the configured attributes
+  [tonell-m](https://github.com/tonell-m)
+  [#5366](https://github.com/realm/SwiftLint/issues/5366)
 
 * Rewrite the following rules with SwiftSyntax:
   * `explicit_acl`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,12 +91,15 @@
   * `orphaned_doc_comment`
   * `trailing_closure`
   * `void_return`
+  * `redundant_type_annotation`
 
   [SimplyDanny](https://github.com/SimplyDanny)  
   [kishikawakatsumi](https://github.com/kishikawakatsumi)  
   [Marcelo Fabri](https://github.com/marcelofabri)  
   [swiftty](https://github.com/swiftty)  
   [KS1019](https://github.com/KS1019)  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [tonell-m](https://github.com/tonell-m)
 
 * Print invalid keys when configuration parsing fails.  
   [SimplyDanny](https://github.com/SimplyDanny)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@
   [Muhammad Zeeshan](https://github.com/mzeeshanid)
   [#2802](https://github.com/realm/SwiftLint/issues/2802)
 
-* Add new `ignored_attributes` option to `redundant_type_annotation` rule
+* Add new `ignore_attributes` option to `redundant_type_annotation` rule
   that allows disabling the rule for properties that are marked with at least
   one of the configured attributes
   [tonell-m](https://github.com/tonell-m)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -2,12 +2,9 @@ import Foundation
 import SwiftLintCore
 import SwiftSyntax
 
-struct RedundantTypeAnnotationRule: SwiftSyntaxCorrectableRule, OptInRule {
+@SwiftSyntaxRule
+struct RedundantTypeAnnotationRule: OptInRule {
     var configuration = RedundantTypeAnnotationConfiguration()
-
-    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor<ConfigurationType> {
-        Visitor(configuration: configuration, file: file)
-    }
 
     func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -13,7 +13,6 @@ struct RedundantTypeAnnotationRule: SwiftSyntaxCorrectableRule, OptInRule {
         nonTriggeringExamples: [
             Example("var url = URL()"),
             Example("var url: CustomStringConvertible = URL()"),
-            Example("@IBInspectable var color: UIColor = UIColor.white"),
             Example("var one: Int = 1, two: Int = 2, three: Int"),
             Example("guard let url = URL() else { return }"),
             Example("if let url = URL() { return }"),
@@ -45,7 +44,13 @@ struct RedundantTypeAnnotationRule: SwiftSyntaxCorrectableRule, OptInRule {
 
             var direction = Direction.up
             """),
-            Example("var values: Set<Int> = Set([0, 1, 2])")
+            Example("@IgnoreMe var a: Int = Int(5)", configuration: ["ignore_attributes": ["IgnoreMe"]]),
+            Example("""
+            var a: Int = {
+                @IgnoreMe let i: Int = Int(1)
+                return i
+            }
+            """, configuration: ["ignore_attributes": ["IgnoreMe"]])
         ],
         triggeringExamples: [
             Example("var url↓:URL=URL()"),
@@ -67,6 +72,7 @@ struct RedundantTypeAnnotationRule: SwiftSyntaxCorrectableRule, OptInRule {
             Example("guard var set↓: Set<Int> = Set<Int>([]) else { return }"),
             Example("if var set↓: Set<Int> = Set<Int>.init([]) { return }"),
             Example("var set↓: Set = Set<Int>([]), otherSet: Set<Int>"),
+            Example("var num↓: Int = Int.random(0..<10)"),
             Example("""
             class ViewController: UIViewController {
               func someMethod() {
@@ -83,7 +89,14 @@ struct RedundantTypeAnnotationRule: SwiftSyntaxCorrectableRule, OptInRule {
 
             var direction↓: Direction = Direction.up
             """),
-            Example("var num↓: Int = Int.random(0..<10")
+            Example("@DontIgnoreMe var a↓: Int = Int(5)", configuration: ["ignore_attributes": ["IgnoreMe"]]),
+            Example("""
+            @IgnoreMe
+            var a: Int = {
+                let i↓: Int = Int(1)
+                return i
+            }
+            """, configuration: ["ignore_attributes": ["IgnoreMe"]])
         ],
         corrections: [
             Example("var url↓: URL = URL()"): Example("var url = URL()"),
@@ -124,7 +137,21 @@ struct RedundantTypeAnnotationRule: SwiftSyntaxCorrectableRule, OptInRule {
               }
             }
             """),
-            Example("var num: Int = Int.random(0..<10)"): Example("var num = Int.random(0..<10)")
+            Example("var num: Int = Int.random(0..<10)"): Example("var num = Int.random(0..<10)"),
+            Example("""
+            @IgnoreMe
+            var a: Int = {
+                let i↓: Int = Int(1)
+                return i
+            }
+            """, configuration: ["ignore_attributes": ["IgnoreMe"]]):
+            Example("""
+            @IgnoreMe
+            var a: Int = {
+                let i = Int(1)
+                return i
+            }
+            """)
         ]
     )
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -165,34 +165,30 @@ struct RedundantTypeAnnotationRule: OptInRule, SwiftSyntaxCorrectableRule {
 private extension RedundantTypeAnnotationRule {
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: PatternBindingSyntax) {
-            guard node.parentDoesNotContainIgnoredAttributes(for: configuration),
-                  let typeAnnotation = node.typeAnnotation,
-                  let initializer = node.initializer?.value,
-                  typeAnnotation.isRedundant(with: initializer)
-            else {
-                return
+            if node.parentDoesNotContainIgnoredAttributes(for: configuration),
+               let typeAnnotation = node.typeAnnotation,
+               let initializer = node.initializer?.value,
+               typeAnnotation.isRedundant(with: initializer) {
+                violations.append(typeAnnotation.positionAfterSkippingLeadingTrivia)
+                violationCorrections.append(ViolationCorrection(
+                    start: typeAnnotation.position,
+                    end: typeAnnotation.endPositionBeforeTrailingTrivia,
+                    replacement: ""
+                ))
             }
-            violations.append(typeAnnotation.positionAfterSkippingLeadingTrivia)
-            violationCorrections.append(ViolationCorrection(
-                start: typeAnnotation.position,
-                end: typeAnnotation.endPositionBeforeTrailingTrivia,
-                replacement: ""
-            ))
         }
 
         override func visitPost(_ node: OptionalBindingConditionSyntax) {
-            guard let typeAnnotation = node.typeAnnotation,
-                  let initializer = node.initializer?.value,
-                  typeAnnotation.isRedundant(with: initializer)
-            else {
-                return
+            if let typeAnnotation = node.typeAnnotation,
+               let initializer = node.initializer?.value,
+               typeAnnotation.isRedundant(with: initializer) {
+                violations.append(typeAnnotation.positionAfterSkippingLeadingTrivia)
+                violationCorrections.append(ViolationCorrection(
+                    start: typeAnnotation.position,
+                    end: typeAnnotation.endPositionBeforeTrailingTrivia,
+                    replacement: ""
+                ))
             }
-            violations.append(typeAnnotation.positionAfterSkippingLeadingTrivia)
-            violationCorrections.append(ViolationCorrection(
-                start: typeAnnotation.position,
-                end: typeAnnotation.endPositionBeforeTrailingTrivia,
-                replacement: ""
-            ))
         }
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -46,7 +46,7 @@ struct RedundantTypeAnnotationRule: SwiftSyntaxCorrectableRule, OptInRule {
             """),
             Example("@IgnoreMe var a: Int = Int(5)", configuration: ["ignore_attributes": ["IgnoreMe"]]),
             Example("""
-            var a: Int = {
+            var a: Int {
                 @IgnoreMe let i: Int = Int(1)
                 return i
             }
@@ -92,7 +92,7 @@ struct RedundantTypeAnnotationRule: SwiftSyntaxCorrectableRule, OptInRule {
             Example("@DontIgnoreMe var a↓: Int = Int(5)", configuration: ["ignore_attributes": ["IgnoreMe"]]),
             Example("""
             @IgnoreMe
-            var a: Int = {
+            var a: Int {
                 let i↓: Int = Int(1)
                 return i
             }
@@ -140,14 +140,14 @@ struct RedundantTypeAnnotationRule: SwiftSyntaxCorrectableRule, OptInRule {
             Example("var num: Int = Int.random(0..<10)"): Example("var num = Int.random(0..<10)"),
             Example("""
             @IgnoreMe
-            var a: Int = {
+            var a: Int {
                 let i↓: Int = Int(1)
                 return i
             }
             """, configuration: ["ignore_attributes": ["IgnoreMe"]]):
             Example("""
             @IgnoreMe
-            var a: Int = {
+            var a: Int {
                 let i = Int(1)
                 return i
             }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -86,7 +86,8 @@ private extension VariableDeclSyntax {
         guard doesNotContainIgnoredAttributes,
               let binding = bindings.last,
               let typeAnnotation = binding.typeAnnotation,
-              let typeName = typeAnnotation.type.as(IdentifierTypeSyntax.self)?.typeName,
+              let type = typeAnnotation.type.as(IdentifierTypeSyntax.self),
+              let typeName = type.typeName,
               let initializer = binding.initializer?.value
         else {
             return false
@@ -96,7 +97,13 @@ private extension VariableDeclSyntax {
         // check if the base type is the same as the one from the type annotation.
         if let functionCall = initializer.as(FunctionCallExprSyntax.self),
            let calledExpression = functionCall.calledExpression.as(DeclReferenceExprSyntax.self) {
-            return calledExpression.baseName.text == typeName
+
+            // Parse generic arguments if there are any.
+            var genericArguments = ""
+            if let genericArgumentsClauseBytes = type.genericArguments?.trimmed.syntaxTextBytes {
+                genericArguments = String(bytes: genericArgumentsClauseBytes, encoding: .utf8) ?? ""
+            }
+            return calledExpression.baseName.text == typeName + genericArguments
         }
 
         // If the initializer is a member access (i.e. an enum case or a static property),

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -290,7 +290,7 @@ private extension TypeAnnotationSyntax {
 
     /// Checks if the given node is a member access (i.e. an enum case or a static property or function)
     /// and if so checks if the base type is the same as the given type name.
-    private func isMemberAccessViolation(node: some SyntaxProtocol, type: IdentifierTypeSyntax) -> Bool {
+    private func isMemberAccessViolation(node: ExprSyntax, type: IdentifierTypeSyntax) -> Bool {
         guard let memberAccess = node.as(MemberAccessExprSyntax.self),
               let base = memberAccess.base
         else {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -299,7 +299,7 @@ private extension VariableDeclSyntax {
     /// Checks if none of the attributes flagged as ignored in the configuration
     /// are set for this declaration
     func doesNotContainIgnoredAttributes(for configuration: RedundantTypeAnnotationConfiguration) -> Bool {
-        configuration.ignoredAnnotations.allSatisfy {
+        configuration.ignoreAttributes.allSatisfy {
             !attributes.contains(attributeNamed: $0)
         }
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -1,8 +1,8 @@
 import SwiftLintCore
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct RedundantTypeAnnotationRule: SwiftSyntaxCorrectableRule, OptInRule {
+@SwiftSyntaxRule(explicitRewriter: true)
+struct RedundantTypeAnnotationRule: OptInRule {
     var configuration = RedundantTypeAnnotationConfiguration()
 
     static let description = RuleDescription(
@@ -159,14 +159,6 @@ struct RedundantTypeAnnotationRule: SwiftSyntaxCorrectableRule, OptInRule {
             """)
         ]
     )
-
-    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
-        Rewriter(
-            configuration: configuration,
-            locationConverter: file.locationConverter,
-            disabledRegions: disabledRegions(file: file)
-        )
-    }
 }
 
 private extension RedundantTypeAnnotationRule {
@@ -195,17 +187,7 @@ private extension RedundantTypeAnnotationRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
-        private let configuration: ConfigurationType
-
-        init(configuration: ConfigurationType,
-             locationConverter: SourceLocationConverter,
-             disabledRegions: [SourceRange]) {
-            self.configuration = configuration
-
-            super.init(locationConverter: locationConverter, disabledRegions: disabledRegions)
-        }
-
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: PatternBindingSyntax) -> PatternBindingSyntax {
             guard node.parentDoesNotContainIgnoredAttributes(for: configuration),
                   let typeAnnotation = node.typeAnnotation,

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -189,7 +189,7 @@ extension RedundantTypeAnnotationRule {
 
             var direction↓: Direction = Direction.up
             """),
-            Example("var num: Int = Int.random(0..<10"),
+            Example("var num: Int = Int.random(0..<10")
         ],
         corrections: [
             Example("var url↓: URL = URL()"): Example("var url = URL()"),

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -6,6 +6,82 @@ import SwiftSyntax
 struct RedundantTypeAnnotationRule: OptInRule {
     var configuration = RedundantTypeAnnotationConfiguration()
 
+    static let description = RuleDescription(
+        identifier: "redundant_type_annotation",
+        name: "Redundant Type Annotation",
+        description: "Variables should not have redundant type annotation",
+        kind: .idiomatic,
+        nonTriggeringExamples: [
+            Example("var url = URL()"),
+            Example("var url: CustomStringConvertible = URL()"),
+            Example("@IBInspectable var color: UIColor = UIColor.white"),
+            Example("""
+            enum Direction {
+                case up
+                case down
+            }
+
+            var direction: Direction = .up
+            """),
+            Example("""
+            enum Direction {
+                case up
+                case down
+            }
+
+            var direction = Direction.up
+            """),
+            Example("var values: Set<Int> = Set([0, 1, 2])")
+        ],
+        triggeringExamples: [
+            Example("var url↓:URL=URL()"),
+            Example("var url↓:URL = URL(string: \"\")"),
+            Example("var url↓: URL = URL()"),
+            Example("let url↓: URL = URL()"),
+            Example("lazy var url↓: URL = URL()"),
+            Example("let url↓: URL = URL()!"),
+            Example("let alphanumerics↓: CharacterSet = CharacterSet.alphanumerics"),
+            Example("""
+            class ViewController: UIViewController {
+              func someMethod() {
+                let myVar↓: Int = Int(5)
+              }
+            }
+            """),
+            Example("var isEnabled↓: Bool = true"),
+            Example("""
+            enum Direction {
+                case up
+                case down
+            }
+
+            var direction↓: Direction = Direction.up
+            """),
+            Example("var num: Int = Int.random(0..<10")
+        ],
+        corrections: [
+            Example("var url↓: URL = URL()"): Example("var url = URL()"),
+            Example("let url↓: URL = URL()"): Example("let url = URL()"),
+            Example("let alphanumerics↓: CharacterSet = CharacterSet.alphanumerics"):
+                Example("let alphanumerics = CharacterSet.alphanumerics"),
+            Example("""
+            class ViewController: UIViewController {
+              func someMethod() {
+                let myVar↓: Int = Int(5)
+              }
+            }
+            """):
+            Example("""
+            class ViewController: UIViewController {
+              func someMethod() {
+                let myVar = Int(5)
+              }
+            }
+            """),
+            Example("var num: Int = Int.random(0..<10)"): Example("var num = Int.random(0..<10)")
+        ]
+    )
+
     func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
         Rewriter(
             configuration: configuration,
@@ -132,82 +208,4 @@ private extension VariableDeclSyntax {
 
         return base.baseName.text == typeName
     }
-}
-
-extension RedundantTypeAnnotationRule {
-    static let description = RuleDescription(
-        identifier: "redundant_type_annotation",
-        name: "Redundant Type Annotation",
-        description: "Variables should not have redundant type annotation",
-        kind: .idiomatic,
-        nonTriggeringExamples: [
-            Example("var url = URL()"),
-            Example("var url: CustomStringConvertible = URL()"),
-            Example("@IBInspectable var color: UIColor = UIColor.white"),
-            Example("""
-            enum Direction {
-                case up
-                case down
-            }
-
-            var direction: Direction = .up
-            """),
-            Example("""
-            enum Direction {
-                case up
-                case down
-            }
-
-            var direction = Direction.up
-            """),
-            Example("var values: Set<Int> = Set([0, 1, 2])")
-        ],
-        triggeringExamples: [
-            Example("var url↓:URL=URL()"),
-            Example("var url↓:URL = URL(string: \"\")"),
-            Example("var url↓: URL = URL()"),
-            Example("let url↓: URL = URL()"),
-            Example("lazy var url↓: URL = URL()"),
-            Example("let url↓: URL = URL()!"),
-            Example("let alphanumerics↓: CharacterSet = CharacterSet.alphanumerics"),
-            Example("""
-            class ViewController: UIViewController {
-              func someMethod() {
-                let myVar↓: Int = Int(5)
-              }
-            }
-            """),
-            Example("var isEnabled↓: Bool = true"),
-            Example("""
-            enum Direction {
-                case up
-                case down
-            }
-
-            var direction↓: Direction = Direction.up
-            """),
-            Example("var num: Int = Int.random(0..<10")
-        ],
-        corrections: [
-            Example("var url↓: URL = URL()"): Example("var url = URL()"),
-            Example("let url↓: URL = URL()"): Example("let url = URL()"),
-            Example("let alphanumerics↓: CharacterSet = CharacterSet.alphanumerics"):
-                Example("let alphanumerics = CharacterSet.alphanumerics"),
-            Example("""
-            class ViewController: UIViewController {
-              func someMethod() {
-                let myVar↓: Int = Int(5)
-              }
-            }
-            """):
-            Example("""
-            class ViewController: UIViewController {
-              func someMethod() {
-                let myVar = Int(5)
-              }
-            }
-            """),
-            Example("var num: Int = Int.random(0..<10)"): Example("var num = Int.random(0..<10)")
-        ]
-    )
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -1,9 +1,70 @@
 import Foundation
-import SourceKittenFramework
+import SwiftSyntax
+import SwiftLintCore
 
-struct RedundantTypeAnnotationRule: OptInRule, SubstitutionCorrectableRule {
+struct RedundantTypeAnnotationRule: SwiftSyntaxCorrectableRule, OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
+    func makeVisitor(file: SwiftLintFile) -> ViolationsSyntaxVisitor<ConfigurationType> {
+        Visitor(configuration: configuration, file: file)
+    }
+
+    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
+        Rewriter(
+            locationConverter: file.locationConverter,
+            disabledRegions: disabledRegions(file: file)
+        )
+    }
+}
+
+private extension RedundantTypeAnnotationRule {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
+        override func visitPost(_ node: VariableDeclSyntax) {
+            // Only take the last binding into account in case multiple
+            // variables are declared on a single line.
+            // If this binding has both a type annotation and an initializer
+            // it means the type annoation is considered redundant.
+            guard let binding = node.bindings.last,
+                  binding.typeAnnotation != nil,
+                  binding.initializer != nil,
+                  !node.attributes.contains(attributeNamed: "IBInspectable")
+            else {
+                return
+            }
+
+            violations.append(node.bindingSpecifier.positionAfterSkippingLeadingTrivia)
+        }
+    }
+
+    final class Rewriter: ViolationsSyntaxRewriter {
+        override func visit(_ node: VariableDeclSyntax) -> DeclSyntax {
+            guard let lastBinding = node.bindings.last,
+                  let typeAnnotation = lastBinding.typeAnnotation,
+                  let initializer = lastBinding.initializer
+            else {
+                return super.visit(node)
+            }
+
+            correctionPositions.append(typeAnnotation.positionAfterSkippingLeadingTrivia)
+
+            // Add a leading whitespace to the initializer sequence so there is one
+            // between the variable name and the '=' sign
+            let initializerWithLeadingWhitespace = initializer
+                .with(\.leadingTrivia, Trivia.space)
+            // Set the type annotation of the last binding to nil to remove redundancy
+            let lastBindingWithoutTypeAnnotation = lastBinding
+                .with(\.typeAnnotation, nil)
+                .with(\.initializer, initializerWithLeadingWhitespace)
+
+            return super.visit(node.with(
+                \.bindings,
+                node.bindings.dropLast() + [lastBindingWithoutTypeAnnotation]
+            ))
+        }
+    }
+}
+
+extension RedundantTypeAnnotationRule {
     static let description = RuleDescription(
         identifier: "redundant_type_annotation",
         name: "Redundant Type Annotation",
@@ -75,94 +136,4 @@ struct RedundantTypeAnnotationRule: OptInRule, SubstitutionCorrectableRule {
             """)
         ]
     )
-
-    func validate(file: SwiftLintFile) -> [StyleViolation] {
-        return violationRanges(in: file).map { range in
-            StyleViolation(
-                ruleDescription: Self.description,
-                severity: configuration.severity,
-                location: Location(file: file, characterOffset: range.location)
-            )
-        }
-    }
-
-    func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
-        return (violationRange, "")
-    }
-
-    private let typeAnnotationPattern: String
-    private let expressionPattern: String
-
-    init() {
-        typeAnnotationPattern =
-            ":\\s*" + // semicolon and any number of whitespaces
-            "\\w+"    // type name
-
-        expressionPattern =
-            "(var|let)" + // var or let
-            "\\s+" +      // at least single whitespace
-            "\\w+" +      // variable name
-            "\\s*" +      // possible whitespaces
-            typeAnnotationPattern +
-            "\\s*=\\s*" + // assignment operator with possible surrounding whitespaces
-            "\\w+" +      // assignee name (type or keyword)
-            "[\\(\\.]?"   // possible opening parenthesis or dot
-    }
-
-    func violationRanges(in file: SwiftLintFile) -> [NSRange] {
-        return file
-            .match(pattern: expressionPattern)
-            .filter {
-                $0.1 == [.keyword, .identifier, .typeidentifier, .identifier] ||
-                $0.1 == [.keyword, .identifier, .typeidentifier, .keyword]
-            }
-            .filter { !isFalsePositive(file: file, range: $0.0) }
-            .filter { !isIBInspectable(file: file, range: $0.0) }
-            .compactMap {
-                file.match(pattern: typeAnnotationPattern,
-                           excludingSyntaxKinds: SyntaxKind.commentAndStringKinds, range: $0.0).first
-            }
-    }
-
-    private func isFalsePositive(file: SwiftLintFile, range: NSRange) -> Bool {
-        guard let typeNames = getPartsOfExpression(in: file, range: range) else { return false }
-
-        let lhs = typeNames.variableTypeName
-        let rhs = typeNames.assigneeName
-
-        if lhs == rhs || (lhs == "Bool" && (rhs == "true" || rhs == "false")) {
-            return false
-        }
-        return true
-    }
-
-    private func getPartsOfExpression(
-        in file: SwiftLintFile, range: NSRange
-    ) -> (variableTypeName: String, assigneeName: String)? {
-        let substring = file.stringView.substring(with: range)
-        let components = substring.components(separatedBy: "=")
-
-        guard
-            components.count == 2,
-            let variableTypeName = components[0].components(separatedBy: ":").last?.trimmingCharacters(in: .whitespaces)
-        else {
-            return nil
-        }
-
-        let charactersToTrimFromRhs = CharacterSet(charactersIn: ".(").union(.whitespaces)
-        let assigneeName = components[1].trimmingCharacters(in: charactersToTrimFromRhs)
-
-        return (variableTypeName, assigneeName)
-    }
-
-    private func isIBInspectable(file: SwiftLintFile, range: NSRange) -> Bool {
-        guard
-            let byteRange = file.stringView.NSRangeToByteRange(start: range.location, length: range.length),
-            let dict = file.structureDictionary.structures(forByteOffset: byteRange.location).last,
-            let kind = dict.declarationKind,
-            SwiftDeclarationKind.variableKinds.contains(kind)
-        else { return false }
-
-        return dict.enclosedSwiftAttributes.contains(.ibinspectable)
-    }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -170,7 +170,7 @@ private extension RedundantTypeAnnotationRule {
             guard node.parentDoesNotContainIgnoredAttributes(for: configuration),
                   let typeAnnotation = node.typeAnnotation,
                   let initializer = node.initializer?.value,
-                  typeAnnotation.isRedundant(for: configuration, initializerExpr: initializer)
+                  typeAnnotation.isRedundant(with: initializer)
             else {
                 return
             }
@@ -181,7 +181,7 @@ private extension RedundantTypeAnnotationRule {
         override func visitPost(_ node: OptionalBindingConditionSyntax) {
             guard let typeAnnotation = node.typeAnnotation,
                   let initializer = node.initializer?.value,
-                  typeAnnotation.isRedundant(for: configuration, initializerExpr: initializer)
+                  typeAnnotation.isRedundant(with: initializer)
             else {
                 return
             }
@@ -191,9 +191,9 @@ private extension RedundantTypeAnnotationRule {
     }
 
     final class Rewriter: ViolationsSyntaxRewriter {
-        private let configuration: RedundantTypeAnnotationConfiguration
+        private let configuration: ConfigurationType
 
-        init(configuration: RedundantTypeAnnotationConfiguration,
+        init(configuration: ConfigurationType,
              locationConverter: SourceLocationConverter,
              disabledRegions: [SourceRange]) {
             self.configuration = configuration
@@ -205,7 +205,7 @@ private extension RedundantTypeAnnotationRule {
             guard node.parentDoesNotContainIgnoredAttributes(for: configuration),
                   let typeAnnotation = node.typeAnnotation,
                   let initializer = node.initializer,
-                  typeAnnotation.isRedundant(for: configuration, initializerExpr: initializer.value)
+                  typeAnnotation.isRedundant(with: initializer.value)
             else {
                 return super.visit(node)
             }
@@ -226,7 +226,7 @@ private extension RedundantTypeAnnotationRule {
         override func visit(_ node: OptionalBindingConditionSyntax) -> OptionalBindingConditionSyntax {
             guard let typeAnnotation = node.typeAnnotation,
                   let initializer = node.initializer,
-                  typeAnnotation.isRedundant(for: configuration, initializerExpr: initializer.value)
+                  typeAnnotation.isRedundant(with: initializer.value)
             else {
                 return super.visit(node)
             }
@@ -247,8 +247,7 @@ private extension RedundantTypeAnnotationRule {
 }
 
 private extension TypeAnnotationSyntax {
-    func isRedundant(for configuration: RedundantTypeAnnotationConfiguration,
-                     initializerExpr: ExprSyntax) -> Bool {
+    func isRedundant(with initializerExpr: ExprSyntax) -> Bool {
         // Extract type and type name from type annotation
         guard let type = type.as(IdentifierTypeSyntax.self) else {
             return false

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -97,7 +97,6 @@ private extension VariableDeclSyntax {
         // check if the base type is the same as the one from the type annotation.
         if let functionCall = initializer.as(FunctionCallExprSyntax.self),
            let calledExpression = functionCall.calledExpression.as(DeclReferenceExprSyntax.self) {
-
             // Parse generic arguments if there are any.
             var genericArguments = ""
             if let genericArgumentsClauseBytes = type.genericArguments?.trimmed.syntaxTextBytes {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -35,7 +35,9 @@ private extension RedundantTypeAnnotationRule {
     final class Rewriter: ViolationsSyntaxRewriter {
         private let configuration: RedundantTypeAnnotationConfiguration
 
-        init(configuration: RedundantTypeAnnotationConfiguration, locationConverter: SourceLocationConverter, disabledRegions: [SourceRange]) {
+        init(configuration: RedundantTypeAnnotationConfiguration,
+             locationConverter: SourceLocationConverter,
+             disabledRegions: [SourceRange]) {
             self.configuration = configuration
 
             super.init(locationConverter: locationConverter, disabledRegions: disabledRegions)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -88,9 +88,13 @@ private extension VariableDeclSyntax {
               let typeAnnotation = binding.typeAnnotation,
               let type = typeAnnotation.type.as(IdentifierTypeSyntax.self),
               let typeName = type.typeName,
-              let initializer = binding.initializer?.value
+              var initializer = binding.initializer?.value
         else {
             return false
+        }
+
+        if let forceUnwrap = initializer.as(ForceUnwrapExprSyntax.self) {
+            initializer = forceUnwrap.expression
         }
 
         // If the initializer is a function call (generally a constructor or static builder),
@@ -167,6 +171,7 @@ extension RedundantTypeAnnotationRule {
             Example("var url↓: URL = URL()"),
             Example("let url↓: URL = URL()"),
             Example("lazy var url↓: URL = URL()"),
+            Example("let url↓: URL = URL()!"),
             Example("let alphanumerics↓: CharacterSet = CharacterSet.alphanumerics"),
             Example("""
             class ViewController: UIViewController {
@@ -184,7 +189,7 @@ extension RedundantTypeAnnotationRule {
 
             var direction↓: Direction = Direction.up
             """),
-            Example("var num: Int = Int.random(0..<10")
+            Example("var num: Int = Int.random(0..<10"),
         ],
         corrections: [
             Example("var url↓: URL = URL()"): Example("var url = URL()"),

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -158,7 +158,8 @@ extension RedundantTypeAnnotationRule {
             }
 
             var direction = Direction.up
-            """)
+            """),
+            Example("var values: Set<Int> = Set([0, 1, 2])")
         ],
         triggeringExamples: [
             Example("var url↓:URL=URL()"),
@@ -182,7 +183,8 @@ extension RedundantTypeAnnotationRule {
             }
 
             var direction↓: Direction = Direction.up
-            """)
+            """),
+            Example("var num: Int = Int.random(0..<10")
         ],
         corrections: [
             Example("var url↓: URL = URL()"): Example("var url = URL()"),
@@ -202,7 +204,8 @@ extension RedundantTypeAnnotationRule {
                 let myVar = Int(5)
               }
             }
-            """)
+            """),
+            Example("var num: Int = Int.random(0..<10)"): Example("var num = Int.random(0..<10)")
         ]
     )
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -89,21 +89,21 @@ struct RedundantTypeAnnotationRule: SwiftSyntaxCorrectableRule, OptInRule {
         corrections: [
             Example("var url↓: URL = URL()"): Example("var url = URL()"),
             Example("let url↓: URL = URL()"): Example("let url = URL()"),
-            Example("var one: Int = 1, two↓: Int = Int(5), three: Int"): 
+            Example("var one: Int = 1, two↓: Int = Int(5), three: Int"):
                 Example("var one: Int = 1, two = Int(5), three: Int"),
-            Example("guard let url↓: URL = URL() else { return }"): 
+            Example("guard let url↓: URL = URL() else { return }"):
                 Example("guard let url = URL() else { return }"),
-            Example("if let url↓: URL = URL() { return }"): 
+            Example("if let url↓: URL = URL() { return }"):
                 Example("if let url = URL() { return }"),
             Example("let alphanumerics↓: CharacterSet = CharacterSet.alphanumerics"):
                 Example("let alphanumerics = CharacterSet.alphanumerics"),
-            Example("var set↓: Set<Int> = Set<Int>([])"): 
+            Example("var set↓: Set<Int> = Set<Int>([])"):
                 Example("var set = Set<Int>([])"),
-            Example("var set↓: Set<Int> = Set<Int>.init([])"): 
+            Example("var set↓: Set<Int> = Set<Int>.init([])"):
                 Example("var set = Set<Int>.init([])"),
-            Example("var set↓: Set = Set<Int>([])"): 
+            Example("var set↓: Set = Set<Int>([])"):
                 Example("var set = Set<Int>([])"),
-            Example("var set↓: Set = Set<Int>.init([])"): 
+            Example("var set↓: Set = Set<Int>.init([])"):
                 Example("var set = Set<Int>.init([])"),
             Example("guard var set↓: Set<Int> = Set<Int>([]) else { return }"):
                 Example("guard var set = Set<Int>([]) else { return }"),

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -108,9 +108,15 @@ private extension VariableDeclSyntax {
             return base.baseName.text == typeName
         }
 
+        // If the initializer is a boolean expression, we consider using the `Bool` type
+        // annotation as redundant.
+        if initializer.as(BooleanLiteralExprSyntax.self) != nil {
+            return typeName == "Bool"
+        }
+
         // In other scenarios, it means the initializer is a literal so the type annoation
-        // is considered redundant.
-        return true
+        // is not considered redundant.
+        return false
     }
 }
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/RedundantTypeAnnotationConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/RedundantTypeAnnotationConfiguration.swift
@@ -1,0 +1,11 @@
+import SwiftLintCore
+
+@AutoApply
+struct RedundantTypeAnnotationConfiguration: SeverityBasedRuleConfiguration {
+    typealias Parent = RedundantTypeAnnotationRule
+
+    @ConfigurationElement(key: "severity")
+    var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement(key: "excluded")
+    var ignoredAnnotations = Set<String>(["IBInspectable"])
+}

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/RedundantTypeAnnotationConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/RedundantTypeAnnotationConfiguration.swift
@@ -6,6 +6,6 @@ struct RedundantTypeAnnotationConfiguration: SeverityBasedRuleConfiguration {
 
     @ConfigurationElement(key: "severity")
     var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    @ConfigurationElement(key: "ignored_annotations")
-    var ignoredAnnotations = Set<String>(["IBInspectable"])
+    @ConfigurationElement(key: "ignore_attributes")
+    var ignoreAttributes = Set<String>(["IBInspectable"])
 }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/RedundantTypeAnnotationConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/RedundantTypeAnnotationConfiguration.swift
@@ -6,6 +6,6 @@ struct RedundantTypeAnnotationConfiguration: SeverityBasedRuleConfiguration {
 
     @ConfigurationElement(key: "severity")
     var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    @ConfigurationElement(key: "excluded")
+    @ConfigurationElement(key: "ignored_annotations")
     var ignoredAnnotations = Set<String>(["IBInspectable"])
 }

--- a/Tests/IntegrationTests/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/default_rule_configurations.yml
@@ -456,6 +456,7 @@ redundant_string_enum_value:
   severity: warning
 redundant_type_annotation:
   severity: warning
+  ignore_attributes: ["IBInspectable"]
 redundant_void_return:
   severity: warning
   include_closures: true


### PR DESCRIPTION
Hi, first time contributing here so just let me know if something is wrong or missing in my PR 🙂 

This PR resolves #5366 by adding a new `ignored_annotations` configuration to this rule that accepts a set of strings listing annotations that should disable this rule for properties that are marked with it. Currently this is already done arbitrarily for `@IBInspectable` but now it is configurable. To solve the linked issue the configuration would be:

```yaml
redundant_type_annotations:
  ignored_attributes:
    - Parameter
```

This configuration still defaults to only `IBDesignable` for retrocompatibility.

And, while I was at it and as @SimplyDanny suggested in the issue's comments, I took the opportunity to rewrite this rule using SwiftSyntax. Let me know what you think!