### PR TITLE
Prefer `package` ACL over `@_spi`

### DIFF
--- a/.sourcery/GeneratedTests.stencil
+++ b/.sourcery/GeneratedTests.stencil
@@ -1,5 +1,4 @@
 @testable import SwiftLintBuiltInRules
-@_spi(TestHelper)
 @testable import SwiftLintCore
 import SwiftLintTestHelpers
 

--- a/BUILD
+++ b/BUILD
@@ -67,6 +67,7 @@ universal_swift_compiler_plugin(
 
 swift_library(
     name = "SwiftLintCore",
+    package_name = "SwiftLint",
     srcs = glob(["Source/SwiftLintCore/**/*.swift"]),
     copts = copts,  # TODO: strict_concurrency_copts
     module_name = "SwiftLintCore",
@@ -92,6 +93,7 @@ swift_library(
 
 swift_library(
     name = "SwiftLintBuiltInRules",
+    package_name = "SwiftLint",
     srcs = glob(["Source/SwiftLintBuiltInRules/**/*.swift"]),
     copts = copts + select({
         ":strict_concurrency_builtin_rules": strict_concurrency_copts,
@@ -106,6 +108,7 @@ swift_library(
 
 swift_library(
     name = "SwiftLintExtraRules",
+    package_name = "SwiftLint",
     srcs = [
         "Source/SwiftLintExtraRules/Exports.swift",
         "@swiftlint_extra_rules//:extra_rules",
@@ -120,6 +123,7 @@ swift_library(
 
 swift_library(
     name = "SwiftLintFramework",
+    package_name = "SwiftLint",
     srcs = glob(
         ["Source/SwiftLintFramework/**/*.swift"],
     ),
@@ -135,6 +139,7 @@ swift_library(
 
 swift_library(
     name = "swiftlint.library",
+    package_name = "SwiftLint",
     srcs = glob(["Source/swiftlint/**/*.swift"]),
     copts = copts,  # TODO: strict_concurrency_copts
     module_name = "swiftlint",

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gem 'cocoapods'
 gem 'danger'
-gem 'jazzy'
+gem 'jazzy', '~> 0.14.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,13 +92,13 @@ GEM
     httpclient (2.8.3)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
-    jazzy (0.14.3)
+    jazzy (0.14.4)
       cocoapods (~> 1.5)
       mustache (~> 1.1)
       open4 (~> 1.3)
       redcarpet (~> 3.4)
       rexml (~> 3.2)
-      rouge (>= 2.0.6, < 4.0)
+      rouge (>= 2.0.6, < 5.0)
       sassc (~> 2.1)
       sqlite3 (~> 1.3)
       xcinvoke (~> 0.3.0)
@@ -123,7 +123,7 @@ GEM
     rchardet (1.8.0)
     redcarpet (3.6.0)
     rexml (3.2.5)
-    rouge (3.30.0)
+    rouge (4.2.0)
     ruby-macho (2.5.1)
     ruby2_keywords (0.0.5)
     sassc (2.4.0)
@@ -131,8 +131,8 @@ GEM
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
-    sqlite3 (1.6.2-arm64-darwin)
-    sqlite3 (1.6.2-x86_64-linux)
+    sqlite3 (1.7.2-arm64-darwin)
+    sqlite3 (1.7.2-x86_64-linux)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     typhoeus (1.4.0)
@@ -153,12 +153,13 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
   cocoapods
   danger
-  jazzy
+  jazzy (~> 0.14.4)
 
 BUNDLED WITH
    2.4.12

--- a/Source/SwiftLintCore/Extensions/Configuration+FileGraph.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+FileGraph.swift
@@ -1,7 +1,6 @@
 import Foundation
 
-@_spi(TestHelper)
-public extension Configuration {
+package extension Configuration {
     struct FileGraph: Hashable {
         // MARK: - Properties
         private static let defaultRemoteConfigTimeout: TimeInterval = 2

--- a/Source/SwiftLintCore/Extensions/Configuration+IndentationStyle.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+IndentationStyle.swift
@@ -7,8 +7,7 @@ public extension Configuration {
         case spaces(count: Int)
 
         /// The default indentation style if none is explicitly provided.
-        @_spi(TestHelper)
-        public static let `default` = spaces(count: 4)
+        package static let `default` = spaces(count: 4)
 
         /// Creates an indentation style based on an untyped configuration value.
         ///

--- a/Source/SwiftLintCore/Extensions/Configuration+Merging.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Merging.swift
@@ -6,8 +6,7 @@ import SourceKittenFramework
 
 extension Configuration {
     // MARK: - Methods: Merging
-    @_spi(TestHelper)
-    public func merged(
+    package func merged(
         withChild childConfiguration: Configuration,
         rootDirectory: String
     ) -> Configuration {

--- a/Source/SwiftLintCore/Extensions/SwiftLintFile+Cache.swift
+++ b/Source/SwiftLintCore/Extensions/SwiftLintFile+Cache.swift
@@ -53,8 +53,7 @@ private let linesWithTokensCache = Cache { $0.computeLinesWithTokens() }
 internal typealias AssertHandler = () -> Void
 // Re-enable once all parser diagnostics in tests have been addressed.
 // https://github.com/realm/SwiftLint/issues/3348
-@_spi(TestHelper)
-public var parserDiagnosticsDisabledForTests = false
+package var parserDiagnosticsDisabledForTests = false
 
 private let assertHandlers = [FileCacheKey: AssertHandler]()
 private let assertHandlerCache = Cache { file in assertHandlers[file.cacheKey] }
@@ -209,8 +208,7 @@ extension SwiftLintFile {
         linesWithTokensCache.invalidate(self)
     }
 
-    @_spi(TestHelper)
-    public static func clearCaches() {
+    package static func clearCaches() {
         responseCache.clear()
         assertHandlerCache.clear()
         structureDictionaryCache.clear()

--- a/Source/SwiftLintCore/Models/Configuration.swift
+++ b/Source/SwiftLintCore/Models/Configuration.swift
@@ -124,8 +124,7 @@ public struct Configuration {
     /// - parameter pinnedVersion:          The SwiftLint version defined in this configuration.
     /// - parameter allowZeroLintableFiles: Allow SwiftLint to exit successfully when passed ignored or unlintable files
     /// - parameter strict:                 Treat warnings as errors
-    @_spi(TestHelper)
-    public init(
+    package init(
         rulesMode: RulesMode = .default(disabled: [], optIn: []),
         allRulesWrapped: [ConfigurationRuleWrapper]? = nil,
         ruleList: RuleList = RuleRegistry.shared.list,

--- a/Source/SwiftLintCore/Models/ConfigurationRuleWrapper.swift
+++ b/Source/SwiftLintCore/Models/ConfigurationRuleWrapper.swift
@@ -1,2 +1,1 @@
-@_spi(TestHelper)
-public typealias ConfigurationRuleWrapper = (rule: any Rule, initializedWithNonEmptyConfiguration: Bool)
+package typealias ConfigurationRuleWrapper = (rule: any Rule, initializedWithNonEmptyConfiguration: Bool)

--- a/Source/SwiftLintCore/Models/Example.swift
+++ b/Source/SwiftLintCore/Models/Example.swift
@@ -19,14 +19,11 @@ public struct Example: Sendable {
     /// - SeeAlso: addEmoji(_:)
     public private(set) var testMultiByteOffsets: Bool
     /// Whether tests shall verify that the example wrapped in a comment doesn't trigger
-    @_spi(TestHelper)
-    public private(set) var testWrappingInComment: Bool
+    package private(set) var testWrappingInComment: Bool
     /// Whether tests shall verify that the example wrapped into a string doesn't trigger
-    @_spi(TestHelper)
-    public private(set) var testWrappingInString: Bool
+    package private(set) var testWrappingInString: Bool
     /// Whether tests shall verify that the disabled rule (comment in the example) doesn't trigger
-    @_spi(TestHelper)
-    public private(set) var testDisableCommand: Bool
+    package private(set) var testDisableCommand: Bool
     /// Whether the example should be tested on Linux
     public private(set) var testOnLinux: Bool
     /// The path to the file where the example was created
@@ -43,8 +40,7 @@ public struct Example: Sendable {
     let excludeFromDocumentation: Bool
 
     /// Specifies whether the test example should be the only example run during the current test case execution.
-    @_spi(TestHelper)
-    public var isFocused: Bool
+    package var isFocused: Bool
 }
 
 public extension Example {

--- a/Source/SwiftLintCore/Models/SwiftLintFile.swift
+++ b/Source/SwiftLintCore/Models/SwiftLintFile.swift
@@ -66,8 +66,7 @@ public final class SwiftLintFile {
     }
 
     /// Mark this file as used for testing purposes.
-    @_spi(TestHelper)
-    public func markAsTestFile() {
+    package func markAsTestFile() {
         isTestFile = true
     }
 }

--- a/Source/SwiftLintCore/Protocols/CollectingRule.swift
+++ b/Source/SwiftLintCore/Protocols/CollectingRule.swift
@@ -87,8 +87,7 @@ public extension CollectingRule where Self: AnalyzerRule {
 }
 
 /// A `CollectingRule` that is also a `CorrectableRule`.
-@_spi(TestHelper)
-public protocol CollectingCorrectableRule: CollectingRule, CorrectableRule {
+package protocol CollectingCorrectableRule: CollectingRule, CorrectableRule {
     /// Attempts to correct the violations to this rule in the specified file after collecting file info for all files
     /// and returns all corrections that were applied.
     ///
@@ -114,8 +113,7 @@ public protocol CollectingCorrectableRule: CollectingRule, CorrectableRule {
     func correct(file: SwiftLintFile, collectedInfo: [SwiftLintFile: FileInfo]) -> [Correction]
 }
 
-@_spi(TestHelper)
-public extension CollectingCorrectableRule {
+package extension CollectingCorrectableRule {
     func correct(file: SwiftLintFile, collectedInfo: [SwiftLintFile: FileInfo],
                  compilerArguments: [String]) -> [Correction] {
         return correct(file: file, collectedInfo: collectedInfo)
@@ -137,7 +135,7 @@ public extension CollectingCorrectableRule {
     }
 }
 
-public extension CollectingCorrectableRule where Self: AnalyzerRule {
+package extension CollectingCorrectableRule where Self: AnalyzerRule {
     func correct(file: SwiftLintFile) -> [Correction] {
         queuedFatalError("Must call `correct(file:collectedInfo:compilerArguments:)` for AnalyzerRule")
     }

--- a/Source/SwiftLintCore/Rules/SuperfluousDisableCommandRule.swift
+++ b/Source/SwiftLintCore/Rules/SuperfluousDisableCommandRule.swift
@@ -1,10 +1,9 @@
-@_spi(TestHelper)
-public struct SuperfluousDisableCommandRule: SourceKitFreeRule {
-    public var configuration = SeverityConfiguration<Self>(.warning)
+package struct SuperfluousDisableCommandRule: SourceKitFreeRule {
+    package var configuration = SeverityConfiguration<Self>(.warning)
 
-    public init() {}
+    package init() {}
 
-    public static let description = RuleDescription(
+    package static let description = RuleDescription(
         identifier: "superfluous_disable_command",
         name: "Superfluous Disable Command",
         description: """
@@ -30,7 +29,7 @@ public struct SuperfluousDisableCommandRule: SourceKitFreeRule {
         ]
     )
 
-    public func validate(file: SwiftLintFile) -> [StyleViolation] {
+    package func validate(file: SwiftLintFile) -> [StyleViolation] {
         // This rule is implemented in Linter.swift
         return []
     }

--- a/Tests/BUILD
+++ b/Tests/BUILD
@@ -11,6 +11,7 @@ swift_library(
     testonly = True,
     srcs = glob(["CLITests/**/*.swift"]),
     module_name = "CLITests",
+    package_name = "SwiftLint",
     deps = [
         "//:swiftlint.library",
     ],
@@ -50,6 +51,7 @@ swift_library(
     testonly = True,
     srcs = glob(["SwiftLintTestHelpers/**/*.swift"]),
     module_name = "SwiftLintTestHelpers",
+    package_name = "SwiftLint",
     deps = [
         "//:SwiftLintFramework",
     ],
@@ -85,6 +87,7 @@ swift_library(
     testonly = True,
     srcs = [":SwiftLintFrameworkTestsSources"],
     module_name = "SwiftLintFrameworkTests",
+    package_name = "SwiftLint",
     deps = [
         ":SwiftLintTestHelpers",
     ],
@@ -109,6 +112,7 @@ swift_library(
     testonly = True,
     srcs = ["GeneratedTests/GeneratedTests.swift"],
     module_name = "GeneratedTests",
+    package_name = "SwiftLint",
     deps = [
         ":SwiftLintTestHelpers",
     ],
@@ -128,6 +132,7 @@ swift_library(
     testonly = True,
     srcs = ["IntegrationTests/IntegrationTests.swift"],
     module_name = "IntegrationTests",
+    package_name = "SwiftLint",
     deps = [
         ":SwiftLintTestHelpers",
     ],
@@ -163,6 +168,7 @@ swift_library(
         "//conditions:default": [],
     }),
     module_name = "ExtraRulesTests",
+    package_name = "SwiftLint",
     deps = [
         ":SwiftLintTestHelpers",
     ],

--- a/Tests/CLITests/RulesFilterTests.swift
+++ b/Tests/CLITests/RulesFilterTests.swift
@@ -1,5 +1,4 @@
 @testable import swiftlint
-@_spi(TestHelper)
 import SwiftLintFramework
 import XCTest
 

--- a/Tests/GeneratedTests/GeneratedTests.swift
+++ b/Tests/GeneratedTests/GeneratedTests.swift
@@ -1,7 +1,6 @@
 // Generated using Sourcery 2.1.2 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
 @testable import SwiftLintBuiltInRules
-@_spi(TestHelper)
 @testable import SwiftLintCore
 import SwiftLintTestHelpers
 

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -1,5 +1,4 @@
 import Foundation
-@_spi(TestHelper)
 import SwiftLintFramework
 import SwiftLintTestHelpers
 import XCTest

--- a/Tests/SwiftLintFrameworkTests/CollectingRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CollectingRuleTests.swift
@@ -1,6 +1,4 @@
-@_spi(TestHelper)
 @testable import SwiftLintCore
-@_spi(TestHelper)
 import SwiftLintTestHelpers
 import XCTest
 

--- a/Tests/SwiftLintFrameworkTests/CommandTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CommandTests.swift
@@ -1,7 +1,6 @@
 // swiftlint:disable file_length
 import Foundation
 import SourceKittenFramework
-@_spi(TestHelper)
 @testable import SwiftLintCore
 import XCTest
 

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -1,5 +1,4 @@
 @testable import SwiftLintBuiltInRules
-@_spi(TestHelper)
 @testable import SwiftLintCore
 import XCTest
 

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -1,6 +1,5 @@
 import Foundation
 import SourceKittenFramework
-@_spi(TestHelper)
 @testable import SwiftLintCore
 import XCTest
 

--- a/Tests/SwiftLintFrameworkTests/ParserDiagnosticsTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ParserDiagnosticsTests.swift
@@ -1,5 +1,4 @@
 @testable import SwiftLintBuiltInRules
-@_spi(TestHelper)
 @testable import SwiftLintCore
 import XCTest
 

--- a/Tests/SwiftLintFrameworkTests/SourceKitCrashTests.swift
+++ b/Tests/SwiftLintFrameworkTests/SourceKitCrashTests.swift
@@ -1,4 +1,3 @@
-@_spi(TestHelper)
 @testable import SwiftLintCore
 import XCTest
 

--- a/Tests/SwiftLintTestHelpers/TestHelpers.swift
+++ b/Tests/SwiftLintTestHelpers/TestHelpers.swift
@@ -1,6 +1,5 @@
 import Foundation
 import SourceKittenFramework
-@_spi(TestHelper)
 import SwiftLintCore
 import XCTest
 
@@ -87,7 +86,6 @@ public extension Collection where Element == String {
                 .violations(config: config, requiresFileOnDisk: requiresFileOnDisk)
     }
 
-    @_spi(TestHelper)
     func corrections(config: Configuration = Configuration.default, requiresFileOnDisk: Bool = false) -> [Correction] {
         return map { SwiftLintFile.testFile(withContents: $0, persistToDisk: requiresFileOnDisk) }
             .corrections(config: config, requiresFileOnDisk: requiresFileOnDisk)
@@ -109,7 +107,6 @@ public extension Collection where Element: SwiftLintFile {
             return requiresFileOnDisk ? violations.withoutFiles() : violations
     }
 
-    @_spi(TestHelper)
     func corrections(config: Configuration = Configuration.default, requiresFileOnDisk: Bool = false) -> [Correction] {
         let storage = RuleStorage()
         let corrections = map({ file in


### PR DESCRIPTION
The `@_spi` workaround was introduced in #4607 to make the build work for `SwiftLintTestHelper` in Xcode and SPM.

With the new `package` access control modifier in Swift 5.9, the internal `@_spi` attribute doesn't seem to be needed to give `SwiftLintTestHelper` access to internal symbols.

@ryanaveo: You contributed #4607 back then. In your environment, would this change work?