### PR TITLE
Make `superfluous_else` rule auto-correctable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@
 * Add new `final_test_case` rule that triggers on non-final test classes.  
   [SimplyDanny](https://github.com/SimplyDanny)
 
+* Make `superfluous_else` rule auto-correctable.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+
 * Trigger on `-> ()` return signatures in `return_value_from_void_function`
   rule. Moreover, support automatic fixes for obvious cases.  
   [SimplyDanny](https://github.com/SimplyDanny)

--- a/Source/SwiftLintCore/Extensions/SwiftSyntax+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/SwiftSyntax+SwiftLint.swift
@@ -266,6 +266,18 @@ public extension Trivia {
         return self
     }
 
+    var withTrailingEmptyLineRemoved: Trivia {
+        if let index = pieces.lastIndex(where: \.isNewline), index < endIndex {
+            if index == endIndex - 1 {
+                return Trivia(pieces: dropLast(1))
+            }
+            if pieces.suffix(from: index + 1).allSatisfy(\.isHorizontalWhitespace) {
+                return Trivia(pieces: prefix(upTo: index))
+            }
+        }
+        return self
+    }
+
     var withoutTrailingIndentation: Trivia {
         Trivia(pieces: reversed().drop(while: \.isHorizontalWhitespace).reversed())
     }

--- a/Source/SwiftLintCore/Rewriters/CodeIndentingRewriter.swift
+++ b/Source/SwiftLintCore/Rewriters/CodeIndentingRewriter.swift
@@ -1,0 +1,76 @@
+import SwiftSyntax
+
+/// Rewriter that indents or unindents a syntax piece including comments and nested
+/// AST nodes (e.g. a code block in a code block).
+public class CodeIndentingRewriter: SyntaxRewriter {
+    /// Style defining whether the rewriter shall indent or unindent and whether it shall use tabs or spaces and
+    /// how many of them.
+    public enum IndentationStyle {
+        /// Indentation with a number of spaces.
+        case indentSpaces(Int)
+        /// Reverse indentation of a number of spaces.
+        case unindentSpaces(Int)
+        /// Indentation with a number of tabs
+        case indentTabs(Int)
+        /// Reverse indentation of a number of tabs.
+        case unindentTabs(Int)
+    }
+
+    private let style: IndentationStyle
+    private var isFirstToken = true
+
+    /// Initializer accepting an indentation style.
+    ///
+    /// - parameter style: Indentation style. The default is indentation by 4 spaces.
+    public init(style: IndentationStyle = .indentSpaces(4)) {
+        self.style = style
+    }
+
+    override public func visit(_ token: TokenSyntax) -> TokenSyntax {
+        defer { isFirstToken = false }
+        return super.visit(
+            token.with(\.leadingTrivia, Trivia(pieces: indentedTriviaPieces(for: token.leadingTrivia)))
+        )
+    }
+
+    private func indentedTriviaPieces(for trivia: Trivia) -> [TriviaPiece] {
+        switch style {
+        case let .indentSpaces(number): indent(trivia: trivia, by: .spaces(number))
+        case let .indentTabs(number): indent(trivia: trivia, by: .tabs(number))
+        case let .unindentSpaces(number): unindent(trivia: trivia, by: .spaces(number))
+        case let .unindentTabs(number): unindent(trivia: trivia, by: .tabs(number))
+        }
+    }
+
+    private func indent(trivia: Trivia, by indentation: TriviaPiece) -> [TriviaPiece] {
+        let indentedPieces = trivia.pieces.flatMap { piece in
+            switch piece {
+            case .newlines: [piece, indentation]
+            default: [piece]
+            }
+        }
+        return isFirstToken ? [indentation] + indentedPieces : indentedPieces
+    }
+
+    private func unindent(trivia: Trivia, by indentation: TriviaPiece) -> [TriviaPiece] {
+        var indentedTrivia = [TriviaPiece]()
+        for piece in trivia.pieces {
+            if !isFirstToken {
+                guard case .newlines = indentedTrivia.last else {
+                    indentedTrivia.append(piece)
+                    continue
+                }
+            }
+            switch (piece, indentation) {
+            case let (.spaces(number), .spaces(requestedNumber)) where number >= requestedNumber:
+                indentedTrivia.append(.spaces(number - requestedNumber))
+                if isFirstToken { break }
+            case let (.tabs(number), .tabs(requestedNumber)) where number >= requestedNumber:
+                indentedTrivia.append(.tabs(number - requestedNumber))
+                if isFirstToken { break }
+            default: indentedTrivia.append(piece)
+            }
+        }
+        return indentedTrivia
+    }
+}

--- a/Tests/SwiftLintFrameworkTests/CodeIndentingRewriterTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CodeIndentingRewriterTests.swift
@@ -1,0 +1,159 @@
+import SwiftLintCore
+import SwiftParser
+import SwiftSyntax
+import XCTest
+
+class CodeIndentingRewriterTests: XCTestCase {
+    func testIndentDefaultStyle() {
+        assertIndent(
+            source: """
+                if c {
+                    // comment
+                    return 1
+                    // another comment
+                }
+                """,
+            indentedSource: """
+                if c {
+                    // comment
+                    return 1
+                    // another comment
+                }
+            """,
+            style: .indentSpaces(4)
+        )
+    }
+
+    func testIndentThreeSpaces() {
+        assertIndent(
+            source: """
+                 if c {
+                       // comment
+                     return 1
+                     // another comment
+                 }
+                """,
+            indentedSource: """
+                if c {
+                      // comment
+                    return 1
+                    // another comment
+                }
+            """,
+            style: .indentSpaces(3)
+        )
+    }
+
+    func testIndentTabs() {
+        assertIndent(
+            source: """
+                if c {
+                    // comment
+                    return 1
+                       // another comment
+                }
+                """,
+            indentedSource: """
+            \tif c {
+            \t    // comment
+            \t    return 1
+            \t       // another comment
+            \t}
+            """,
+            style: .indentTabs(1)
+        )
+    }
+
+    func testIndentCodeBlock() {
+        assertIndent(
+            source: """
+                // initial comment
+                {
+                    if c {
+                        // comment
+                        return 1
+                        // another comment
+                    }
+                    // yet another comment
+                }
+                """,
+            indentedSource: """
+                    // initial comment
+                    {
+                        if c {
+                            // comment
+                            return 1
+                            // another comment
+                        }
+                        // yet another comment
+                    }
+                """,
+            style: .indentSpaces(4)
+        )
+    }
+
+    func testUnindentDefaultStyle() {
+        assertIndent(
+            source: """
+                if c {
+                    // comment
+                    return 1
+                    // another comment
+                }
+            """,
+            indentedSource: """
+                if c {
+                    // comment
+                    return 1
+                    // another comment
+                }
+                """,
+            style: .unindentSpaces(4)
+        )
+    }
+
+    func testUnindentTwoSpaces() {
+        assertIndent(
+            source: """
+              if c {
+                   // comment
+                  return 1
+                  // another comment
+              }
+            """,
+            indentedSource: """
+                if c {
+                     // comment
+                    return 1
+                    // another comment
+                }
+                """,
+            style: .unindentSpaces(2)
+        )
+    }
+
+    func testUnindentTabs() {
+        assertIndent(
+            source: """
+            \tif c {
+            \t\t   // comment
+            \t\treturn 1
+            \t\t\t// another comment
+            \t}
+            """,
+            indentedSource: """
+                if c {
+                \t   // comment
+                \treturn 1
+                \t\t// another comment
+                }
+                """,
+            style: .unindentTabs(1)
+        )
+    }
+
+    private func assertIndent(source: String, indentedSource: String, style: CodeIndentingRewriter.IndentationStyle) {
+        let rewritten = CodeIndentingRewriter(style: style).rewrite(Parser.parse(source: source))
+        XCTAssertEqual(rewritten.description, indentedSource)
+    }
+}


### PR DESCRIPTION
This introduces `CodeIndentingRewriter` which indents or unindents a syntax piece including comments and nested AST nodes (e.g. a code block in a code block).