### PR TITLE
Update switch_case_on_newline rule to allow returnless cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 
 #### Enhancements
 
+* Add option `allow_returnless_cases` to `switch_case_on_newline` rule.
+  It excludes single line cases that have no return statement.
+  [gsl-anthonymerle](https://github.com/gsl-anthonymerle)
+  [#5485](https://github.com/realm/SwiftLint/pull/5485)
+  
 * Add new option `ignore_typealiases_and_associatedtypes` to
   `nesting` rule. It excludes `typealias` and `associatedtype`
   declarations from the analysis.

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SwitchCaseOnNewLineConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SwitchCaseOnNewLineConfiguration.swift
@@ -1,0 +1,11 @@
+import SwiftLintCore
+
+@AutoApply
+struct SwitchCaseOnNewLineConfiguration: SeverityBasedRuleConfiguration {
+    typealias Parent = SwitchCaseOnNewlineRule
+
+    @ConfigurationElement(key: "severity")
+    private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement(key: "allow_returnless_cases")
+    private(set) var allowReturnlessCases = false
+}

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SwitchCaseOnNewLineConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SwitchCaseOnNewLineConfiguration.swift
@@ -6,6 +6,6 @@ struct SwitchCaseOnNewLineConfiguration: SeverityBasedRuleConfiguration {
 
     @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    @ConfigurationElement(key: "allow_returnless_cases")
-    private(set) var allowReturnlessCases = false
+    @ConfigurationElement(key: "skip_switch_expressions")
+    private(set) var skipSwitchExpressions = false
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SwitchCaseOnNewlineRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SwitchCaseOnNewlineRule.swift
@@ -66,7 +66,10 @@ private extension SwitchCaseOnNewlineRule {
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: SwitchCaseSyntax) {
             if isCaseOnSingleLine(node) {
-                violations.append(node.positionAfterSkippingLeadingTrivia)
+                if configuration.allowReturnlessCases && !containsReturnStatement(node) {
+                } else {
+                    violations.append(node.positionAfterSkippingLeadingTrivia)
+                }
             }
         }
 
@@ -76,6 +79,14 @@ private extension SwitchCaseOnNewlineRule {
             let statementStartLine = locationConverter.location(for: statementsPosition).line
 
             return statementStartLine == caseEndLine
+        }
+
+        private func containsReturnStatement(_ node: SwitchCaseSyntax) -> Bool {
+            let lastReturn = node.statements
+                .last?.as(CodeBlockItemSyntax.self)?
+                .item.as(ReturnStmtSyntax.self)
+
+            return lastReturn != nil
         }
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SwitchCaseOnNewlineRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SwitchCaseOnNewlineRule.swift
@@ -65,12 +65,17 @@ struct SwitchCaseOnNewlineRule: OptInRule {
 private extension SwitchCaseOnNewlineRule {
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: SwitchCaseSyntax) {
+            if isCaseOnSingleLine(node) {
+                violations.append(node.positionAfterSkippingLeadingTrivia)
+            }
+        }
+
+        private func isCaseOnSingleLine(_ node: SwitchCaseSyntax) -> Bool {
             let caseEndLine = locationConverter.location(for: node.label.endPositionBeforeTrailingTrivia).line
             let statementsPosition = node.statements.positionAfterSkippingLeadingTrivia
             let statementStartLine = locationConverter.location(for: statementsPosition).line
-            if statementStartLine == caseEndLine {
-                violations.append(node.positionAfterSkippingLeadingTrivia)
-            }
+
+            return statementStartLine == caseEndLine
         }
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SwitchCaseOnNewlineRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SwitchCaseOnNewlineRule.swift
@@ -57,7 +57,16 @@ struct SwitchCaseOnNewlineRule: OptInRule {
             wrapInSwitch("↓case let .myCase(value) where value > 10: return false"),
             wrapInSwitch("↓case #selector(aFunction(_:)): return false"),
             wrapInSwitch("↓case let .myCase(value)\n where value > 10: return false"),
-            wrapInSwitch("↓case .first,\n .second: return false")
+            wrapInSwitch("↓case .first,\n .second: return false"),
+            wrapInSwitch("↓case 1: true"),
+            wrapInSwitch("↓case let value: true"),
+            wrapInSwitch("↓default: true"),
+            wrapInSwitch("↓case \"a string\": false"),
+            wrapInSwitch("↓case .myCase: false // error from network"),
+            wrapInSwitch("↓case let .myCase(value) where value > 10: false"),
+            wrapInSwitch("↓case #selector(aFunction(_:)): false"),
+            wrapInSwitch("↓case let .myCase(value)\n where value > 10: false"),
+            wrapInSwitch("↓case .first,\n .second: false")
         ]
     )
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SwitchCaseOnNewlineRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SwitchCaseOnNewlineRule.swift
@@ -75,8 +75,7 @@ private extension SwitchCaseOnNewlineRule {
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: SwitchCaseSyntax) {
             if isCaseOnSingleLine(node) {
-                if configuration.allowReturnlessCases && !containsReturnStatement(node) {
-                } else {
+                if !configuration.allowReturnlessCases || containsReturnStatement(node) {
                     violations.append(node.positionAfterSkippingLeadingTrivia)
                 }
             }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SwitchCaseOnNewlineRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SwitchCaseOnNewlineRule.swift
@@ -10,7 +10,7 @@ private func wrapInSwitch(_ str: String, file: StaticString = #file, line: UInt 
 
 @SwiftSyntaxRule
 struct SwitchCaseOnNewlineRule: OptInRule {
-    var configuration = SeverityConfiguration<Self>(.warning)
+    var configuration = SwitchCaseOnNewLineConfiguration()
 
     static let description = RuleDescription(
         identifier: "switch_case_on_newline",

--- a/Tests/SwiftLintFrameworkTests/SwitchCaseOnNewlineRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/SwitchCaseOnNewlineRuleTests.swift
@@ -5,37 +5,22 @@ class SwitchCaseOnNewlineRuleTests: SwiftLintTestCase {
         verifyRule(
             SwitchCaseOnNewlineRule.description.with(
                 nonTriggeringExamples: [
-                    wrapInSwitch("case 1: true"),
-                    wrapInSwitch("case let value: true"),
-                    wrapInSwitch("default: true"),
-                    wrapInSwitch("case \"a string\": false"),
-                    wrapInSwitch("case .myCase: false // error from network"),
-                    wrapInSwitch("case let .myCase(value) where value > 10: false"),
-                    wrapInSwitch("case #selector(aFunction(_:)): false"),
-                    wrapInSwitch("case let .myCase(value)\n where value > 10: false"),
-                    wrapInSwitch("case .first,\n .second: false")
+                    Example("""
+                    let value = switch foo {
+                        case 1: true
+                    }
+                    """)
                 ],
                 triggeringExamples: [
-                    wrapInSwitch("↓case 1: return true"),
-                    wrapInSwitch("↓case let value: return true"),
-                    wrapInSwitch("↓default: return true"),
-                    wrapInSwitch("↓case \"a string\": return false"),
-                    wrapInSwitch("↓case .myCase: return false // error from network"),
-                    wrapInSwitch("↓case let .myCase(value) where value > 10: return false"),
-                    wrapInSwitch("↓case #selector(aFunction(_:)): return false"),
-                    wrapInSwitch("↓case let .myCase(value)\n where value > 10: return false"),
-                    wrapInSwitch("↓case .first,\n .second: return false")
+                    Example("""
+                    var value = false
+                    switch foo {
+                        ↓case 1: value = true
+                    }
+                    """)
                 ]
             ),
-            ruleConfiguration: ["allow_returnless_cases": true]
+            ruleConfiguration: ["skip_switch_expressions": true]
         )
     }
-}
-
-private func wrapInSwitch(_ str: String, file: StaticString = #file, line: UInt = #line) -> Example {
-    return Example("""
-    switch foo {
-        \(str)
-    }
-    """, file: file, line: line)
 }

--- a/Tests/SwiftLintFrameworkTests/SwitchCaseOnNewlineRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/SwitchCaseOnNewlineRuleTests.swift
@@ -1,0 +1,41 @@
+@testable import SwiftLintBuiltInRules
+
+class SwitchCaseOnNewlineRuleTests: SwiftLintTestCase {
+    func testSwitchCaseOnNewlineAllowingReturnlessCases() {
+        verifyRule(
+            SwitchCaseOnNewlineRule.description.with(
+                nonTriggeringExamples: [
+                    wrapInSwitch("case 1: true"),
+                    wrapInSwitch("case let value: true"),
+                    wrapInSwitch("default: true"),
+                    wrapInSwitch("case \"a string\": false"),
+                    wrapInSwitch("case .myCase: false // error from network"),
+                    wrapInSwitch("case let .myCase(value) where value > 10: false"),
+                    wrapInSwitch("case #selector(aFunction(_:)): false"),
+                    wrapInSwitch("case let .myCase(value)\n where value > 10: false"),
+                    wrapInSwitch("case .first,\n .second: false")
+                ],
+                triggeringExamples: [
+                    wrapInSwitch("↓case 1: return true"),
+                    wrapInSwitch("↓case let value: return true"),
+                    wrapInSwitch("↓default: return true"),
+                    wrapInSwitch("↓case \"a string\": return false"),
+                    wrapInSwitch("↓case .myCase: return false // error from network"),
+                    wrapInSwitch("↓case let .myCase(value) where value > 10: return false"),
+                    wrapInSwitch("↓case #selector(aFunction(_:)): return false"),
+                    wrapInSwitch("↓case let .myCase(value)\n where value > 10: return false"),
+                    wrapInSwitch("↓case .first,\n .second: return false")
+                ]
+            ),
+            ruleConfiguration: ["allow_returnless_cases": true]
+        )
+    }
+}
+
+private func wrapInSwitch(_ str: String, file: StaticString = #file, line: UInt = #line) -> Example {
+    return Example("""
+    switch foo {
+        \(str)
+    }
+    """, file: file, line: line)
+}


### PR DESCRIPTION
Since Swift 5.9, switch cases can return a value without having to explicitly use the `return` keyword with the condition that they contain only a single line statement.

With this evolution, we tend to see more and more switch cases written on a single line.
This pull request aims to offer a configuration point to the `switch_case_on_newline` rule so that it skip these specific cases, so that we can allow the following:
```
switch myEnum {
    case .foo: 42,
    case .bar: 24 
}
```
but still preventing:
```
switch myEnum {
    case .foo: return 42,
    case .bar: return 24 
}
```
