### PR TITLE
Add 5.9.2 to Swift version tests

### DIFF
--- a/Tests/SwiftLintFrameworkTests/SwiftVersionTests.swift
+++ b/Tests/SwiftLintFrameworkTests/SwiftVersionTests.swift
@@ -5,6 +5,8 @@ final class SwiftVersionTests: SwiftLintTestCase {
     func testDetectSwiftVersion() {
 #if compiler(>=6.0.0)
         let version = "6.0.0"
+#elseif compiler(>=5.9.2)
+        let version = "5.9.2"
 #elseif compiler(>=5.9.1)
         let version = "5.9.1"
 #elseif compiler(>=5.9.0)


### PR DESCRIPTION
`make docker_test` now passes
Docker version 24.0.6
Swift version 5.9.2 (swift-5.9.2-RELEASE)