### PR TITLE
Document modified configurations used for examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@
   [Ueeek](https://github.com/Ueeek)
   [#5615](https://github.com/realm/SwiftLint/issues/5615)
 
+* Add modified configurations to examples in rule documentation.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+
 * Add new option `evaluate_effective_access_control_level` to `missing_docs`
   rule. Setting it to `true` stops the rule from triggering on declarations
   inside of types with lower visibility. These declarations effectively

--- a/Source/SwiftLintCore/Documentation/RuleDocumentation.swift
+++ b/Source/SwiftLintCore/Documentation/RuleDocumentation.swift
@@ -52,6 +52,27 @@ struct RuleDocumentation {
         }
         return content.joined(separator: "\n\n")
     }
+
+    private func formattedCode(_ example: Example) -> String {
+        if let config = example.configuration, let configuredRule = try? ruleType.init(configuration: config) {
+            let configDescription = configuredRule.createConfigurationDescription(exclusiveOptions: Set(config.keys))
+            return """
+                ```swift
+                //
+                // \(configDescription.yaml().linesPrefixed(with: "// "))
+                //
+
+                \(example.code)
+
+                ```
+                """
+        }
+        return """
+            ```swift
+            \(example.code)
+            ```
+            """
+    }
 }
 
 private func h1(_ text: String) -> String { "# \(text)" }
@@ -60,30 +81,20 @@ private func h2(_ text: String) -> String { "## \(text)" }
 
 private func detailsSummary(_ rule: some Rule) -> String {
     let ruleDescription = """
-        * **Identifier:** \(type(of: rule).description.identifier)
+        * **Identifier:** `\(type(of: rule).description.identifier)`
         * **Enabled by default:** \(rule is any OptInRule ? "No" : "Yes")
         * **Supports autocorrection:** \(rule is any CorrectableRule ? "Yes" : "No")
         * **Kind:** \(type(of: rule).description.kind)
         * **Analyzer rule:** \(rule is any AnalyzerRule ? "Yes" : "No")
         * **Minimum Swift compiler version:** \(type(of: rule).description.minSwiftVersion.rawValue)
         """
-    if rule.configurationDescription.hasContent {
-        let configurationTable = rule.configurationDescription.markdown()
-            .split(separator: "\n")
-            .joined(separator: "\n  ")
+    let description = rule.createConfigurationDescription()
+    if description.hasContent {
         return ruleDescription + """
 
             * **Default configuration:**
-              \(configurationTable)
+              \(description.markdown().linesPrefixed(with: "  "))
             """
     }
     return ruleDescription
-}
-
-private func formattedCode(_ example: Example) -> String {
-    return """
-        ```swift
-        \(example.code)
-        ```
-        """
 }

--- a/Source/SwiftLintCore/Extensions/String+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/String+SwiftLint.swift
@@ -124,4 +124,8 @@ public extension String {
             .map { String(repeating: " ", count: spaces) + $0 }
             .joined(separator: "\n")
     }
+
+    func linesPrefixed(with prefix: Self) -> Self {
+        split(separator: "\n").joined(separator: "\n\(prefix)")
+    }
 }

