### PR TITLE
Let all rewriters have a configuration by default

### DIFF
--- a/Source/SwiftLintBuiltInRules/Helpers/LegacyFunctionRuleHelper.swift
+++ b/Source/SwiftLintBuiltInRules/Helpers/LegacyFunctionRuleHelper.swift
@@ -35,16 +35,16 @@ enum LegacyFunctionRuleHelper {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
+    final class Rewriter<Configuration: RuleConfiguration>: ViolationsSyntaxRewriter<Configuration> {
         private let legacyFunctions: [String: RewriteStrategy]
 
         init(
             legacyFunctions: [String: RewriteStrategy],
-            locationConverter: SourceLocationConverter,
-            disabledRegions: [SourceRange]
+            configuration: Configuration,
+            file: SwiftLintFile
         ) {
             self.legacyFunctions = legacyFunctions
-            super.init(locationConverter: locationConverter, disabledRegions: disabledRegions)
+            super.init(configuration: configuration, file: file)
         }
 
         override func visit(_ node: FunctionCallExprSyntax) -> ExprSyntax {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DuplicateImportsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DuplicateImportsRule.swift
@@ -35,12 +35,8 @@ struct DuplicateImportsRule: SwiftSyntaxCorrectableRule {
         queuedFatalError("Unreachable: `validate(file:)` will be used instead")
     }
 
-    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
-        Rewriter(
-            importPositionsToRemove: file.duplicateImportsViolationPositions(),
-            locationConverter: file.locationConverter,
-            disabledRegions: disabledRegions(file: file)
-        )
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter<ConfigurationType>? {
+        Rewriter(configuration: configuration, file: file)
     }
 }
 
@@ -152,17 +148,8 @@ private extension SwiftLintFile {
 }
 
 private extension DuplicateImportsRule {
-    final class Rewriter: ViolationsSyntaxRewriter {
-        let importPositionsToRemove: [AbsolutePosition]
-
-        init(
-            importPositionsToRemove: [AbsolutePosition],
-            locationConverter: SourceLocationConverter,
-            disabledRegions: [SourceRange]
-        ) {
-            self.importPositionsToRemove = importPositionsToRemove
-            super.init(locationConverter: locationConverter, disabledRegions: disabledRegions)
-        }
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
+        private lazy var importPositionsToRemove = file.duplicateImportsViolationPositions()
 
         override func visit(_ node: CodeBlockItemListSyntax) -> CodeBlockItemListSyntax {
             let itemsToRemove = node

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitInitRule.swift
@@ -201,7 +201,7 @@ private extension ExplicitInitRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: FunctionCallExprSyntax) -> ExprSyntax {
             guard let calledExpression = node.calledExpression.as(MemberAccessExprSyntax.self),
                   let violationPosition = calledExpression.explicitInitPosition,

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/JoinedDefaultParameterRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/JoinedDefaultParameterRule.swift
@@ -47,7 +47,7 @@ private extension JoinedDefaultParameterRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: FunctionCallExprSyntax) -> ExprSyntax {
             guard let violationPosition = node.violationPosition else {
                 return super.visit(node)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyCGGeometryFunctionsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyCGGeometryFunctionsRule.swift
@@ -108,11 +108,11 @@ struct LegacyCGGeometryFunctionsRule: SwiftSyntaxCorrectableRule {
         )
     }
 
-    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter<ConfigurationType>? {
         LegacyFunctionRuleHelper.Rewriter(
             legacyFunctions: Self.legacyFunctions,
-            locationConverter: file.locationConverter,
-            disabledRegions: disabledRegions(file: file)
+            configuration: configuration,
+            file: file
         )
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyConstantRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyConstantRule.swift
@@ -31,7 +31,7 @@ private extension LegacyConstantRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: DeclReferenceExprSyntax) -> ExprSyntax {
             guard let correction = LegacyConstantRuleExamples.patterns[node.baseName.text] else {
                 return super.visit(node)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyConstructorRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyConstructorRule.swift
@@ -134,7 +134,7 @@ private extension LegacyConstructorRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: FunctionCallExprSyntax) -> ExprSyntax {
             guard let identifierExpr = node.calledExpression.as(DeclReferenceExprSyntax.self),
                   case let identifier = identifierExpr.baseName.text,

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyNSGeometryFunctionsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyNSGeometryFunctionsRule.swift
@@ -108,11 +108,11 @@ struct LegacyNSGeometryFunctionsRule: SwiftSyntaxCorrectableRule {
         )
     }
 
-    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter<ConfigurationType>? {
         LegacyFunctionRuleHelper.Rewriter(
             legacyFunctions: Self.legacyFunctions,
-            locationConverter: file.locationConverter,
-            disabledRegions: disabledRegions(file: file)
+            configuration: configuration,
+            file: file
         )
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NimbleOperatorRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NimbleOperatorRule.swift
@@ -80,7 +80,7 @@ private extension NimbleOperatorRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: FunctionCallExprSyntax) -> ExprSyntax {
             guard let expectation = node.expectation(),
                   let predicate = predicatesMapping[expectation.operatorExpr.baseName.text],

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferZeroOverExplicitInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferZeroOverExplicitInitRule.swift
@@ -45,7 +45,7 @@ private extension PreferZeroOverExplicitInitRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: FunctionCallExprSyntax) -> ExprSyntax {
             guard node.hasViolation, let name = node.name else {
                 return super.visit(node)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantNilCoalescingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantNilCoalescingRule.swift
@@ -33,7 +33,7 @@ private extension RedundantNilCoalescingRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: ExprListSyntax) -> ExprListSyntax {
             guard
                 node.count > 2,

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantOptionalInitializationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantOptionalInitializationRule.swift
@@ -118,7 +118,7 @@ private extension RedundantOptionalInitializationRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visitAny(_ node: Syntax) -> Syntax? { nil }
 
         override func visit(_ node: VariableDeclSyntax) -> DeclSyntax {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantVoidReturnRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantVoidReturnRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct RedundantVoidReturnRule: SwiftSyntaxCorrectableRule {
+@SwiftSyntaxRule(explicitRewriter: true)
+struct RedundantVoidReturnRule: Rule {
     var configuration = RedundantVoidReturnConfiguration()
 
     static let description = RuleDescription(
@@ -68,14 +68,6 @@ struct RedundantVoidReturnRule: SwiftSyntaxCorrectableRule {
                 Example("protocol Foo {\n    #if true\n    func foo()\n    #endif\n}")
         ]
     )
-
-    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
-        Rewriter(
-            configuration: configuration,
-            locationConverter: file.locationConverter,
-            disabledRegions: disabledRegions(file: file)
-        )
-    }
 }
 
 private extension RedundantVoidReturnRule {
@@ -92,18 +84,7 @@ private extension RedundantVoidReturnRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
-        let configuration: ConfigurationType
-
-        init(
-            configuration: ConfigurationType,
-            locationConverter: SourceLocationConverter,
-            disabledRegions: [SourceRange]
-        ) {
-            self.configuration = configuration
-            super.init(locationConverter: locationConverter, disabledRegions: disabledRegions)
-        }
-
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: ClosureSignatureSyntax) -> ClosureSignatureSyntax {
             guard configuration.includeClosures,
                   let output = node.returnClause,

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ReturnValueFromVoidFunctionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ReturnValueFromVoidFunctionRule.swift
@@ -26,7 +26,7 @@ private extension ReturnValueFromVoidFunctionRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ statements: CodeBlockItemListSyntax) -> CodeBlockItemListSyntax {
             guard let returnStmt = statements.last?.item.as(ReturnStmtSyntax.self),
                   let expr = returnStmt.expression,

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ShorthandOptionalBindingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ShorthandOptionalBindingRule.swift
@@ -90,7 +90,7 @@ private extension ShorthandOptionalBindingRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: OptionalBindingConditionSyntax) -> OptionalBindingConditionSyntax {
             guard node.isShadowingOptionalBinding else {
                 return super.visit(node)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ToggleBoolRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ToggleBoolRule.swift
@@ -40,7 +40,7 @@ private extension ToggleBoolRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: ExprListSyntax) -> ExprListSyntax {
             guard node.hasToggleBoolViolation, let firstExpr = node.first, let index = node.index(of: firstExpr) else {
                 return super.visit(node)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/TrailingSemicolonRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/TrailingSemicolonRule.swift
@@ -35,7 +35,7 @@ private extension TrailingSemicolonRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: TokenSyntax) -> TokenSyntax {
             guard node.isTrailingSemicolon else {
                 return super.visit(node)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
@@ -99,7 +99,7 @@ private extension UnneededBreakInSwitchRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: SwitchCaseSyntax) -> SwitchCaseSyntax {
             let stmts = CodeBlockItemListSyntax(node.statements.dropLast())
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededSynthesizedInitializerRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededSynthesizedInitializerRule.swift
@@ -46,7 +46,7 @@ private extension UnneededSynthesizedInitializerRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         private var unneededInitializers: [InitializerDeclSyntax] = []
 
         override func visitAny(_ node: Syntax) -> Syntax? { nil }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UntypedErrorInCatchRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UntypedErrorInCatchRule.swift
@@ -119,7 +119,7 @@ private extension UntypedErrorInCatchRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: CatchClauseSyntax) -> CatchClauseSyntax {
             guard let item = node.catchItems.onlyElement, item.isIdentifierPattern else {
                 return super.visit(node)

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AnyObjectProtocolRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AnyObjectProtocolRule.swift
@@ -43,11 +43,8 @@ struct AnyObjectProtocolRule: SwiftSyntaxCorrectableRule, OptInRule {
         return Visitor(configuration: configuration, file: file)
     }
 
-    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
-        Rewriter(
-            locationConverter: file.locationConverter,
-            disabledRegions: disabledRegions(file: file)
-        )
+    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter<ConfigurationType>? {
+        Rewriter(configuration: configuration, file: file)
     }
 }
 
@@ -58,7 +55,7 @@ private extension AnyObjectProtocolRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: InheritedTypeSyntax) -> InheritedTypeSyntax {
             let typeName = node.type
             guard typeName.is(ClassRestrictionTypeSyntax.self) else {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/LowerACLThanParentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/LowerACLThanParentRule.swift
@@ -91,7 +91,7 @@ private extension LowerACLThanParentRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: DeclModifierSyntax) -> DeclModifierSyntax {
             guard node.isHigherACLThanParent else {
                 return super.visit(node)

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/MarkRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/MarkRule.swift
@@ -25,7 +25,7 @@ private extension MarkRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ token: TokenSyntax) -> TokenSyntax {
             var pieces = token.leadingTrivia.pieces
             for result in token.violationResults() {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateUnitTestRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateUnitTestRule.swift
@@ -1,8 +1,8 @@
 import Foundation
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct PrivateUnitTestRule: SwiftSyntaxCorrectableRule {
+@SwiftSyntaxRule(explicitRewriter: true)
+struct PrivateUnitTestRule: Rule {
     var configuration = PrivateUnitTestConfiguration()
 
     static let description = RuleDescription(
@@ -125,14 +125,6 @@ struct PrivateUnitTestRule: SwiftSyntaxCorrectableRule {
                     """)
         ]
     )
-
-    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
-        Rewriter(
-            configuration: configuration,
-            locationConverter: file.locationConverter,
-            disabledRegions: disabledRegions(file: file)
-        )
-    }
 }
 
 private extension PrivateUnitTestRule {
@@ -156,16 +148,7 @@ private extension PrivateUnitTestRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
-        private let configuration: PrivateUnitTestConfiguration
-
-        init(configuration: PrivateUnitTestConfiguration,
-             locationConverter: SourceLocationConverter,
-             disabledRegions: [SourceRange]) {
-            self.configuration = configuration
-            super.init(locationConverter: locationConverter, disabledRegions: disabledRegions)
-        }
-
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: ClassDeclSyntax) -> DeclSyntax {
             guard node.isPrivate, node.hasParent(configuredIn: configuration) else {
                 return super.visit(node)

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/StrongIBOutletRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/StrongIBOutletRule.swift
@@ -38,7 +38,7 @@ private extension StrongIBOutletRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: VariableDeclSyntax) -> DeclSyntax {
             guard let violationPosition = node.violationPosition,
                   let weakOrUnownedModifier = node.weakOrUnownedModifier,

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnneededOverrideRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnneededOverrideRule.swift
@@ -31,7 +31,7 @@ private extension UnneededOverrideRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: FunctionDeclSyntax) -> DeclSyntax {
             guard node.isUnneededOverride else {
                 return super.visit(node)

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedClosureParameterRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedClosureParameterRule.swift
@@ -33,7 +33,7 @@ private extension UnusedClosureParameterRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: ClosureExprSyntax) -> ExprSyntax {
             guard node.namedParameters.isNotEmpty,
                   let signature = node.signature,

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedControlFlowLabelRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedControlFlowLabelRule.swift
@@ -94,7 +94,7 @@ private extension UnusedControlFlowLabelRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: LabeledStmtSyntax) -> StmtSyntax {
             guard let violationPosition = node.violationPosition else {
                 return super.visit(node)

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/EmptyCountRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/EmptyCountRule.swift
@@ -1,8 +1,8 @@
 import SwiftLintCore
 import SwiftSyntax
 
-@SwiftSyntaxRule(foldExpressions: true)
-struct EmptyCountRule: SwiftSyntaxCorrectableRule, OptInRule {
+@SwiftSyntaxRule(foldExpressions: true, explicitRewriter: true)
+struct EmptyCountRule: OptInRule {
     var configuration = EmptyCountConfiguration()
 
     static let description = RuleDescription(
@@ -64,14 +64,6 @@ struct EmptyCountRule: SwiftSyntaxCorrectableRule, OptInRule {
                 Example("[Int]().count != 3 && ![Int]().isEmpty || isEmpty && [Int]().count > 2")
         ]
     )
-
-    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
-        Rewriter(
-            configuration: configuration,
-            locationConverter: file.locationConverter,
-            disabledRegions: disabledRegions(file: file)
-        )
-    }
 }
 
 private extension EmptyCountRule {
@@ -87,16 +79,7 @@ private extension EmptyCountRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
-        private let configuration: EmptyCountConfiguration
-
-        init(configuration: EmptyCountConfiguration,
-             locationConverter: SourceLocationConverter,
-             disabledRegions: [SourceRange]) {
-            self.configuration = configuration
-            super.init(locationConverter: locationConverter, disabledRegions: disabledRegions)
-        }
-
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: InfixOperatorExprSyntax) -> ExprSyntax {
             guard let binaryOperator = node.binaryOperator, binaryOperator.isComparison else {
                 return super.visit(node)

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/FinalTestCaseRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/FinalTestCaseRule.swift
@@ -1,8 +1,8 @@
 import SwiftLintCore
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct FinalTestCaseRule: SwiftSyntaxCorrectableRule, OptInRule {
+@SwiftSyntaxRule(explicitRewriter: true)
+struct FinalTestCaseRule: OptInRule {
     var configuration = FinalTestCaseConfiguration()
 
     static var description = RuleDescription(
@@ -29,14 +29,6 @@ struct FinalTestCaseRule: SwiftSyntaxCorrectableRule, OptInRule {
                 Example("internal final class Test: XCTestCase {}")
         ]
     )
-
-    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
-       Rewriter(
-           configuration: configuration,
-           locationConverter: file.locationConverter,
-           disabledRegions: disabledRegions(file: file)
-       )
-   }
 }
 
 private extension FinalTestCaseRule {
@@ -48,16 +40,7 @@ private extension FinalTestCaseRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
-        private let configuration: FinalTestCaseConfiguration
-
-        init(configuration: FinalTestCaseConfiguration,
-             locationConverter: SourceLocationConverter,
-             disabledRegions: [SourceRange]) {
-            self.configuration = configuration
-            super.init(locationConverter: locationConverter, disabledRegions: disabledRegions)
-        }
-
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: ClassDeclSyntax) -> DeclSyntax {
             var newNode = node
             if node.isNonFinalTestClass(parentClasses: configuration.testParentClasses) {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ClosingBraceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ClosingBraceRule.swift
@@ -32,7 +32,7 @@ private extension ClosingBraceRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: TokenSyntax) -> TokenSyntax {
             guard node.hasClosingBraceViolation else {
                 return super.visit(node)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ClosureSpacingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ClosureSpacingRule.swift
@@ -56,7 +56,7 @@ private extension ClosureSpacingRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: ClosureExprSyntax) -> ExprSyntax {
             var node = node
             node.statements = visit(node.statements)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ControlStatementRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ControlStatementRule.swift
@@ -108,7 +108,7 @@ private extension ControlStatementRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: CatchClauseSyntax) -> CatchClauseSyntax {
             guard case let items = node.catchItems, items.containSuperfluousParens == true else {
                 return super.visit(node)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/DirectReturnRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/DirectReturnRule.swift
@@ -191,7 +191,7 @@ private extension DirectReturnRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ statements: CodeBlockItemListSyntax) -> CodeBlockItemListSyntax {
             guard let (binding, returnStmt) = statements.violation,
                   let bindingList = binding.parent?.as(PatternBindingListSyntax.self),

--- a/Source/SwiftLintBuiltInRules/Rules/Style/EmptyEnumArgumentsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/EmptyEnumArgumentsRule.swift
@@ -128,7 +128,7 @@ private extension EmptyEnumArgumentsRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: SwitchCaseItemSyntax) -> SwitchCaseItemSyntax {
             guard let (violationPosition, newPattern) = node.pattern.emptyEnumArgumentsViolation(rewrite: true) else {
                 return super.visit(node)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/EmptyParametersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/EmptyParametersRule.swift
@@ -44,7 +44,7 @@ private extension EmptyParametersRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: FunctionTypeSyntax) -> TypeSyntax {
             guard let violationPosition = node.emptyParametersViolationPosition else {
                 return super.visit(node)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/EmptyParenthesesWithTrailingClosureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/EmptyParenthesesWithTrailingClosureRule.swift
@@ -57,7 +57,7 @@ private extension EmptyParenthesesWithTrailingClosureRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: FunctionCallExprSyntax) -> ExprSyntax {
             guard let violationPosition = node.violationPosition else {
                 return super.visit(node)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/NoSpaceInMethodCallRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/NoSpaceInMethodCallRule.swift
@@ -56,7 +56,7 @@ private extension NoSpaceInMethodCallRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: FunctionCallExprSyntax) -> ExprSyntax {
             guard node.hasNoSpaceInMethodCallViolation else {
                 return super.visit(node)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/NumberSeparatorRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/NumberSeparatorRule.swift
@@ -1,8 +1,8 @@
 import Foundation
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct NumberSeparatorRule: OptInRule, SwiftSyntaxCorrectableRule {
+@SwiftSyntaxRule(explicitRewriter: true)
+struct NumberSeparatorRule: OptInRule {
     var configuration = NumberSeparatorConfiguration()
 
     static let description = RuleDescription(
@@ -25,14 +25,6 @@ struct NumberSeparatorRule: OptInRule, SwiftSyntaxCorrectableRule {
     static let misplacedSeparatorsReason = """
         Underscore(s) used as thousand separator(s) should be added after every 3 digits only
         """
-
-    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
-        Rewriter(
-            configuration: configuration,
-            locationConverter: file.locationConverter,
-            disabledRegions: disabledRegions(file: file)
-        )
-    }
 }
 
 private extension NumberSeparatorRule {
@@ -50,16 +42,7 @@ private extension NumberSeparatorRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter, NumberSeparatorValidator {
-        let configuration: NumberSeparatorConfiguration
-
-        init(configuration: NumberSeparatorConfiguration,
-             locationConverter: SourceLocationConverter,
-             disabledRegions: [SourceRange]) {
-            self.configuration = configuration
-            super.init(locationConverter: locationConverter, disabledRegions: disabledRegions)
-        }
-
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType>, NumberSeparatorValidator {
         override func visit(_ node: FloatLiteralExprSyntax) -> ExprSyntax {
             guard let violation = violation(token: node.literal) else {
                 return super.visit(node)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/OptionalEnumCaseMatchingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/OptionalEnumCaseMatchingRule.swift
@@ -174,7 +174,7 @@ private extension OptionalEnumCaseMatchingRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: SwitchCaseItemSyntax) -> SwitchCaseItemSyntax {
             guard
                 let pattern = node.pattern.as(ExpressionPatternSyntax.self),

--- a/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfTypeOverTypeOfSelfRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfTypeOverTypeOfSelfRule.swift
@@ -116,7 +116,7 @@ private extension PreferSelfTypeOverTypeOfSelfRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: MemberAccessExprSyntax) -> ExprSyntax {
             guard let function = node.base?.as(FunctionCallExprSyntax.self), function.hasViolation else {
                 return super.visit(node)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ProtocolPropertyAccessorsOrderRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ProtocolPropertyAccessorsOrderRule.swift
@@ -39,7 +39,7 @@ private extension ProtocolPropertyAccessorsOrderRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: AccessorBlockSyntax) -> AccessorBlockSyntax {
             guard node.hasViolation else {
                 return super.visit(node)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/RedundantDiscardableLetRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/RedundantDiscardableLetRule.swift
@@ -37,7 +37,7 @@ private extension RedundantDiscardableLetRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: VariableDeclSyntax) -> DeclSyntax {
             guard node.hasRedundantDiscardableLetViolation else {
                 return super.visit(node)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SuperfluousElseRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SuperfluousElseRule.swift
@@ -1,8 +1,8 @@
 import SwiftLintCore
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct SuperfluousElseRule: SwiftSyntaxCorrectableRule, OptInRule {
+@SwiftSyntaxRule(explicitRewriter: true)
+struct SuperfluousElseRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(
@@ -243,14 +243,6 @@ struct SuperfluousElseRule: SwiftSyntaxCorrectableRule, OptInRule {
             """)
         ]
     )
-
-    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
-        Rewriter(
-            configuration: configuration,
-            file: file,
-            disabledRegions: disabledRegions(file: file)
-        )
-    }
 }
 
 private extension SuperfluousElseRule {
@@ -264,11 +256,9 @@ private extension SuperfluousElseRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
-        init(configuration: ConfigurationType,
-             file: SwiftLintFile,
-             disabledRegions: [SourceRange]) {
-            super.init(locationConverter: file.locationConverter, disabledRegions: disabledRegions)
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
+        override init(configuration: ConfigurationType, file: SwiftLintFile) {
+            super.init(configuration: configuration, file: file)
             let correctionPositions = Visitor(configuration: configuration, file: file).walk(file: file) {
                 $0.violations.map(\.position)
             }.filter { !$0.isContainedIn(regions: disabledRegions, locationConverter: locationConverter) }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/UnneededParenthesesInClosureArgumentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/UnneededParenthesesInClosureArgumentRule.swift
@@ -87,7 +87,7 @@ private extension UnneededParenthesesInClosureArgumentRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: ClosureSignatureSyntax) -> ClosureSignatureSyntax {
             guard let clause = node.parameterClause?.as(ClosureParameterClauseSyntax.self),
                   clause.parameters.isNotEmpty,

--- a/Source/SwiftLintBuiltInRules/Rules/Style/VoidReturnRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/VoidReturnRule.swift
@@ -59,7 +59,7 @@ private extension VoidReturnRule {
         }
     }
 
-    final class Rewriter: ViolationsSyntaxRewriter {
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: ReturnClauseSyntax) -> ReturnClauseSyntax {
             if node.violates {
                 correctionPositions.append(node.type.positionAfterSkippingLeadingTrivia)

--- a/Source/SwiftLintCore/Models/Region.swift
+++ b/Source/SwiftLintCore/Models/Region.swift
@@ -46,13 +46,20 @@ public struct Region: Equatable {
     ///
     /// - returns: True if the specified rule is disabled in this region.
     public func isRuleDisabled(_ rule: some Rule) -> Bool {
-        guard !disabledRuleIdentifiers.contains(.all) else {
+        return areRulesDisabled(ruleIDs: type(of: rule).description.allIdentifiers)
+    }
+
+    /// Whether the given rules are disabled in this region.
+    ///
+    /// - parameter ruleIDs: A list of rule IDs. Typically all identifiers of a single rule.
+    ///
+    /// - returns: True if the specified rules are disabled in this region.
+    public func areRulesDisabled(ruleIDs: [String]) -> Bool {
+        if disabledRuleIdentifiers.contains(.all) {
             return true
         }
-
-        let identifiersToCheck = type(of: rule).description.allIdentifiers
         let regionIdentifiers = Set(disabledRuleIdentifiers.map { $0.stringRepresentation })
-        return !regionIdentifiers.isDisjoint(with: identifiersToCheck)
+        return !regionIdentifiers.isDisjoint(with: ruleIDs)
     }
 
     /// Returns the deprecated rule aliases that are disabling the specified rule in this region.

--- a/Source/SwiftLintCore/Protocols/SwiftSyntaxRule.swift
+++ b/Source/SwiftLintCore/Protocols/SwiftSyntaxRule.swift
@@ -40,18 +40,6 @@ public extension SwiftSyntaxRule where ConfigurationType: SeverityBasedRuleConfi
 }
 
 public extension SwiftSyntaxRule {
-    /// Returns the source ranges in the specified file where this rule is disabled.
-    ///
-    /// - parameter file: The file to get regions.
-    ///
-    /// - returns: The source ranges in the specified file where this rule is disabled.
-    func disabledRegions(file: SwiftLintFile) -> [SourceRange] {
-        let locationConverter = file.locationConverter
-        return file.regions()
-            .filter { $0.isRuleDisabled(self) }
-            .compactMap { $0.toSourceRange(locationConverter: locationConverter) }
-    }
-
     @inlinable
     func validate(file: SwiftLintFile) -> [StyleViolation] {
         guard let syntaxTree = preprocess(file: file) else {

--- a/Source/SwiftLintCoreMacros/SwiftSyntaxRule.swift
+++ b/Source/SwiftLintCoreMacros/SwiftSyntaxRule.swift
@@ -29,11 +29,8 @@ enum SwiftSyntaxRule: ExtensionMacro {
             ),
             try makeExtension(dependingOn: node.explicitRewriterArgument, in: context, with: """
                 extension \(type): SwiftSyntaxCorrectableRule {
-                    func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
-                        Rewriter(
-                            locationConverter: file.locationConverter,
-                            disabledRegions: disabledRegions(file: file)
-                        )
+                    func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter<ConfigurationType>? {
+                        Rewriter(configuration: configuration, file: file)
                     }
                 }
                 """

--- a/Tests/MacroTests/SwiftSyntaxRuleTests.swift
+++ b/Tests/MacroTests/SwiftSyntaxRuleTests.swift
@@ -67,11 +67,8 @@ final class SwiftSyntaxRuleTests: XCTestCase {
             }
 
             extension Hello: SwiftSyntaxCorrectableRule {
-                func makeRewriter(file: SwiftLintFile) -> (some ViolationsSyntaxRewriter)? {
-                    Rewriter(
-                        locationConverter: file.locationConverter,
-                        disabledRegions: disabledRegions(file: file)
-                    )
+                func makeRewriter(file: SwiftLintFile) -> ViolationsSyntaxRewriter<ConfigurationType>? {
+                    Rewriter(configuration: configuration, file: file)
                 }
             }
             """,


### PR DESCRIPTION
Like all visitors got a configuration in #5275, all rewriters should also get one to get rid of some boilerplate.