### PR TITLE
Ignore absence of a non-initial local config instead of falling back to default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 * None.
 
 #### Enhancements
+* Ignore absence of a non-initial local config instead of
+  falling back to default.  
+  [kohtenko](https://github.com/kohtenko)
+  [#5407](https://github.com/realm/SwiftLint/pull/5407)
 
 * Add new option `ignore_typealiases_and_associatedtypes` to
   `nesting` rule. It excludes `typealias` and `associatedtype`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@
 * None.
 
 #### Enhancements
+
 * Ignore absence of a non-initial local config instead of
   falling back to default.  
   [kohtenko](https://github.com/kohtenko)
-  [#5407](https://github.com/realm/SwiftLint/pull/5407)
 
 * Add new option `ignore_typealiases_and_associatedtypes` to
   `nesting` rule. It excludes `typealias` and `associatedtype`

--- a/Source/SwiftLintCore/Extensions/Configuration+FileGraphSubtypes.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+FileGraphSubtypes.swift
@@ -72,9 +72,9 @@ internal extension Configuration.FileGraph {
 
         private func read(at path: String) throws -> String {
             guard !path.isEmpty && FileManager.default.fileExists(atPath: path) else {
-                throw isInitialVertex ?
-                    Issue.initialFileNotFound(path: path) :
-                    Issue.genericWarning("File \(path) can't be found.")
+                throw isInitialVertex
+                    ? Issue.initialFileNotFound(path: path)
+                    : Issue.fileNotFound(path: path)
             }
 
             return try String(contentsOfFile: path, encoding: .utf8)

--- a/Source/SwiftLintCore/Models/Issue.swift
+++ b/Source/SwiftLintCore/Models/Issue.swift
@@ -32,6 +32,9 @@ public enum Issue: LocalizedError, Equatable {
     /// The initial configuration file was not found.
     case initialFileNotFound(path: String)
 
+    /// A file at specified path was not found.
+    case fileNotFound(path: String)
+
     /// The file at `path` is not readable or cannot be opened.
     case fileNotReadable(path: String?, ruleID: String)
 
@@ -125,6 +128,8 @@ public enum Issue: LocalizedError, Equatable {
             return "Cannot get cursor info from file at path '\(path ?? "...")' within '\(id)' rule."
         case let .yamlParsing(message):
             return "Cannot parse YAML file: \(message)"
+        case let .fileNotFound(path):
+            return "File at path '\(path)' not found."
         }
     }
 }

--- a/Tests/SwiftLintFrameworkTests/Resources/ProjectMock/ChildConfig/Test1/Main/main.yml
+++ b/Tests/SwiftLintFrameworkTests/Resources/ProjectMock/ChildConfig/Test1/Main/main.yml
@@ -9,3 +9,4 @@ excluded:
 line_length: 80
 
 child_config: child1.yml
+parent_config: nonExistingParent.yml


### PR DESCRIPTION
This change is helpful for Swift Package Manager (SPM) users. When one sets up the parent config to be shared between packages and keeps it in a working directory like following:
```
- WorkingDirectory
   - parent_config.yml
   - Package1
      - .swiftlint.yaml
      - ... 
   - Package2
      - .swiftlint.yaml
      - ... 
   - .... 
```

The current configuration works as expected. The challenge comes when the package is not local anymore (not in active development anymore). SPM checks out the repository in project's DerivedData instead, and no parent config is available at that new folder structure. Swiftlint plugin runs normally by SPM, but the config is now corrupted and fallback to default, which might bring unexpected warnings and errors.