--- a/Source/SwiftLintCore/Protocols/Rule.swift
+++ b/Source/SwiftLintCore/Protocols/Rule.swift
@@ -3,18 +3,11 @@ import SourceKittenFramework
 
 /// An executable value that can identify issues (violations) in Swift source code.
 public protocol Rule {
-    /// The rule's description type.
-    associatedtype Description: Documentable
-
     /// The type of the configuration used to configure this rule.
     associatedtype ConfigurationType: RuleConfiguration
 
     /// A verbose description of many of this rule's properties.
     static var description: RuleDescription { get }
-
-    /// A description of how this rule has been configured to run. It can be built using the annotated result builder.
-    @RuleConfigurationDescriptionBuilder
-    var configurationDescription: Description { get }
 
     /// This rule's configuration.
     var configuration: ConfigurationType { get set }
@@ -31,6 +24,9 @@ public protocol Rule {
     ///
     /// - throws: Throws if the configuration didn't match the expected format.
     init(configuration: Any) throws
+
+    /// Create a description of how this rule has been configured to run.
+    func createConfigurationDescription(exclusiveOptions: Set<String>) -> RuleConfigurationDescription
 
     /// Executes the rule on a file and returns any violations to the rule's expectations.
     ///
@@ -109,11 +105,11 @@ public extension Rule {
     /// The cache description which will be used to determine if a previous
     /// cached value is still valid given the new cache value.
     var cacheDescription: String {
-        (self as? any CacheDescriptionProvider)?.cacheDescription ?? configurationDescription.oneLiner()
+        (self as? any CacheDescriptionProvider)?.cacheDescription ?? createConfigurationDescription().oneLiner()
     }
 
-    var configurationDescription: some Documentable {
-        RuleConfigurationDescription.from(configuration: configuration)
+    func createConfigurationDescription(exclusiveOptions: Set<String> = []) -> RuleConfigurationDescription {
+        RuleConfigurationDescription.from(configuration: configuration, exclusiveOptions: exclusiveOptions)
     }
 }
 

--- a/Source/swiftlint/Commands/Rules.swift
+++ b/Source/swiftlint/Commands/Rules.swift
@@ -70,10 +70,11 @@ extension SwiftLint {
             }
 
             print("\(description.consoleDescription)")
-            if rule.configurationDescription.hasContent {
+            let configDescription = rule.createConfigurationDescription()
+            if configDescription.hasContent {
                 print("\nConfiguration (YAML):\n")
                 print("  \(description.identifier):")
-                print(rule.configurationDescription.yaml().indent(by: 4))
+                print(configDescription.yaml().indent(by: 4))
             }
 
             guard description.triggeringExamples.isNotEmpty else { return }
@@ -85,9 +86,10 @@ extension SwiftLint {
         }
 
         private func printConfig(for rule: any Rule) {
-            if rule.configurationDescription.hasContent {
+            let configDescription = rule.createConfigurationDescription()
+            if configDescription.hasContent {
                 print("\(type(of: rule).identifier):")
-                print(rule.configurationDescription.yaml().indent(by: 2))
+                print(configDescription.yaml().indent(by: 2))
             }
         }
 
@@ -141,7 +143,7 @@ private extension TextTable {
                 ruleType.description.kind.rawValue,
                 (rule is any AnalyzerRule) ? "yes" : "no",
                 (rule is any SourceKitFreeRule) ? "no" : "yes",
-                truncate((defaultConfig ? rule : configuredRule ?? rule).configurationDescription.oneLiner()),
+                truncate((defaultConfig ? rule : configuredRule ?? rule).createConfigurationDescription().oneLiner()),
             ])
         }
     }

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -60,7 +60,7 @@ final class IntegrationTests: SwiftLintTestCase {
             .map {
                 """
                 \($0.identifier):
-                \($0.init().configurationDescription.yaml().indent(by: 2))
+                \($0.init().createConfigurationDescription().yaml().indent(by: 2))
                 """
             }
             .joined(separator: "\n")

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -621,8 +621,12 @@ extension ConfigurationTests {
         )
 
         XCTAssertEqual(
-            Set(configuration1.rulesWrapper.allRulesWrapped.map { $0.rule.configurationDescription.oneLiner() }),
-            Set(configuration2.rulesWrapper.allRulesWrapped.map { $0.rule.configurationDescription.oneLiner() })
+            Set(configuration1.rulesWrapper.allRulesWrapped.map {
+                $0.rule.createConfigurationDescription().oneLiner()
+            }),
+            Set(configuration2.rulesWrapper.allRulesWrapped.map {
+                $0.rule.createConfigurationDescription().oneLiner()
+            })
         )
 
         XCTAssertEqual(Set(configuration1.includedPaths), Set(configuration2.includedPaths))


### PR DESCRIPTION
Example:

```swift
for user in users {
  if user.id == 1 { return true }
}

//
// allow_for_as_filter: true
//
```