### PR TITLE
Prevent from building SwiftLint when using SwiftLint Plugin on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,14 @@
 
 #### Enhancements
 
+* Prevent from compiling `SwiftLint` target when only using `SwiftLintPlugin` on macOS.  
+  [Julien Baillon](https://github.com/julien-baillon)
+  [#5372](https://github.com/realm/SwiftLint/issues/5372)
+
 * Add new `ignore_one_liners` option to `switch_case_alignment` 
   rule to ignore switch statements written in a single line.  
   [tonell-m](https://github.com/tonell-m)
   [#5373](https://github.com/realm/SwiftLint/issues/5373)
-* Prevent from compiling `SwiftLint` target when only using `SwiftLintPlugin` on macOS.
-  [Julien Baillon](https://github.com/julien-baillon)
-  [#5372](https://github.com/realm/SwiftLint/issues/5372)
 
 * Add new `one_declaration_per_file` rule that allows only a
   single class/struct/enum/protocol declaration per file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
   rule to ignore switch statements written in a single line.  
   [tonell-m](https://github.com/tonell-m)
   [#5373](https://github.com/realm/SwiftLint/issues/5373)
+* Prevent from compiling `SwiftLint` target when only using `SwiftLintPlugin` on macOS.
+  [Julien Baillon](https://github.com/julien-baillon)
+  [#5372](https://github.com/realm/SwiftLint/issues/5372)
 
 * Add new `one_declaration_per_file` rule that allows only a
   single class/struct/enum/protocol declaration per file.

--- a/Package.swift
+++ b/Package.swift
@@ -6,6 +6,13 @@ let swiftFeatures: [SwiftSetting] = [
     .enableUpcomingFeature("ExistentialAny")
 ]
 
+let swiftLintPluginDependencies: [Target.Dependency]
+#if os(macOS)
+swiftLintPluginDependencies = [.target(name: "SwiftLintBinary")]
+#else 
+swiftLintPluginDependencies = [.target(name: "swiftlint")]
+#endif
+
 let package = Package(
     name: "SwiftLint",
     platforms: [.macOS(.v12)],
@@ -27,10 +34,7 @@ let package = Package(
         .plugin(
             name: "SwiftLintPlugin",
             capability: .buildTool(),
-            dependencies: [
-                .target(name: "SwiftLintBinary", condition: .when(platforms: [.macOS])),
-                .target(name: "swiftlint", condition: .when(platforms: [.linux]))
-            ]
+            dependencies: swiftLintPluginDependencies
         ),
         .executableTarget(
             name: "swiftlint",


### PR DESCRIPTION
When we use `SwiftLintPlugin` with SwiftPM on macOS, SwiftLint and all its dependencies are built even if it's useless on macOS because there is `SwiftLintBinary` instead. 

Here is an example project that only use `SwiftLintPlugin`, but takes about one minute to compile because it compiles SwiftLint for nothing.

```swift
// swift-tools-version: 5.9

import PackageDescription

let package = Package(
    name: "MyLibrary",
    platforms: [.macOS(.v14)],
    products: [
        .library(
            name: "MyLibrary",
            targets: ["MyLibrary"]),
    ],
    dependencies: [
        .package(url: "https://github.com/realm/SwiftLint", exact: Version("0.54.0")),
    ],
    targets: [
        .target(
            name: "MyLibrary",
            plugins: [.plugin(name: "SwiftLintPlugin", package: "SwiftLint")]
        )
    ]
)
```

[MyLibrary.zip](https://github.com/realm/SwiftLint/files/13772645/MyLibrary.zip)

I believe it's due to `.target(name: "swiftlint", condition: .when(platforms: [.linux]))` on SwiftLint's `Package.swift`. The condition seams not to work as expected for plugins. 

Related issues: 
- [swiftlint and SwiftLintFramework being build when only using SwiftLintPlugin on MacOS](https://github.com/realm/SwiftLint/issues/5372)
- [SwiftLint Compile Times Extremely Slow](https://github.com/realm/SwiftLint/issues/5099)