### PR TITLE
Add new a configuration option `ignore_nesting_typealias_and_associatedtype` to exclude type aliases and associated types from the analysis of Nesting rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 
 #### Enhancements
 
+* Add new option `ignore_typealiases_and_associatedtypes` to
+  `nesting` rule. It excludes `typealias` and `associatedtype`
+  declarations from the analysis.
+  [marunomi](https://github.com/marunomi)
+  [#3183](https://github.com/realm/SwiftLint/issues/3183)
+
 * Prevent from compiling `SwiftLint` target when only using `SwiftLintPlugin` on macOS.  
   [Julien Baillon](https://github.com/julien-baillon)
   [#5372](https://github.com/realm/SwiftLint/issues/5372)
@@ -98,9 +104,6 @@
   [#5405](https://github.com/realm/SwiftLint/issues/issue_number)
 
 #### Bug Fixes
-
-* Adding a nesting rule configuration option:`ignore_nesting_typealias_and_associatedtype` that Typealias and AssociatedType will be ignored from the analysis of the rule.
-  [#3183](https://github.com/realm/SwiftLint/issues/3183)
 
 * Silence `discarded_notification_center_observer` rule in closures. Furthermore,
   handle `get` and `set` accessors correctly and consider implicit returns.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,9 @@
 
 #### Bug Fixes
 
+* Adding a nesting rule configuration option:`ignore_nesting_typealias_and_associatedtype` that Typealias and AssociatedType will be ignored from the analysis of the rule.
+  [#3183](https://github.com/realm/SwiftLint/issues/3183)
+
 * Silence `discarded_notification_center_observer` rule in closures. Furthermore,
   handle `get` and `set` accessors correctly and consider implicit returns.  
   [SimplyDanny](https://github.com/SimplyDanny)

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/NestingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/NestingRule.swift
@@ -37,8 +37,7 @@ struct NestingRule: Rule {
     private func validate(file: SwiftLintFile, substructure: [SourceKittenDictionary],
                           args: ValidationArgs) -> [StyleViolation] {
         return args.violations + substructure.flatMap { dictionary -> [StyleViolation] in
-            guard let kindString = dictionary.kind, let structureKind = SwiftStructureKind(kindString)
-            else {
+            guard let kindString = dictionary.kind, let structureKind = SwiftStructureKind(kindString) else {
                 return validate(file: file, substructure: dictionary.substructure, args: args.with(previousKind: nil))
             }
             guard !omittedStructureKinds.contains(structureKind) else {

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/NestingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/NestingRule.swift
@@ -37,7 +37,9 @@ struct NestingRule: Rule {
     private func validate(file: SwiftLintFile, substructure: [SourceKittenDictionary],
                           args: ValidationArgs) -> [StyleViolation] {
         return args.violations + substructure.flatMap { dictionary -> [StyleViolation] in
-            guard let kindString = dictionary.kind, let structureKind = SwiftStructureKind(kindString) else {
+            guard let kindString = dictionary.kind,
+                  let structureKind = SwiftStructureKind(kindString,
+                                                         ignoreTypealiasAndAssociatedtype: configuration.ignoreNestingTypealiasAndAssociatedtype) else {
                 return validate(file: file, substructure: dictionary.substructure, args: args.with(previousKind: nil))
             }
             guard !omittedStructureKinds.contains(structureKind) else {
@@ -130,9 +132,10 @@ private enum SwiftStructureKind: Equatable {
     case expression(SwiftExpressionKind)
     case statement(StatementKind)
 
-    init?(_ structureKind: String) {
+    init?(_ structureKind: String, ignoreTypealiasAndAssociatedtype: Bool) {
         if let declarationKind = SwiftDeclarationKind(rawValue: structureKind) {
-            if declarationKind == .associatedtype || declarationKind == .typealias {
+            if ignoreTypealiasAndAssociatedtype,
+               declarationKind == .associatedtype || declarationKind == .typealias {
                 return nil
             }
             self = .declaration(declarationKind)

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/NestingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/NestingRule.swift
@@ -132,6 +132,9 @@ private enum SwiftStructureKind: Equatable {
 
     init?(_ structureKind: String) {
         if let declarationKind = SwiftDeclarationKind(rawValue: structureKind) {
+            if declarationKind == .associatedtype || declarationKind == .typealias {
+                return nil
+            }
             self = .declaration(declarationKind)
         } else if let expressionKind = SwiftExpressionKind(rawValue: structureKind) {
             self = .expression(expressionKind)

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/NestingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/NestingRule.swift
@@ -39,7 +39,9 @@ struct NestingRule: Rule {
         return args.violations + substructure.flatMap { dictionary -> [StyleViolation] in
             guard let kindString = dictionary.kind,
                   let structureKind = SwiftStructureKind(kindString,
-                                                         ignoreTypealiasAndAssociatedtype: configuration.ignoreNestingTypealiasAndAssociatedtype) else {
+                                                         // swiftlint:disable:next line_length
+                                                         ignoreTypealiasAndAssociatedtype: configuration.ignoreNestingTypealiasAndAssociatedtype)
+            else {
                 return validate(file: file, substructure: dictionary.substructure, args: args.with(previousKind: nil))
             }
             guard !omittedStructureKinds.contains(structureKind) else {

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/NestingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/NestingRule.swift
@@ -37,8 +37,7 @@ struct NestingRule: Rule {
     private func validate(file: SwiftLintFile, substructure: [SourceKittenDictionary],
                           args: ValidationArgs) -> [StyleViolation] {
         return args.violations + substructure.flatMap { dictionary -> [StyleViolation] in
-            guard let kindString = dictionary.kind,
-                  let structureKind = SwiftStructureKind(kindString)
+            guard let kindString = dictionary.kind, let structureKind = SwiftStructureKind(kindString)
             else {
                 return validate(file: file, substructure: dictionary.substructure, args: args.with(previousKind: nil))
             }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NestingConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NestingConfiguration.swift
@@ -13,6 +13,8 @@ struct NestingConfiguration: RuleConfiguration {
     private(set) var checkNestingInClosuresAndStatements = true
     @ConfigurationElement(key: "always_allow_one_type_in_functions")
     private(set) var alwaysAllowOneTypeInFunctions = false
+    @ConfigurationElement(key: "ignore_nesting_typealias_and_associatedtype")
+    private(set) var ignoreNestingTypealiasAndAssociatedtype = false
 
     func severity(with config: Severity, for level: Int) -> ViolationSeverity? {
         if let error = config.error, level > error {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NestingConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NestingConfiguration.swift
@@ -13,8 +13,8 @@ struct NestingConfiguration: RuleConfiguration {
     private(set) var checkNestingInClosuresAndStatements = true
     @ConfigurationElement(key: "always_allow_one_type_in_functions")
     private(set) var alwaysAllowOneTypeInFunctions = false
-    @ConfigurationElement(key: "ignore_nesting_typealias_and_associatedtype")
-    private(set) var ignoreNestingTypealiasAndAssociatedtype = false
+    @ConfigurationElement(key: "ignore_typealiases_and_associatedtypes")
+    private(set) var ignoreTypealiasesAndAssociatedtypes = false
 
     func severity(with config: Severity, for level: Int) -> ViolationSeverity? {
         if let error = config.error, level > error {

--- a/Tests/SwiftLintFrameworkTests/NestingRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/NestingRuleTests.swift
@@ -409,6 +409,6 @@ class NestingRuleTests: SwiftLintTestCase {
                                          nonTriggeringExamples: nonTriggeringExamples,
                                          triggeringExamples: triggeringExamples)
 
-        verifyRule(descripton, ruleConfiguration: ["ignore_nesting_typealias_and_associatedtype": true])
+        verifyRule(descripton, ruleConfiguration: ["ignore_typealiases_and_associatedtypes": true])
     }
 }

--- a/Tests/SwiftLintFrameworkTests/NestingRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/NestingRuleTests.swift
@@ -368,4 +368,45 @@ class NestingRuleTests: SwiftLintTestCase {
 
         verifyRule(description, ruleConfiguration: ["check_nesting_in_closures_and_statements": false])
     }
+    
+    func testNestingWithoutTypealiasAndAssociatedtype() {
+        var nonTriggeringExamples = NestingRule.description.nonTriggeringExamples
+        nonTriggeringExamples.append(contentsOf: ["class", "struct", "enum"].flatMap { type -> [Example] in
+            [
+                .init("""
+                    \(type) Example_0 {
+                        \(type) Example_1 {
+                            typealias Example_2_Type = Example_2.Type
+                        }
+                        \(type) Example_2 {
+                           
+                        }
+                    }
+                """),
+            ]
+        })
+        
+        let triggeringExamples = ["class", "struct", "enum"].flatMap { type -> [Example] in
+            [
+                .init("""
+                    \(type) Example_0 {
+                        \(type) Example_1 {
+                            \(type) Example_2 {
+                               
+                            }
+                        }
+                    }
+                """),
+            ]
+        }
+        
+        let descripton = RuleDescription(identifier: NestingRule.description.identifier,
+                                         name: NestingRule.description.name,
+                                         description: NestingRule.description.description,
+                                         kind: .metrics,
+                                         nonTriggeringExamples: nonTriggeringExamples,
+                                         triggeringExamples: triggeringExamples)
+        
+        verifyRule(descripton, ruleConfiguration: ["ignore_nesting_typealias_and_associatedtype": true])
+    }
 }

--- a/Tests/SwiftLintFrameworkTests/NestingRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/NestingRuleTests.swift
@@ -368,7 +368,8 @@ class NestingRuleTests: SwiftLintTestCase {
 
         verifyRule(description, ruleConfiguration: ["check_nesting_in_closures_and_statements": false])
     }
-    
+
+    // swiftlint:disable:next function_body_length
     func testNestingWithoutTypealiasAndAssociatedtype() {
         var nonTriggeringExamples = NestingRule.description.nonTriggeringExamples
         nonTriggeringExamples.append(contentsOf: ["class", "struct", "enum"].flatMap { type -> [Example] in
@@ -379,34 +380,34 @@ class NestingRuleTests: SwiftLintTestCase {
                             typealias Example_2_Type = Example_2.Type
                         }
                         \(type) Example_2 {
-                           
+
                         }
                     }
-                """),
+                """)
             ]
         })
-        
+
         let triggeringExamples = ["class", "struct", "enum"].flatMap { type -> [Example] in
             [
                 .init("""
                     \(type) Example_0 {
                         \(type) Example_1 {
                             \(type) Example_2 {
-                               
+
                             }
                         }
                     }
-                """),
+                """)
             ]
         }
-        
+
         let descripton = RuleDescription(identifier: NestingRule.description.identifier,
                                          name: NestingRule.description.name,
                                          description: NestingRule.description.description,
                                          kind: .metrics,
                                          nonTriggeringExamples: nonTriggeringExamples,
                                          triggeringExamples: triggeringExamples)
-        
+
         verifyRule(descripton, ruleConfiguration: ["ignore_nesting_typealias_and_associatedtype": true])
     }
 }

--- a/Tests/SwiftLintFrameworkTests/NestingRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/NestingRuleTests.swift
@@ -1,5 +1,7 @@
 @testable import SwiftLintBuiltInRules
 
+// swiftlint:disable file_length
+
 class NestingRuleTests: SwiftLintTestCase {
     // swiftlint:disable:next function_body_length
     func testNestingWithAlwaysAllowOneTypeInFunctions() {
@@ -369,7 +371,6 @@ class NestingRuleTests: SwiftLintTestCase {
         verifyRule(description, ruleConfiguration: ["check_nesting_in_closures_and_statements": false])
     }
 
-    // swiftlint:disable:next function_body_length
     func testNestingWithoutTypealiasAndAssociatedtype() {
         var nonTriggeringExamples = NestingRule.description.nonTriggeringExamples
         nonTriggeringExamples.append(contentsOf: ["class", "struct", "enum"].flatMap { type -> [Example] in

--- a/Tests/SwiftLintFrameworkTests/NestingRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/NestingRuleTests.swift
@@ -380,35 +380,39 @@ class NestingRuleTests: SwiftLintTestCase {
                         \(type) Example_1 {
                             typealias Example_2_Type = Example_2.Type
                         }
-                        \(type) Example_2 {
+                        \(type) Example_2 {}
+                    }
+                """),
+                .init("""
+                    protocol Example_Protcol {
+                        associatedtype AssociatedType
+                    }
 
+                    \(type) Example_1 {
+                        \(type) Example_2: Example_Protcol {
+                            typealias AssociatedType = Int
+                        }
+                    }
+                """),
+                .init("""
+                    protocol Example_Protcol {
+                        associatedtype AssociatedType
+                    }
+
+                    \(type) Example_1 {
+                        \(type) Example_2: SomeProtcol {
+                            typealias Example_2_Type = Example_2.Type
+                        }
+                        \(type) Example_3: Example_Protcol {
+                            typealias AssociatedType = Int
                         }
                     }
                 """)
             ]
         })
 
-        let triggeringExamples = ["class", "struct", "enum"].flatMap { type -> [Example] in
-            [
-                .init("""
-                    \(type) Example_0 {
-                        \(type) Example_1 {
-                            \(type) Example_2 {
+        let description = NestingRule.description.with(nonTriggeringExamples: nonTriggeringExamples)
 
-                            }
-                        }
-                    }
-                """)
-            ]
-        }
-
-        let descripton = RuleDescription(identifier: NestingRule.description.identifier,
-                                         name: NestingRule.description.name,
-                                         description: NestingRule.description.description,
-                                         kind: .metrics,
-                                         nonTriggeringExamples: nonTriggeringExamples,
-                                         triggeringExamples: triggeringExamples)
-
-        verifyRule(descripton, ruleConfiguration: ["ignore_typealiases_and_associatedtypes": true])
+        verifyRule(description, ruleConfiguration: ["ignore_typealiases_and_associatedtypes": true])
     }
 }

--- a/Tests/SwiftLintFrameworkTests/RuleConfigurationDescriptionTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleConfigurationDescriptionTests.swift
@@ -8,7 +8,7 @@ import XCTest
 class RuleConfigurationDescriptionTests: XCTestCase {
     @AutoApply
     private struct TestConfiguration: RuleConfiguration {
-        typealias Parent = RuleMock // swiftlint:disable:this nesting
+        typealias Parent = RuleMock
 
         @ConfigurationElement(key: "flag")
         var flag = true
@@ -211,7 +211,7 @@ class RuleConfigurationDescriptionTests: XCTestCase {
 
     func testPrefersParameterDescription() {
         struct Config: RuleConfiguration {
-            typealias Parent = RuleMock // swiftlint:disable:this nesting
+            typealias Parent = RuleMock
 
             var parameterDescription: RuleConfigurationDescription? {
                 "visible" => .flag(true)

--- a/Tests/SwiftLintFrameworkTests/RuleConfigurationDescriptionTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleConfigurationDescriptionTests.swift
@@ -8,7 +8,7 @@ import XCTest
 class RuleConfigurationDescriptionTests: XCTestCase {
     @AutoApply
     private struct TestConfiguration: RuleConfiguration {
-        typealias Parent = RuleMock
+        typealias Parent = RuleMock // swiftlint:disable:this nesting
 
         @ConfigurationElement(key: "flag")
         var flag = true
@@ -211,7 +211,7 @@ class RuleConfigurationDescriptionTests: XCTestCase {
 
     func testPrefersParameterDescription() {
         struct Config: RuleConfiguration {
-            typealias Parent = RuleMock
+            typealias Parent = RuleMock // swiftlint:disable:this nesting
 
             var parameterDescription: RuleConfigurationDescription? {
                 "visible" => .flag(true)


### PR DESCRIPTION
As discussed in https://github.com/realm/SwiftLint/issues/3183 this PR adds a `ignore_nesting_typealias_and_associatedtype` option to the nesting rule configuration to allow this typealias and associatedtype are nested in some defining enum, class and struct like:

```
struct AStruct {
    struct BStruct {
        typealias GreatType = CStruct .Type
    }
    struct CStruct {

    }
}
```

This option is still disabled by default.