### PR TITLE
Refine violation positions of `superfluous_else` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,9 @@
   [Ben P](https://github.com/ben-p-commits)
   [#5263](https://github.com/realm/SwiftLint/issues/5263)
 
+* Refine violation position of `superfluous_else` rule.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+
 * Make `sorted_enum_cases` rule's comparison case-insensitive to
   avoid unexpected ordering.  
   [Oleg Kokhtenko](https://github.com/kohtenko)


### PR DESCRIPTION
Trigger on the `else` keyword. The previous `if` keyword seemed unrelated.

Correction positions for this rule are tricky to figure out as the rewriting mechanism is called recursively. That's why, as a workaround, the visitor is asked to compute the violation/correction positions beforehand.