### PR TITLE
Add destination to xcodebuild test instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ with Swift Package Manager on Linux. When contributing code changes, please
 ensure that all three supported build methods continue to work and pass tests.
 
 ```shell
-$ xcodebuild -scheme swiftlint test
+$ xcodebuild -scheme swiftlint test -destination 'platform=macOS'
 $ swift test
 $ make docker_test
 ```


### PR DESCRIPTION
Without `-destination`:
```
SwiftLint on branch improve-readme [$] via 💎 ruby-3.1.0 on 🐳 v24.0.6 
➜ xcodebuild -scheme swiftlint test                              
Command line invocation:
    /Applications/Xcode_15.0.1.app/Contents/Developer/usr/bin/xcodebuild -scheme swiftlint test
...
xcodebuild: error: Building a Swift package requires that a destination is provided using the "-destination" option. The "-showdestinations" option can be used to list the available destinations.
```

Xcode 15.0.1
Build version 15A507