### PR TITLE
Allow line_length rule configuration accept regex patterns to exclude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,10 @@
   [Oleg Kokhtenko](https://github.com/kohtenko)
   [#5405](https://github.com/realm/SwiftLint/issues/issue_number)
 
+* Add `excluded_patterns` to `line_length` to avoid linting lines
+  that match the patterns.
+  [kasrababaei](https://github.com/kasrababaei)
+
 #### Bug Fixes
 
 * Silence `discarded_notification_center_observer` rule in closures. Furthermore,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,8 +104,8 @@
   [Oleg Kokhtenko](https://github.com/kohtenko)
   [#5405](https://github.com/realm/SwiftLint/issues/issue_number)
 
-* Add `excluded_patterns` to `line_length` to avoid linting lines
-  that match the patterns.
+* Add `excluded_lines_patterns` to `line_length` to avoid linting lines
+  that contain one of the patterns.  
   [kasrababaei](https://github.com/kasrababaei)
 
 #### Bug Fixes

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/LineLengthRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/LineLengthRule.swift
@@ -62,7 +62,7 @@ struct LineLengthRule: Rule {
                 return nil
             }
 
-            for pattern in configuration.excludedPatterns where line.containsMatchingPattern(pattern) {
+            for pattern in configuration.excludedLinesPatterns where line.containsMatchingPattern(pattern) {
                 return nil
             }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/LineLengthRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/LineLengthRule.swift
@@ -62,6 +62,10 @@ struct LineLengthRule: Rule {
                 return nil
             }
 
+            for pattern in configuration.excludedPatterns where line.containsMatchingPattern(pattern) {
+                return nil
+            }
+
             var strippedString = line.content
             if configuration.ignoresURLs {
                 strippedString = strippedString.strippingURLs
@@ -118,6 +122,12 @@ struct LineLengthRule: Rule {
             return false
         }
         return !kinds.isDisjoint(with: kindsByLine[index])
+    }
+}
+
+private extension Line {
+    func containsMatchingPattern(_ pattern: String) -> Bool {
+        regex(pattern).firstMatch(in: content, range: content.fullNSRange) != nil
     }
 }
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/LineLengthConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/LineLengthConfiguration.swift
@@ -14,6 +14,8 @@ struct LineLengthConfiguration: RuleConfiguration {
     private(set) var ignoresComments = false
     @ConfigurationElement(key: "ignores_interpolated_strings")
     private(set) var ignoresInterpolatedStrings = false
+    @ConfigurationElement(key: "excluded_patterns")
+    private(set) var excludedPatterns: Set<String> = []
 
     var params: [RuleParameter<Int>] {
         return length.params

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/LineLengthConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/LineLengthConfiguration.swift
@@ -14,8 +14,8 @@ struct LineLengthConfiguration: RuleConfiguration {
     private(set) var ignoresComments = false
     @ConfigurationElement(key: "ignores_interpolated_strings")
     private(set) var ignoresInterpolatedStrings = false
-    @ConfigurationElement(key: "excluded_patterns")
-    private(set) var excludedPatterns: Set<String> = []
+    @ConfigurationElement(key: "excluded_lines_patterns")
+    private(set) var excludedLinesPatterns: Set<String> = []
 
     var params: [RuleParameter<Int>] {
         return length.params

--- a/Tests/SwiftLintFrameworkTests/LineLengthConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LineLengthConfigurationTests.swift
@@ -46,6 +46,15 @@ class LineLengthConfigurationTests: SwiftLintTestCase {
         XCTAssertFalse(configuration2.ignoresInterpolatedStrings)
     }
 
+    func testLineLengthConfigurationInitialiserSetsExcludedPatterns() {
+        let patterns: Set = ["foo", "bar"]
+        let configuration1 = LineLengthConfiguration(length: severityLevels, excludedPatterns: patterns)
+        XCTAssertEqual(configuration1.excludedPatterns, patterns)
+
+        let configuration2 = LineLengthConfiguration(length: severityLevels)
+        XCTAssertTrue(configuration2.excludedPatterns.isEmpty)
+    }
+
     func testLineLengthConfigurationParams() {
         let warning = 13
         let error = 10

--- a/Tests/SwiftLintFrameworkTests/LineLengthConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LineLengthConfigurationTests.swift
@@ -46,13 +46,13 @@ class LineLengthConfigurationTests: SwiftLintTestCase {
         XCTAssertFalse(configuration2.ignoresInterpolatedStrings)
     }
 
-    func testLineLengthConfigurationInitialiserSetsExcludedPatterns() {
+    func testLineLengthConfigurationInitialiserSetsExcludedLinesPatterns() {
         let patterns: Set = ["foo", "bar"]
-        let configuration1 = LineLengthConfiguration(length: severityLevels, excludedPatterns: patterns)
-        XCTAssertEqual(configuration1.excludedPatterns, patterns)
+        let configuration1 = LineLengthConfiguration(length: severityLevels, excludedLinesPatterns: patterns)
+        XCTAssertEqual(configuration1.excludedLinesPatterns, patterns)
 
         let configuration2 = LineLengthConfiguration(length: severityLevels)
-        XCTAssertTrue(configuration2.excludedPatterns.isEmpty)
+        XCTAssertTrue(configuration2.excludedLinesPatterns.isEmpty)
     }
 
     func testLineLengthConfigurationParams() {

--- a/Tests/SwiftLintFrameworkTests/LineLengthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LineLengthRuleTests.swift
@@ -92,7 +92,7 @@ class LineLengthRuleTests: SwiftLintTestCase {
                    commentDoesntViolate: false, stringDoesntViolate: false)
     }
 
-    func testLineLengthWithExcludedPatterns() {
+    func testLineLengthWithExcludedLinesPatterns() {
         let nonTriggeringLines = [plainString, interpolatedString]
 
         let baseDescription = LineLengthRule.description
@@ -105,13 +105,13 @@ class LineLengthRuleTests: SwiftLintTestCase {
 
         verifyRule(
             description,
-            ruleConfiguration: ["excluded_patterns": ["^print"]],
+            ruleConfiguration: ["excluded_lines_patterns": ["^print"]],
             commentDoesntViolate: false,
             stringDoesntViolate: false
         )
     }
 
-    func testLineLengthWithEmptyExcludedPatterns() {
+    func testLineLengthWithEmptyExcludedLinesPatterns() {
         let triggeringLines = [plainString, interpolatedString]
 
         let baseDescription = LineLengthRule.description
@@ -124,7 +124,7 @@ class LineLengthRuleTests: SwiftLintTestCase {
 
         verifyRule(
             description,
-            ruleConfiguration: ["excluded_patterns": []],
+            ruleConfiguration: ["excluded_lines_patterns": []],
             commentDoesntViolate: false,
             stringDoesntViolate: false
         )

--- a/Tests/SwiftLintFrameworkTests/LineLengthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LineLengthRuleTests.swift
@@ -91,4 +91,42 @@ class LineLengthRuleTests: SwiftLintTestCase {
         verifyRule(description, ruleConfiguration: ["ignores_interpolated_strings": false],
                    commentDoesntViolate: false, stringDoesntViolate: false)
     }
+
+    func testLineLengthWithExcludedPatterns() {
+        let nonTriggeringLines = [plainString, interpolatedString]
+
+        let baseDescription = LineLengthRule.description
+        let nonTriggeringExamples = baseDescription.nonTriggeringExamples + nonTriggeringLines
+        let triggeringExamples = baseDescription.triggeringExamples
+
+        let description = baseDescription
+            .with(nonTriggeringExamples: nonTriggeringExamples)
+            .with(triggeringExamples: triggeringExamples)
+
+        verifyRule(
+            description,
+            ruleConfiguration: ["excluded_patterns": ["^print"]],
+            commentDoesntViolate: false,
+            stringDoesntViolate: false
+        )
+    }
+
+    func testLineLengthWithEmptyExcludedPatterns() {
+        let triggeringLines = [plainString, interpolatedString]
+
+        let baseDescription = LineLengthRule.description
+        let nonTriggeringExamples = baseDescription.nonTriggeringExamples
+        let triggeringExamples = baseDescription.triggeringExamples + triggeringLines
+
+        let description = baseDescription
+            .with(nonTriggeringExamples: nonTriggeringExamples)
+            .with(triggeringExamples: triggeringExamples)
+
+        verifyRule(
+            description,
+            ruleConfiguration: ["excluded_patterns": []],
+            commentDoesntViolate: false,
+            stringDoesntViolate: false
+        )
+    }
 }


### PR DESCRIPTION
We noticed there's no way to define a set of regex to skip running the `line_length` rule on lines that match the pattern. 

This is to avoid disabling the rule in many places. A good example, that actually made me put up a PR, is having long test names. We use Quick and Nimble in our project and don't want to discourage developers to shorten test descriptions. 

So, provided the configuration is:
```
line_length:
  warning: 30
  error: 50
  ignores_comments: true
  ignores_urls: true
  excluded_patterns:
    - "^print"
```

swiflint won't trigger a warning for this sample code:
```
enum Foo {
    static func testFunc() {
        print("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA") // This wouldn't trigger a warning
    }
}
```
