### PR TITLE
Add a new option to `switch_case_alignment` rule to ignore switch statements written in a single line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@
 
 #### Enhancements
 
-* Add a new `ignore_one_liners` option to `switch_case_alignment` rule to ignore switch statements written in a single line.  
+* Add new `ignore_one_liners` option to `switch_case_alignment` 
+  rule to ignore switch statements written in a single line.  
   [tonell-m](https://github.com/tonell-m)
   [#5373](https://github.com/realm/SwiftLint/issues/5373)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 #### Enhancements
 
+* Add a new `ignore_one_liners` option to `switch_case_alignment` rule to ignore switch statements written in a single line.  
+  [tonell-m](https://github.com/tonell-m)
+  [#5373](https://github.com/realm/SwiftLint/issues/5373)
+
 * Add new `one_declaration_per_file` rule that allows only a
   single class/struct/enum/protocol declaration per file.
   Extensions are an exception; more than one is allowed.  

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SwitchCaseAlignmentConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SwitchCaseAlignmentConfiguration.swift
@@ -8,4 +8,6 @@ struct SwitchCaseAlignmentConfiguration: SeverityBasedRuleConfiguration {
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "indented_cases")
     private(set) var indentedCases = false
+    @ConfigurationElement(key: "ignore_one_liners")
+    private(set) var ignoreOneLiners = false
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SwitchCaseAlignmentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SwitchCaseAlignmentRule.swift
@@ -43,14 +43,22 @@ struct SwitchCaseAlignmentRule: Rule {
 extension SwitchCaseAlignmentRule {
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: SwitchExprSyntax) {
-            let closingBracePosition = node.rightBrace.positionAfterSkippingLeadingTrivia
-            let closingBraceColumn = locationConverter.location(for: closingBracePosition).column
             guard node.cases.isNotEmpty,
                 let firstCasePosition = node.cases.first?.positionAfterSkippingLeadingTrivia
             else {
                 return
             }
 
+            let closingBracePosition = node.rightBrace.positionAfterSkippingLeadingTrivia
+            let closingBraceLocation = locationConverter.location(for: closingBracePosition)
+            let openingBracePosition = node.leftBrace.positionAfterSkippingLeadingTrivia
+            let openingBraceLocation = locationConverter.location(for: openingBracePosition)
+
+            if configuration.ignoreOneLiners && openingBraceLocation.line == closingBraceLocation.line {
+                return
+            }
+
+            let closingBraceColumn = closingBraceLocation.column
             let firstCaseColumn = locationConverter.location(for: firstCasePosition).column
 
             for `case` in node.cases where `case`.is(SwitchCaseSyntax.self) {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SwitchCaseAlignmentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SwitchCaseAlignmentRule.swift
@@ -247,24 +247,24 @@ extension SwitchCaseAlignmentRule {
                 ),
                 Example("""
                 switch i {
-                case .x: 1 default: 0 }
+                \(violationMarker)case .x: 1 \(violationMarker)default: 0 }
                 """, configuration: ["ignore_one_liners": true]),
                 Example("""
-                switch i { case .x: 1 default: 0
+                switch i { \(violationMarker)case .x: 1 \(violationMarker)default: 0
                 }
                 """, configuration: ["ignore_one_liners": true]),
                 Example("""
                 switch i
-                { case .x: 1 default: 0 }
+                { \(violationMarker)case .x: 1 \(violationMarker)default: 0 }
                 """, configuration: ["ignore_one_liners": true]),
                 Example("""
                 let a = switch i {
-                case .x: 1 default: 0
+                case .x: 1 \(violationMarker)default: 0
                 }
                 """, configuration: ["ignore_one_liners": true]),
                 Example("""
                 let a = switch i {
-                case .x: 1 default: 0 }
+                \(violationMarker)case .x: 1 \(violationMarker)default: 0 }
                 """, configuration: ["ignore_one_liners": true])
             ]
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SwitchCaseAlignmentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SwitchCaseAlignmentRule.swift
@@ -93,11 +93,14 @@ extension SwitchCaseAlignmentRule {
         }
 
         var triggeringExamples: [Example] {
-            return (indentedCasesOption ? nonIndentedCases : indentedCases) + invalidCases
+            return (indentedCasesOption ? nonIndentedCases : indentedCases)
+                + invalidCases
+                + [getOneLinerExample(ignoreOneLiners: false)]
         }
 
         var nonTriggeringExamples: [Example] {
             return indentedCasesOption ? indentedCases : nonIndentedCases
+                + [getOneLinerExample(ignoreOneLiners: true)]
         }
 
         private var indentedCases: [Example] {
@@ -223,6 +226,15 @@ extension SwitchCaseAlignmentRule {
                 }
                 """)
             ]
+        }
+
+        private func getOneLinerExample(ignoreOneLiners: Bool) -> Example {
+            let marker = ignoreOneLiners ? "" : violationMarker
+
+            return Example(
+                "switch i { \(marker)case .x: 1 \(marker)default: 0 }",
+                configuration: ["ignore_one_liners": ignoreOneLiners]
+            )
         }
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SwitchCaseAlignmentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SwitchCaseAlignmentRule.swift
@@ -265,7 +265,7 @@ extension SwitchCaseAlignmentRule {
                 Example("""
                 let a = switch i {
                 case .x: 1 default: 0 }
-                """, configuration: ["ignore_one_liners": true]),
+                """, configuration: ["ignore_one_liners": true])
             ]
         }
     }


### PR DESCRIPTION
As discussed in #5373 this PR adds a new `ignore_one_liners` option to the `switch_case_alignment` rule to allow this new one liner syntax for switch statements:

```swift
switch s { case .x: a default: b }
```

This option is still disabled by default.