### PR TITLE
Add new opt-in rule `discouraged_orphan_init`

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -16,6 +16,7 @@ disabled_rules:
   - conditional_returns_on_newline
   - convenience_type
   - discouraged_optional_collection
+  - discouraged_orphan_init
   - explicit_acl
   - explicit_enum_raw_value
   - explicit_top_level_acl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,10 @@
   that contain one of the patterns.  
   [kasrababaei](https://github.com/kasrababaei)
 
+* Add new opt-in rule `discouraged_orphan_init` to enforces explicit type
+  declaration to improve readability by avoiding ambiguous .init usage.  
+  [Otávio Cordeiro](https://github.com/otaviocc)
+
 #### Bug Fixes
 
 * Silence `discarded_notification_center_observer` rule in closures. Furthermore,

--- a/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
+++ b/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
@@ -43,6 +43,7 @@ public let builtInRules: [any Rule.Type] = [
     DiscouragedObjectLiteralRule.self,
     DiscouragedOptionalBooleanRule.self,
     DiscouragedOptionalCollectionRule.self,
+    DiscouragedOrphanInitRule.self,
     DuplicateConditionsRule.self,
     DuplicateEnumCasesRule.self,
     DuplicateImportsRule.self,

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedOrphanInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedOrphanInitRule.swift
@@ -1,0 +1,31 @@
+import SwiftSyntax
+
+@SwiftSyntaxRule
+struct DiscouragedOrphanInitRule: OptInRule {
+    var configuration = SeverityConfiguration<Self>(.warning)
+
+    static let description = RuleDescription(
+        identifier: "discouraged_orphan_init",
+        name: "Discouraged Orphan .init",
+        description: "Enforces explicit type declaration to improve readability by avoiding ambiguous .init usage",
+        kind: .idiomatic,
+        nonTriggeringExamples: DiscouragedOrphanInitRuleExamples.nonTriggeringExamples,
+        triggeringExamples: DiscouragedOrphanInitRuleExamples.triggeringExamples
+    )
+}
+
+private extension DiscouragedOrphanInitRule {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
+        override func visitPost(_ node: FunctionCallExprSyntax) {
+            guard let expression = node.calledExpression.as(MemberAccessExprSyntax.self),
+                  expression.base == nil,
+                  expression.period.tokenKind == .period,
+                  let name = expression.declName.as(DeclReferenceExprSyntax.self),
+                  name.baseName.tokenKind == .keyword(.`init`) else {
+                return
+            }
+
+            violations.append(node.positionAfterSkippingLeadingTrivia)
+        }
+    }
+}

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedOrphanInitRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedOrphanInitRuleExamples.swift
@@ -1,0 +1,31 @@
+internal struct DiscouragedOrphanInitRuleExamples {
+    static let nonTriggeringExamples = [
+        Example("callSomething(Foobar.init())"),
+        Example("callSomething(Foobar.init(parameter: 42))"),
+        Example("""
+        callSomething(
+            parameter: Foobar.init()
+        )
+        """),
+        Example("""
+        callSomething(
+            Foobar.init(parameter: 42)
+        )
+        """)
+    ]
+
+    static let triggeringExamples = [
+        Example("callSomething(↓.init())"),
+        Example("callSomething(↓.init(parameter: 42))"),
+        Example("""
+        callSomething(
+            parameter: ↓.init()
+        )
+        """),
+        Example("""
+        callSomething(
+            ↓.init(parameter: 42)
+        )
+        """)
+    ]
+}

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedOrphanInitRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedOrphanInitRuleExamples.swift
@@ -11,6 +11,23 @@ internal struct DiscouragedOrphanInitRuleExamples {
         callSomething(
             Foobar.init(parameter: 42)
         )
+        """),
+        Example("""
+        callSomething(
+            parameter: Foobar.init(
+                parameter: 42
+            )
+        )
+        """),
+        Example("""
+        someClosure {
+            Foobar.init()
+        }
+        """),
+        Example("""
+        someClosure { _ in
+            Foobar.init(parameter: 42)
+        }
         """)
     ]
 
@@ -26,6 +43,23 @@ internal struct DiscouragedOrphanInitRuleExamples {
         callSomething(
             ↓.init(parameter: 42)
         )
+        """),
+        Example("""
+        callSomething(
+            parameter: ↓.init(
+                parameter: 42
+            )
+        )
+        """),
+        Example("""
+        someClosure {
+            ↓.init()
+        }
+        """),
+        Example("""
+        someClosure { _ in
+            ↓.init(parameter: 42)
+        }
         """)
     ]
 }

--- a/Tests/GeneratedTests/GeneratedTests.swift
+++ b/Tests/GeneratedTests/GeneratedTests.swift
@@ -248,6 +248,12 @@ class DiscouragedOptionalCollectionRuleGeneratedTests: SwiftLintTestCase {
     }
 }
 
+class DiscouragedOrphanInitRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(DiscouragedOrphanInitRule.description)
+    }
+}
+
 class DuplicateConditionsRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(DuplicateConditionsRule.description)


### PR DESCRIPTION
This pull request introduces a new **opt-in** rule, `discouraged_orphan_init`, aimed at improving code readability and clarity within Swift projects. The rule discourages the use of `.init` without explicit type declaration, addressing a common readability issue in code reviews and collaborative environments.

In many instances, using `.init` alone can make it challenging to understand the type being initialized, especially when the type cannot be easily inferred from the context. This lack of clarity can lead to confusion and increased time spent on understanding and reviewing code. By enforcing explicit type declaration with initializers, this rule helps ensure that the code is more self-documenting and easier to read.

Some triggering examples:

```swift
callSomething(↓.init())
callSomething(↓.init(parameter: 42))

callSomething(
    parameter: ↓.init()
)

someClosure {
    ↓.init()
}
```

I believe this rule will be a valuable addition to our SwiftLint configuration, and I look forward to your feedback and suggestions on this pull request.