### PR TITLE
Make `sorted_enum_cases` rule's comparison case-insensitive to avoid unexpected ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,11 @@
   [Ben P](https://github.com/ben-p-commits)
   [#5263](https://github.com/realm/SwiftLint/issues/5263)
 
+* Make `sorted_enum_cases` rule's comparison case-insensitive to
+  avoid unexpected ordering.  
+  [Oleg Kokhtenko](https://github.com/kohtenko)
+  [#5405](https://github.com/realm/SwiftLint/issues/issue_number)
+
 #### Bug Fixes
 
 * Silence `discarded_notification_center_observer` rule in closures. Furthermore,

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SortedEnumCasesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SortedEnumCasesRule.swift
@@ -19,6 +19,19 @@ struct SortedEnumCasesRule: OptInRule {
             """),
             Example("""
             enum foo {
+                case example
+                case exBoyfriend
+            }
+            """),
+            Example("""
+            enum foo {
+                case a
+                case B
+                case c
+            }
+            """),
+            Example("""
+            enum foo {
                 case a, b, c
             }
             """),
@@ -32,6 +45,12 @@ struct SortedEnumCasesRule: OptInRule {
             enum foo {
                 case a(foo: Foo)
                 case b(String), c
+            }
+            """),
+            Example("""
+            enum foo {
+                case a
+                case b, C, d
             }
             """),
             Example("""
@@ -53,7 +72,19 @@ struct SortedEnumCasesRule: OptInRule {
             """),
             Example("""
             enum foo {
+                ↓case B
+                ↓case a
+                case c
+            }
+            """),
+            Example("""
+            enum foo {
                 case ↓b, ↓a, c
+            }
+            """),
+            Example("""
+            enum foo {
+                case ↓B, ↓a, c
             }
             """),
             Example("""
@@ -91,7 +122,11 @@ private extension SortedEnumCasesRule {
 
             let cases = node.memberBlock.members.compactMap { $0.decl.as(EnumCaseDeclSyntax.self) }
             let sortedCases = cases
-                .sorted(by: { $0.elements.first!.name.text < $1.elements.first!.name.text })
+                .sorted(by: {
+                    let lhs = $0.elements.first!.name.text
+                    let rhs = $1.elements.first!.name.text
+                    return lhs.caseInsensitiveCompare(rhs) == .orderedAscending
+                })
 
             zip(sortedCases, cases).forEach { sortedCase, currentCase in
                 if sortedCase.elements.first?.name.text != currentCase.elements.first?.name.text {
@@ -103,7 +138,9 @@ private extension SortedEnumCasesRule {
         }
 
         override func visitPost(_ node: EnumCaseDeclSyntax) {
-            let sortedElements = node.elements.sorted(by: { $0.name.text < $1.name.text })
+            let sortedElements = node.elements.sorted(by: {
+                $0.name.text.caseInsensitiveCompare($1.name.text) == .orderedAscending
+            })
 
             zip(sortedElements, node.elements).forEach { sortedElement, currentElement in
                 if sortedElement.name.text != currentElement.name.text {


### PR DESCRIPTION
Update `sorted_enum_cases` rule to compare lowercase cases.

This is helpful, because in swift's comparison `B` is less than `a`.
The newly added triggering examples show how the case comparison looks like.