### PR TITLE
Make implicitly confirming to Actor to trigger warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 #### Enhancements
 
+* Make implicitly confirming to `Actor` to trigger warning.
+  [marunomi](https://github.com/marunomi)
+  [#issue_number](https://github.com/realm/SwiftLint/issues/issue_number)
+
 * Add new option `ignore_typealiases_and_associatedtypes` to
   `nesting` rule. It excludes `typealias` and `associatedtype`
   declarations from the analysis.

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/MissingDocsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/MissingDocsRule.swift
@@ -1,4 +1,5 @@
 import SourceKittenFramework
+import SwiftSyntax
 
 private extension SwiftLintFile {
     func missingDocOffsets(in dictionary: SourceKittenDictionary,
@@ -43,7 +44,7 @@ private extension SwiftLintFile {
     }
 }
 
-struct MissingDocsRule: OptInRule {
+struct MissingDocsRule: OptInRule, SourceKitFreeRule {
     init() {
         configuration = MissingDocsConfiguration()
     }
@@ -123,6 +124,12 @@ struct MissingDocsRule: OptInRule {
     func validate(file: SwiftLintFile) -> [StyleViolation] {
         let acls = configuration.parameters.map { $0.value }
         let dict = file.structureDictionary
+        let isImplictlyActorDecleation: Bool = ClassDeclaratopmVisitor(viewMode: .sourceAccurate)
+            .walk(tree: file.syntaxTree, handler: \.isActorImplicitlyHerited)
+
+        if isImplictlyActorDecleation && configuration.excludesInheritedTypes {
+            return []
+        }
         return file.missingDocOffsets(
             in: dict,
             acls: acls,
@@ -135,5 +142,12 @@ struct MissingDocsRule: OptInRule {
                            location: Location(file: file, byteOffset: offset),
                            reason: "\(acl.description) declarations should be documented")
         }
+    }
+}
+
+private class ClassDeclaratopmVisitor: SyntaxVisitor {
+    private(set) var isActorImplicitlyHerited: Bool = false
+    override func visitPost(_ node: ActorDeclSyntax) {
+        isActorImplicitlyHerited = true
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/MissingDocsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/MissingDocsRule.swift
@@ -44,7 +44,7 @@ private extension SwiftLintFile {
     }
 }
 
-struct MissingDocsRule: OptInRule, SourceKitFreeRule {
+struct MissingDocsRule: OptInRule {
     init() {
         configuration = MissingDocsConfiguration()
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/MissingDocsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/MissingDocsRule.swift
@@ -146,7 +146,8 @@ struct MissingDocsRule: OptInRule, SourceKitFreeRule {
 }
 
 private class ClassDeclaratopmVisitor: SyntaxVisitor {
-    private(set) var isActorImplicitlyHerited: Bool = false
+    private(set) var isActorImplicitlyHerited = false
+
     override func visitPost(_ node: ActorDeclSyntax) {
         isActorImplicitlyHerited = true
     }

--- a/Tests/SwiftLintFrameworkTests/MissingDocsRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/MissingDocsRuleTests.swift
@@ -188,6 +188,27 @@ class MissingDocsRuleTests: SwiftLintTestCase {
         )
     }
 
+    func testExcludesImplicitlyActorHelitedTrueByDefault() {
+        let baseDescription = MissingDocsRule.description
+        let nonTriggeringExamples = [
+            Example("""
+            /// Docs
+            public final actor MyActor {
+                public nonisolated var unownedExecutor: UnownedSerialExecutor { }
+            }
+            """),
+            Example("""
+            /// Docs
+            public final actor MyActor: Actor {
+                public nonisolated var unownedExecutor: UnownedSerialExecutor { }
+            }
+            """)
+        ]
+        let description = baseDescription.with(nonTriggeringExamples: nonTriggeringExamples)
+        verifyRule(description,
+                   ruleConfiguration: ["excludes_inherited_types": true])
+    }
+
     func testWithExcludesExtensionsDisabled() {
         // Perform additional tests with the ignores_comments settings disabled.
         let baseDescription = MissingDocsRule.description


### PR DESCRIPTION
This PR will resolve https://github.com/realm/SwiftLint/issues/5422 by adding checking for implicitly confirming to Actor protocol.

Before the validate function, I used visitPost(_ node: ActorDeclSyntax) to determine if the actor keyword is used.
I wrote it this way because I could not determine within the missingDocOffsets function whether the actor keyword is used or not.