### PR TITLE
Allow rules to lint empty files

### DIFF
--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -67,8 +67,8 @@ private extension Rule {
             return nil
         }
 
-        // Empty files shouldn't trigger violations
-        guard !shouldLintEmptyFiles, !file.isEmpty else {
+        // Empty files shouldn't trigger violations if `shouldLintEmptyFiles` is `false`
+        if file.isEmpty, !shouldLintEmptyFiles {
             return nil
         }
 
@@ -221,7 +221,7 @@ public struct CollectedLinter {
     private func getStyleViolations(using storage: RuleStorage,
                                     benchmark: Bool = false) -> ([StyleViolation], [(id: String, time: Double)]) {
         guard !rules.isEmpty else {
-            // Empty files shouldn't trigger violations
+            // Nothing to validate if there are no active rules!
             return ([], [])
         }
 

--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -150,7 +150,13 @@ public struct Linter {
         self.cache = cache
         self.configuration = configuration
         self.compilerArguments = compilerArguments
+
+        let fileIsEmpty = file.isEmpty
         let rules = configuration.rules.filter { rule in
+            if fileIsEmpty, !rule.shouldLintEmptyFiles {
+                return false
+            }
+
             if compilerArguments.isEmpty {
                 return !(rule is any AnalyzerRule)
             } else {
@@ -214,11 +220,6 @@ public struct CollectedLinter {
 
     private func getStyleViolations(using storage: RuleStorage,
                                     benchmark: Bool = false) -> ([StyleViolation], [(id: String, time: Double)]) {
-        var rules = rules
-        if file.isEmpty {
-            rules = rules.filter(\.shouldLintEmptyFiles)
-        }
-
         guard !rules.isEmpty else {
             // Empty files shouldn't trigger violations
             return ([], [])

--- a/Source/SwiftLintCore/Protocols/Rule.swift
+++ b/Source/SwiftLintCore/Protocols/Rule.swift
@@ -19,6 +19,9 @@ public protocol Rule {
     /// This rule's configuration.
     var configuration: ConfigurationType { get set }
 
+    /// Whether this rule should be used on empty files. Defaults to `false`.
+    var shouldLintEmptyFiles: Bool { get }
+
     /// A default initializer for rules. All rules need to be trivially initializable.
     init()
 
@@ -74,6 +77,10 @@ public protocol Rule {
 }
 
 public extension Rule {
+    var shouldLintEmptyFiles: Bool {
+        false
+    }
+
     init(configuration: Any) throws {
         self.init()
         try self.configuration.apply(configuration: configuration)


### PR DESCRIPTION
https://github.com/realm/SwiftLint/pull/3885 made it so no violations ever trigger when a file is empty. 

While this makes sense in general, we'd like to introduce a custom rule in our codebase to avoid empty files. But that doesn't work as expected because the rule isn't even called.

The simplest thing I could think of is to introduce `shouldLintEmptyFiles` on `Rule` (defaulting it to `false`) and using it when deciding whether to lint a file or not.