### PR TITLE
Don't trigger the return_value_from_void_function warning from initializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,7 +130,7 @@
   [SimplyDanny](https://github.com/SimplyDanny)
   [#3852](https://github.com/realm/SwiftLint/pull/3852)
 
-* Don't trigger the return_value_from_void_function warning from initializers.  
+* Don't trigger the `return_value_from_void_function` warning from initializers.  
   [mrbkap](https://github.com/mrbkap)
   [#5429](https://github.com/realm/SwiftLint/pull/5429)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,7 +132,6 @@
 
 * Don't trigger the `return_value_from_void_function` warning from initializers.  
   [mrbkap](https://github.com/mrbkap)
-  [#5429](https://github.com/realm/SwiftLint/pull/5429)
 
 ## 0.54.0: Macro-Economic Forces
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,10 @@
   [SimplyDanny](https://github.com/SimplyDanny)
   [#3852](https://github.com/realm/SwiftLint/pull/3852)
 
+* Don't trigger the return_value_from_void_function warning from initializers.  
+  [mrbkap](https://github.com/mrbkap)
+  [#5429](https://github.com/realm/SwiftLint/pull/5429)
+
 ## 0.54.0: Macro-Economic Forces
 
 #### Breaking

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ReturnValueFromVoidFunctionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ReturnValueFromVoidFunctionRule.swift
@@ -57,7 +57,7 @@ private extension Syntax {
             return node
         }
 
-        if self.is(ClosureExprSyntax.self) || self.is(VariableDeclSyntax.self) {
+        if self.is(ClosureExprSyntax.self) || self.is(VariableDeclSyntax.self) || self.is(InitializerDeclSyntax.self) {
             return nil
         }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ReturnValueFromVoidFunctionRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ReturnValueFromVoidFunctionRuleExamples.swift
@@ -54,7 +54,7 @@ internal struct ReturnValueFromVoidFunctionRuleExamples {
                 }
             }
         }
-        """),
+        """, excludeFromDocumentation: true),
         Example("""
         func test() {
             guard condition else {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ReturnValueFromVoidFunctionRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ReturnValueFromVoidFunctionRuleExamples.swift
@@ -45,6 +45,17 @@ internal struct ReturnValueFromVoidFunctionRuleExamples {
         }
         """),
         Example("""
+        func baz() {
+            enum Foo {
+                case bar
+
+                init?(arg: String?) {
+                    return nil
+                }
+            }
+        }
+        """),
+        Example("""
         func test() {
             guard condition else {
                 return


### PR DESCRIPTION
Consider the code:
```swift
func foo() {
   enum Bar: RawRepresentable() {
       case one
       case two

       init?(rawValue: String) {
           return nil
       }
   }
}
```

This example should not trigger `return_value_from_void_function` in the initializer because the initializer is nullable and can return `nil`. However, using the latest version of `SwiftLint` I'm seeing this rule trigger on this example.

The problem appears to be that `Syntax.enclosingFunction` extension climbs the AST's parent chain looking for a `FunctionDecl` but initializers are neither blocks nor variable declarations. By bailing when we see an initializer, we won't trigger this rule incorrectly.