### PR TITLE
Add Accessibility Font Size Rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,10 @@
 
 #### Enhancements
 
+* Add `Accessibility Font Size` rule to warn if a SwiftUI Text
+  has a fixed font size.  
+  [MartijnAmbagtsheer](https://github.com/MartijnAmbagtsheer)
+
 * Add `only` configuration option to `todo` rule which allows to specify
   whether the rule shall trigger on `TODO`s, `FIXME`s or both.  
   [gibachan](https://github.com/gibachan)

--- a/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
+++ b/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
@@ -3,6 +3,7 @@
 
 /// The rule list containing all available rules built into SwiftLint.
 public let builtInRules: [any Rule.Type] = [
+    AccessibilityFontSizeRule.self,
     AccessibilityLabelForImageRule.self,
     AccessibilityTraitForButtonRule.self,
     AnonymousArgumentInMultilineClosureRule.self,

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityFontScaleRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityFontScaleRule.swift
@@ -1,0 +1,101 @@
+import SourceKittenFramework
+
+struct AccessibilityFontSizeRule: ASTRule, OptInRule {
+    var configuration = SeverityConfiguration<Self>(.warning)
+
+    static let description = RuleDescription(
+        identifier: "accessibility_font_size",
+        name: "Accessibility Font Size",
+        description: """
+            Text may not have a fixed font size
+        """,
+        kind: .lint,
+        minSwiftVersion: .fiveDotOne,
+        nonTriggeringExamples: AccessibilityLabelForImageRuleExamples.nonTriggeringExamples,
+        triggeringExamples: AccessibilityLabelForImageRuleExamples.triggeringExamples
+    )
+
+    // MARK: AST Rule
+
+    func validate(file: SwiftLintFile, kind: SwiftDeclarationKind,
+                  dictionary: SourceKittenDictionary) -> [StyleViolation] {
+        // Only proceed to check View structs.
+        guard (( kind == .struct && dictionary.inheritedTypes.contains("View")) || kind == .extension),
+            dictionary.substructure.isNotEmpty else {
+                return []
+        }
+
+        return findTextViolations(file: file, substructure: dictionary.substructure)
+    }
+
+    /// Recursively check a file for image violations, and return all such violations.
+    private func findTextViolations(file: SwiftLintFile, substructure: [SourceKittenDictionary]) -> [StyleViolation] {
+        var violations = [StyleViolation]()
+        for dictionary in substructure {
+            guard let offset: ByteCount = dictionary.offset else {
+                continue
+            }
+
+            // If it's image, and does not hide from accessibility or provide a label, it's a violation.
+            if dictionary.isText && dictionary.hasStrictFontModifier(in: file) {
+                violations.append(
+                    StyleViolation(ruleDescription: Self.description,
+                                   severity: configuration.severity,
+                                   location: Location(file: file, byteOffset: offset))
+                )
+            }
+
+            // If dictionary did not represent an Image, recursively check substructure,
+            // unless it's a container that hides its children from accessibility or is labeled.
+//            else if dictionary.substructure.isNotEmpty {
+//                if dictionary.hasAccessibilityHiddenModifier(in: file) ||
+//                    dictionary.hasAccessibilityElementChildrenIgnoreModifier(in: file) ||
+//                    dictionary.hasStrictFontModifier(in: file) {
+//                    continue
+//                }
+//
+//                violations.append(contentsOf: findTextViolations(file: file, substructure: dictionary.substructure))
+//            }
+        }
+
+        return violations
+    }
+}
+
+// MARK: SourceKittenDictionary extensions
+
+private extension SourceKittenDictionary {
+    /// Whether or not the dictionary represents a SwiftUI Image.
+    /// Currently only accounts for SwiftUI image literals and not instance variables.
+    var isText: Bool {
+        // Image literals will be reported as calls to the initializer.
+        guard expressionKind == .call else {
+            return false
+        }
+
+        if name == "Text" || name == "SwiftUI.Text" {
+            return true
+        }
+
+        return substructure.contains(where: { $0.isText })
+    }
+
+    /// Whether or not the dictionary represents a SwiftUI View with an `accesibilityLabel(_:)`
+    /// or `accessibility(label:)` modifier.
+    func hasStrictFontModifier(in file: SwiftLintFile) -> Bool {
+        return hasModifier(
+            anyOf: [
+                SwiftUIModifier(
+                    name: "font",
+                    arguments: [
+                        .init(
+                            name: "", 
+                            values: [".system"],
+                            matchType: .prefix)
+                    ]
+                ),
+            ],
+            in: file
+        )
+    }
+}

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityFontSizeRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityFontSizeRule.swift
@@ -52,28 +52,38 @@ struct AccessibilityFontSizeRule: ASTRule, OptInRule {
             }
 
             guard dictionary.isText else {
+                if dictionary.substructure.isNotEmpty {
+                    violations.append(
+                        contentsOf: findTextViolations(
+                            file: file,
+                            substructure: dictionary.substructure
+                        )
+                    )
+                }
+
                 continue
             }
 
             if checkForViolations(dictionaries: [dictionary], in: file) {
-                violations.append(getViolation(in: file, onOffset: offset))
+                violations.append(
+                    StyleViolation(
+                        ruleDescription: Self.description,
+                        severity: configuration.severity,
+                        location: Location(file: file, byteOffset: offset)
+                    )
+                )
             }
         }
 
         return violations
     }
 
-    private func getViolation(in file: SwiftLintFile, onOffset offset: ByteCount) -> StyleViolation {
-        return StyleViolation(
-            ruleDescription: Self.description,
-            severity: configuration.severity,
-            location: Location(file: file, byteOffset: offset)
-        )
-    }
-
     private func checkForViolations(dictionaries: [SourceKittenDictionary], in file: SwiftLintFile) -> Bool {
         for dictionary in dictionaries {
-            if dictionary.hasSystemFontModifier(in: file) || dictionary.hasCustomFontModifierWithFixedSize(in: file) {
+            if (
+                dictionary.hasSystemFontModifier(in: file) ||
+                dictionary.hasCustomFontModifierWithFixedSize(in: file)
+            ) {
                 return true
             }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityFontSizeRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityFontSizeRule.swift
@@ -96,7 +96,7 @@ private extension SourceKittenDictionary {
                     arguments: [
                         .init(
                             name: "",
-                            values: [".system"],
+                            values: [".system("],
                             matchType: .prefix)
                     ]
                 )

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityFontSizeRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityFontSizeRule.swift
@@ -65,9 +65,7 @@ struct AccessibilityFontSizeRule: ASTRule, OptInRule {
         for dictionary in dictionaries {
             if dictionary.hasSystemFontModifier(in: file) || dictionary.hasCustomFontModifierWithFixedSize(in: file) {
                 return true
-            }
-
-            else if dictionary.substructure.isNotEmpty {
+            } else if dictionary.substructure.isNotEmpty {
                 if checkForViolations(dictionaries: dictionary.substructure, in: file) {
                     return true
                 }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityFontSizeRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityFontSizeRule.swift
@@ -59,7 +59,7 @@ struct AccessibilityFontSizeRule: ASTRule, OptInRule {
                 )
             }
 
-            // If dictionary did not represent an Image, recursively check substructure,
+            // If dictionary did not represent an Text, recursively check substructure,
             // unless it's a container that hides its children from accessibility or is labeled.
             else if dictionary.substructure.isNotEmpty && dictionary.hasStrictFontModifier(in: file) {
                 violations.append(contentsOf: findTextViolations(file: file, substructure: dictionary.substructure))
@@ -73,10 +73,10 @@ struct AccessibilityFontSizeRule: ASTRule, OptInRule {
 // MARK: SourceKittenDictionary extensions
 
 private extension SourceKittenDictionary {
-    /// Whether or not the dictionary represents a SwiftUI Image.
-    /// Currently only accounts for SwiftUI image literals and not instance variables.
+    /// Whether or not the dictionary represents a SwiftUI Text.
+    /// Currently only accounts for SwiftUI text literals and not instance variables.
     var isText: Bool {
-        // Image literals will be reported as calls to the initializer.
+        // Text literals will be reported as calls to the initializer.
         guard expressionKind == .call else {
             return false
         }
@@ -88,8 +88,7 @@ private extension SourceKittenDictionary {
         return substructure.contains(where: { $0.isText })
     }
 
-    /// Whether or not the dictionary represents a SwiftUI View with an `accesibilityLabel(_:)`
-    /// or `accessibility(label:)` modifier.
+    /// Whether or not the dictionary represents a SwiftUI View with an `font(.system())` modifier.
     func hasStrictFontModifier(in file: SwiftLintFile) -> Bool {
         return hasModifier(
             anyOf: [

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityFontSizeRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityFontSizeRule.swift
@@ -43,7 +43,7 @@ struct AccessibilityFontSizeRule: ASTRule, OptInRule {
         return findTextViolations(file: file, substructure: dictionary.substructure)
     }
 
-    /// Recursively check a file for image violations, and return all such violations.
+    /// Recursively check a file for font violations, and return all such violations.
     private func findTextViolations(file: SwiftLintFile, substructure: [SourceKittenDictionary]) -> [StyleViolation] {
         var violations = [StyleViolation]()
         for dictionary in substructure {
@@ -59,9 +59,8 @@ struct AccessibilityFontSizeRule: ASTRule, OptInRule {
                 )
             }
 
-            // If dictionary did not represent an Text, recursively check substructure,
-            // unless it's a container that hides its children from accessibility or is labeled.
-            else if dictionary.substructure.isNotEmpty && dictionary.hasStrictFontModifier(in: file) {
+            // If dictionary did not represent an Text, recursively check substructure.
+            else if dictionary.substructure.isNotEmpty {
                 violations.append(contentsOf: findTextViolations(file: file, substructure: dictionary.substructure))
             }
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityFontSizeRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityFontSizeRule.swift
@@ -63,10 +63,7 @@ struct AccessibilityFontSizeRule: ASTRule, OptInRule {
 
     private func checkForViolations(dictionaries: [SourceKittenDictionary], in file: SwiftLintFile) -> Bool {
         for dictionary in dictionaries {
-            if (
-                dictionary.hasSystemFontModifier(in: file) ||
-                dictionary.hasCustomFontModifierWithFixedSize(in: file)
-            ) {
+            if dictionary.hasSystemFontModifier(in: file) || dictionary.hasCustomFontModifierWithFixedSize(in: file) {
                 return true
             }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityFontSizeRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityFontSizeRuleExamples.swift
@@ -1,0 +1,155 @@
+internal struct AccessibilityFontSizeRuleExamples {
+    static let nonTriggeringExamples = [
+        Example("""
+        struct TestView: View {
+            var body: some View {
+                Text("Hello World!")
+            }
+        }
+        """),
+        Example("""
+        struct TestView: View {
+            var body: some View {
+                Text("Hello World!")
+                    .font(.system(.largeTitle))
+            }
+        }
+        """),
+        Example("""
+        struct TestView: View {
+            var body: some View {
+                TextField("Username", text: .constant(""))
+                    .font(.system(.largeTitle))
+            }
+        }
+        """),
+        Example("""
+        struct TestView: View {
+            var body: some View {
+                SecureField("Password", text: .constant(""))
+                    .font(.system(.largeTitle))
+            }
+        }
+        """),
+        Example("""
+        struct TestView: View {
+            var body: some View {
+                Button("Login") {}
+                    .font(.system(.largeTitle))
+            }
+        }
+        """)
+    ]
+
+    static let triggeringExamples = [
+        Example("""
+        struct TestView: View {
+            var body: some View {
+                ↓Text("Hello World!")
+                    .font(.system(size: 20))
+            }
+        }
+        """),
+        Example("""
+        struct TestView: View {
+            var body: some View {
+                ↓Text("Hello World!")
+                    .italic()
+                    .font(.system(size: 20))
+            }
+        }
+        """),
+        Example("""
+        struct TestView: View {
+            var body: some View {
+                ↓TextField("Username", text: .constant(""))
+                    .font(.system(size: 15))
+            }
+        }
+        """),
+        Example("""
+        struct TestView: View {
+            var body: some View {
+                ↓SecureField("Password", text: .constant(""))
+                    .font(.system(size: 15))
+            }
+        }
+        """),
+        Example("""
+        struct TestView: View {
+            var body: some View {
+                ↓Button("Login") {}
+                    .font(.system(size: 15))
+            }
+        }
+        """),
+        Example("""
+        struct TestView: View {
+            var body: some View {
+                ↓Text("Hello World!")
+                    .font(.custom("Havana", fixedSize: 16))
+            }
+        }
+        """),
+        Example("""
+        struct TestView: View {
+            var body: some View {
+                ↓Text("Hello World!")
+                    .italic()
+                    .font(.custom("Havana", fixedSize: 16))
+            }
+        }
+        """),
+        Example("""
+        struct TestView: View {
+            var body: some View {
+                ↓TextField("Username", text: .constant(""))
+                    .font(.custom("Havana", fixedSize: 16))
+            }
+        }
+        """),
+        Example("""
+        struct TestView: View {
+            var body: some View {
+                ↓TextField("Username", text: .constant(""))
+                    .italic()
+                    .font(.custom("Havana", fixedSize: 16))
+            }
+        }
+        """),
+        Example("""
+        struct TestView: View {
+            var body: some View {
+                ↓SecureField("Password", text: .constant(""))
+                    .font(.custom("Havana", fixedSize: 16))
+            }
+        }
+        """),
+        Example("""
+        struct TestView: View {
+            var body: some View {
+                ↓SecureField("Password", text: .constant(""))
+                    .italic()
+                    .font(.custom("Havana", fixedSize: 16))
+            }
+        }
+        """),
+        Example("""
+        struct TestView: View {
+            var body: some View {
+                ↓Button("Login") {}
+                    .font(.custom("Havana", fixedSize: 16))
+            }
+        }
+        """),
+        Example("""
+        struct TestView: View {
+            var body: some View {
+                ↓Button("Login") {}
+                    .italic()
+                    .font(.custom("Havana", fixedSize: 16))
+            }
+        }
+        """)
+    ]
+}

--- a/Tests/GeneratedTests/GeneratedTests.swift
+++ b/Tests/GeneratedTests/GeneratedTests.swift
@@ -8,6 +8,12 @@ import SwiftLintTestHelpers
 // swiftlint:disable:next blanket_disable_command
 // swiftlint:disable file_length single_test_class type_name
 
+class AccessibilityFontSizeRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(AccessibilityFontSizeRule.description)
+    }
+}
+
 class AccessibilityLabelForImageRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(AccessibilityLabelForImageRule.description)


### PR DESCRIPTION
The text below has been taken from the `rule request` template.

**1. Why should this rule be added? Share links to existing discussion about what the community thinks about this.**  
The increasing focus on accessibility in both [America through the ADA (Americans with Disabilities Act)](https://www.ada.gov/resources/web-guidance/) and the upcoming [European legislation](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=uriserv%3AOJ.L_.2019.151.01.0070.01.NLD&toc=OJ%3AL%3A2019%3A151%3ATOC) underscores the growing importance of accessible applications. To assist in this effort, we can identify existing inaccessible elements using tools such as SwiftLint, among others.

There are already two rules for testing the accessibility of images and buttons. With this new rule, I aim to align with the [WCAG (Web Content Accessibility Guidelines) 1.4.4](https://www.w3.org/WAI/WCAG21/Understanding/resize-text.html). This guideline stipulates that every text must be scalable.

**2. Provide several examples of what _would_ and _wouldn't_  trigger violations.**  
Insofar as I have been able to find, SwiftUI inherently scales well on its own, but this can be forcibly disabled using the `.font(.system())` modifier.

```Swift
struct TestView: View {
	var body: some View {
		Text("Hello World!")
			.font(.system(size: 20))
	}
}
```

Using the default Text, without the .font(.system(size:)) modifier would work and not trigger the linter.

```Swift
struct TestView: View {
	var body: some View {
		Text("Hello World!")
	}
}
```

This also applies to other view elements like a Button, TextField or SecureField.


**3. Should the rule be configurable, if so what parameters should be configurable?**   
For this rule, no additional configuration is required.  

**4. Should the rule be opt-in or enabled by default? Why?
    See [README.md](../README.md#opt-in-rules) for guidelines on when to mark a rule as opt-in.**  
As stated in the rules in the README, this rule complies with the guidelines to be opt-in, as the rule, like the other accessibility rules, is opt-in due to potential false positives given the many possibilities to set up a view within SwiftUI.