### PR TITLE
Introduce SwiftLintCommandPlugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@
   [kohtenko](https://github.com/kohtenko)
 * Introduce SwiftLintCommand plugin.  
 * Introduce SwiftLintCommandPlugin plugin.  
+* Introduce SwiftLintCommandPlugin.
+  Rename SwiftLintBuildToolPlugin.
+  Add Swift Package Manager installation instructions.
+  Improve README.md.  
   [garricn](https://github.com/garricn)
 
 * Add new option `ignore_typealiases_and_associatedtypes` to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 * Rewrite `SwiftLintPlugin` using `BUILD_WORKSPACE_DIRECTORY` without relying
   on the `--config` option.  
   [Garric Nahapetian](https://github.com/garricn)
+  
+* Introduce SwiftLintCommandPlugin.
+  Rename SwiftLintBuildToolPlugin.
+  Add Swift Package Manager installation instructions.    
+  [garricn](https://github.com/garricn)
 
 #### Experimental
 
@@ -15,12 +20,6 @@
 * Ignore absence of a non-initial local config instead of
   falling back to default.  
   [kohtenko](https://github.com/kohtenko)
-* Introduce SwiftLintCommand plugin.  
-* Introduce SwiftLintCommandPlugin plugin.  
-* Introduce SwiftLintCommandPlugin.
-  Rename SwiftLintBuildToolPlugin.
-  Add Swift Package Manager installation instructions.    
-  [garricn](https://github.com/garricn)
 
 * Add new option `ignore_typealiases_and_associatedtypes` to
   `nesting` rule. It excludes `typealias` and `associatedtype`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 * Ignore absence of a non-initial local config instead of
   falling back to default.  
   [kohtenko](https://github.com/kohtenko)
+* Introduce SwiftLintCommand plugin.  
+  [garricn](https://github.com/garricn)
 
 * Add new option `ignore_typealiases_and_associatedtypes` to
   `nesting` rule. It excludes `typealias` and `associatedtype`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
   falling back to default.  
   [kohtenko](https://github.com/kohtenko)
 * Introduce SwiftLintCommand plugin.  
+* Introduce SwiftLintCommandPlugin plugin.  
   [garricn](https://github.com/garricn)
 
 * Add new option `ignore_typealiases_and_associatedtypes` to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   
 * Introduce SwiftLintCommandPlugin.
   Rename SwiftLintBuildToolPlugin.
-  Add Swift Package Manager installation instructions.    
+  Add Swift Package Manager installation instructions.  
   [garricn](https://github.com/garricn)
 
 #### Experimental

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,7 @@
 * Introduce SwiftLintCommandPlugin plugin.  
 * Introduce SwiftLintCommandPlugin.
   Rename SwiftLintBuildToolPlugin.
-  Add Swift Package Manager installation instructions.
-  Improve README.md.  
+  Add Swift Package Manager installation instructions.    
   [garricn](https://github.com/garricn)
 
 * Add new option `ignore_typealiases_and_associatedtypes` to

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,8 @@ let package = Package(
     products: [
         .executable(name: "swiftlint", targets: ["swiftlint"]),
         .library(name: "SwiftLintFramework", targets: ["SwiftLintFramework"]),
-        .plugin(name: "SwiftLintBuildToolPlugin", targets: ["SwiftLintBuildToolPlugin"])
+        .plugin(name: "SwiftLintBuildToolPlugin", targets: ["SwiftLintBuildToolPlugin"]),
+        .plugin(name: "SwiftLintCommandPlugin", targets: ["SwiftLintCommandPlugin"])
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.2.1")),

--- a/Package.swift
+++ b/Package.swift
@@ -32,13 +32,13 @@ let package = Package(
     ],
     targets: [
         .plugin(
-            name: "SwiftLintCommandPlugin",
-            capability: .command(intent: .custom(verb: "swiftlint", description: "SwiftLint Command Plugin")),
+            name: "SwiftLintBuildToolPlugin",
+            capability: .buildTool(),
             dependencies: swiftLintPluginDependencies
         ),
         .plugin(
-            name: "SwiftLintBuildToolPlugin",
-            capability: .buildTool(),
+            name: "SwiftLintCommandPlugin",
+            capability: .command(intent: .custom(verb: "swiftlint", description: "SwiftLint Command Plugin")),
             dependencies: swiftLintPluginDependencies
         ),
         .executableTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
     products: [
         .executable(name: "swiftlint", targets: ["swiftlint"]),
         .library(name: "SwiftLintFramework", targets: ["SwiftLintFramework"]),
-        .plugin(name: "SwiftLintPlugin", targets: ["SwiftLintPlugin"])
+        .plugin(name: "SwiftLintBuildToolPlugin", targets: ["SwiftLintBuildToolPlugin"])
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.2.1")),
@@ -38,7 +38,7 @@ let package = Package(
                 .target(name: "SwiftLintBinary")
             ]),
         .plugin(
-            name: "SwiftLintPlugin",
+            name: "SwiftLintBuildToolPlugin",
             capability: .buildTool(),
             dependencies: swiftLintPluginDependencies
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -32,6 +32,12 @@ let package = Package(
     ],
     targets: [
         .plugin(
+            name: "SwiftLintCommand",
+            capability: .command(intent: .custom(verb: "swiftlint", description: "SwiftLint Command Plugin")),
+            dependencies: [
+                .target(name: "SwiftLintBinary")
+            ]),
+        .plugin(
             name: "SwiftLintPlugin",
             capability: .buildTool(),
             dependencies: swiftLintPluginDependencies

--- a/Package.swift
+++ b/Package.swift
@@ -32,11 +32,10 @@ let package = Package(
     ],
     targets: [
         .plugin(
-            name: "SwiftLintCommand",
+            name: "SwiftLintCommandPlugin",
             capability: .command(intent: .custom(verb: "swiftlint", description: "SwiftLint Command Plugin")),
-            dependencies: [
-                .target(name: "SwiftLintBinary")
-            ]),
+            dependencies: swiftLintPluginDependencies
+        ),
         .plugin(
             name: "SwiftLintBuildToolPlugin",
             capability: .buildTool(),

--- a/Plugins/SwiftLintBuildToolPlugin/Path+Helpers.swift
+++ b/Plugins/SwiftLintBuildToolPlugin/Path+Helpers.swift
@@ -16,7 +16,7 @@ extension Path {
 
     func resolveWorkingDirectory(in directory: Path) throws -> Path {
         guard "\(self)".hasPrefix("\(directory)") else {
-            throw SwiftLintPluginError.pathNotInDirectory(path: self, directory: directory)
+            throw SwiftLintBuildToolPluginError.pathNotInDirectory(path: self, directory: directory)
         }
 
         let path: Path? = sequence(first: self) { path in

--- a/Plugins/SwiftLintBuildToolPlugin/SwiftLintBuildToolPlugin.swift
+++ b/Plugins/SwiftLintBuildToolPlugin/SwiftLintBuildToolPlugin.swift
@@ -2,7 +2,7 @@ import Foundation
 import PackagePlugin
 
 @main
-struct SwiftLintPlugin: BuildToolPlugin {
+struct SwiftLintBuildToolPlugin: BuildToolPlugin {
     func createBuildCommands(
         context: PluginContext,
         target: Target
@@ -86,7 +86,7 @@ struct SwiftLintPlugin: BuildToolPlugin {
 import XcodeProjectPlugin
 
 // swiftlint:disable:next no_grouping_extension
-extension SwiftLintPlugin: XcodeBuildToolPlugin {
+extension SwiftLintBuildToolPlugin: XcodeBuildToolPlugin {
     func createBuildCommands(
         context: XcodePluginContext,
         target: XcodeTarget
@@ -125,7 +125,7 @@ extension SwiftLintPlugin: XcodeBuildToolPlugin {
         let swiftFilesNotInProjectDirectory: [Path] = swiftFiles.filter { !$0.isDescendant(of: projectDirectory) }
 
         guard swiftFilesNotInProjectDirectory.isEmpty else {
-            throw SwiftLintPluginError.swiftFilesNotInProjectDirectory(projectDirectory)
+            throw SwiftLintBuildToolPluginError.swiftFilesNotInProjectDirectory(projectDirectory)
         }
 
         let directories: [Path] = try swiftFiles.map { try $0.resolveWorkingDirectory(in: projectDirectory) }
@@ -133,7 +133,7 @@ extension SwiftLintPlugin: XcodeBuildToolPlugin {
         let swiftFilesNotInWorkingDirectory: [Path] = swiftFiles.filter { !$0.isDescendant(of: workingDirectory) }
 
         guard swiftFilesNotInWorkingDirectory.isEmpty else {
-            throw SwiftLintPluginError.swiftFilesNotInWorkingDirectory(workingDirectory)
+            throw SwiftLintBuildToolPluginError.swiftFilesNotInWorkingDirectory(workingDirectory)
         }
 
         return ["BUILD_WORKSPACE_DIRECTORY": "\(workingDirectory)"]

--- a/Plugins/SwiftLintBuildToolPlugin/SwiftLintBuildToolPluginError.swift
+++ b/Plugins/SwiftLintBuildToolPlugin/SwiftLintBuildToolPluginError.swift
@@ -1,6 +1,6 @@
 import PackagePlugin
 
-enum SwiftLintPluginError: Error, CustomStringConvertible {
+enum SwiftLintBuildToolPluginError: Error, CustomStringConvertible {
     case pathNotInDirectory(path: Path, directory: Path)
     case swiftFilesNotInProjectDirectory(Path)
     case swiftFilesNotInWorkingDirectory(Path)

--- a/Plugins/SwiftLintCommand/SwiftLintCommand.swift
+++ b/Plugins/SwiftLintCommand/SwiftLintCommand.swift
@@ -1,0 +1,39 @@
+import Foundation
+import PackagePlugin
+
+@main
+internal struct SwiftLintCommand: CommandPlugin {
+
+    internal func performCommand(
+        context: PluginContext,
+        arguments: [String]
+    ) throws {
+        let tool: PluginContext.Tool = try context.tool(named: "swiftlint")
+        guard !arguments.contains("--cache-path") else {
+            Diagnostics.error("Setting Cache Path Not Allowed")
+            return
+        }
+        let process: Process = .init()
+        process.currentDirectoryURL = URL(fileURLWithPath: context.package.directory.string)
+        process.executableURL = URL(fileURLWithPath: tool.path.string)
+        if arguments.contains("analyze") {
+            process.arguments = arguments
+        } else {
+            process.arguments = arguments + ["--cache-path", "\(context.pluginWorkDirectory.string)"]
+        }
+        try process.run()
+        process.waitUntilExit()
+        switch process.terminationReason {
+        case .exit:
+            break
+        case .uncaughtSignal:
+            Diagnostics.error("Uncaught Signal")
+        @unknown default:
+            Diagnostics.error("Unexpected Termination Reason")
+        }
+        guard process.terminationStatus == EXIT_SUCCESS else {
+            Diagnostics.error("Command Failed")
+            return
+        }
+    }
+}

--- a/Plugins/SwiftLintCommandPlugin/SwiftLintCommandPlugin.swift
+++ b/Plugins/SwiftLintCommandPlugin/SwiftLintCommandPlugin.swift
@@ -2,21 +2,21 @@ import Foundation
 import PackagePlugin
 
 @main
-internal struct SwiftLintCommandPlugin: CommandPlugin {
-    internal func performCommand(
+struct SwiftLintCommandPlugin: CommandPlugin {
+    func performCommand(
         context: PluginContext,
         arguments: [String]
     ) throws {
         let tool: PluginContext.Tool = try context.tool(named: "swiftlint")
         // Caching is managed internally because the cache must be located within the `pluginWorkDirectory`.
-        guard !arguments.contains("--cache-path") else {
+        if arguments.contains("--cache-path") {
             Diagnostics.error("Setting Cache Path Not Allowed")
             return
         }
         let process: Process = .init()
         process.currentDirectoryURL = URL(fileURLWithPath: context.package.directory.string)
         process.executableURL = URL(fileURLWithPath: tool.path.string)
-        // The analyze command does not support the --cache-path argument
+        // The analyze command does not support the `--cache-path` argument
         if arguments.contains("analyze") {
             process.arguments = arguments
         } else {

--- a/Plugins/SwiftLintCommandPlugin/SwiftLintCommandPlugin.swift
+++ b/Plugins/SwiftLintCommandPlugin/SwiftLintCommandPlugin.swift
@@ -2,13 +2,13 @@ import Foundation
 import PackagePlugin
 
 @main
-internal struct SwiftLintCommand: CommandPlugin {
-
+internal struct SwiftLintCommandPlugin: CommandPlugin {
     internal func performCommand(
         context: PluginContext,
         arguments: [String]
     ) throws {
         let tool: PluginContext.Tool = try context.tool(named: "swiftlint")
+        // Caching is managed internally because the cache must be located within the `pluginWorkDirectory`.
         guard !arguments.contains("--cache-path") else {
             Diagnostics.error("Setting Cache Path Not Allowed")
             return
@@ -16,6 +16,7 @@ internal struct SwiftLintCommand: CommandPlugin {
         let process: Process = .init()
         process.currentDirectoryURL = URL(fileURLWithPath: context.package.directory.string)
         process.executableURL = URL(fileURLWithPath: tool.path.string)
+        // The analyze command does not support the --cache-path argument
         if arguments.contains("analyze") {
             process.arguments = arguments
         } else {

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ products.
 
 Select the target you want to add linting to and open the `Build Phases` inspector.
 Open `Run Build Tool Plug-ins` and select the `+` button.
-Select `SwiftLintPlugin` from the list and add it to the project.
+Select `SwiftLintBuildToolPlugin` from the list and add it to the project.
 
 ![](https://raw.githubusercontent.com/realm/SwiftLint/main/assets/select-swiftlint-plugin.png)
 
@@ -265,7 +265,7 @@ Add SwiftLint to a target using the `plugins` parameter.
 ```swift
 .target(
     ...
-    plugins: [.plugin(name: "SwiftLintPlugin", package: "SwiftLint")]
+    plugins: [.plugin(name: "SwiftLintBuildToolPlugin", package: "SwiftLint")]
 ),
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ unacceptable behavior to [info@realm.io](mailto:info@realm.io).
 .package(url: "https://github.com/realm/SwiftLint.git", from: "<version>")
 ```
 
+SwiftLint can be used as a [command plugin](#swift-package-command-plugin) or a [build tool plugin](#swift-package-build-tool-plugins).
+
 ### Using [Homebrew](http://brew.sh/):
 
 ```

--- a/README.md
+++ b/README.md
@@ -273,12 +273,12 @@ Add SwiftLint to a target using the `plugins` parameter.
 
 You can also use SwiftLint as a Swift Package Command Plugin. After adding
 SwiftLint as a package dependency to your `Package.swift` file, simply add
-the `SwiftLintCommand` to a target using the `plugins` parameter.
+the `SwiftLintCommandPlugin` to a target using the `plugins` parameter.
 
 ```swift
 .target(
     ...
-    plugins: [.plugin(name: "SwiftLintCommand", package: "SwiftLint")]
+    plugins: [.plugin(name: "SwiftLintCommandPlugin", package: "SwiftLint")]
 ),
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ unacceptable behavior to [info@realm.io](mailto:info@realm.io).
 
 ## Installation
 
+### Using [Swift Package Manager](https://github.com/apple/swift-package-manager):
+
+> Replace `<version>` with the desired minimum version.
+
+```swift
+.package(url: "https://github.com/realm/SwiftLint.git", from: "<version>")
+```
+
 ### Using [Homebrew](http://brew.sh/):
 
 ```

--- a/README.md
+++ b/README.md
@@ -285,26 +285,6 @@ Add SwiftLint to a target using the `plugins` parameter.
 ),
 ```
 
-#### SwiftLint Command Plugin
-
-You can also use SwiftLint as a Swift Package Command Plugin. After adding
-SwiftLint as a package dependency to your `Package.swift` file, simply add
-the `SwiftLintCommandPlugin` to a target using the `plugins` parameter.
-
-```swift
-.target(
-    ...
-    plugins: [.plugin(name: "SwiftLintCommandPlugin", package: "SwiftLint")]
-),
-```
-
-You can then execute the plugin via the command line from the root of your
-Swift Package directory. For example:
-
-```
-swift package plugin swiftlint lint
-```
-
 ### Visual Studio Code
 
 To integrate SwiftLint with [vscode](https://code.visualstudio.com), install the

--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ The command plugin enables running SwiftLint from the command line as follows:
 swift package plugin swiftlint
 ```
 
+### Swift Package Build Tool Plugins
 
 The build tool plugin determines the SwiftLint working directory by locating 
 the topmost config file within the package/project directory. If a config file

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ we encourage you to watch this presentation or read the transcript:
 
 [![Presentation](https://raw.githubusercontent.com/realm/SwiftLint/main/assets/presentation.svg)](https://youtu.be/9Z1nTMTejqU)
 
-### Xcode
+### Xcode Run Script Build Phase
 
 Integrate SwiftLint into your Xcode project to get warnings and errors displayed
 in the issue navigator.
@@ -206,7 +206,7 @@ If you've installed SwiftLint via CocoaPods the script should look like this:
 "${PODS_ROOT}/SwiftLint/swiftlint"
 ```
 
-### Plugin Support
+### Swift Package Command Plugin
 
 SwiftLint can be used as a build tool plugin for both Swift Package projects 
 and Xcode projects.
@@ -239,7 +239,7 @@ plugin, please consider one of the following options:
 - You can also consider the use of a Run Script Build Phase in place of the
   build tool plugin.
 
-#### Xcode
+#### Xcode Projects
 
 You can integrate SwiftLint as an Xcode Build Tool Plugin if you're working
 with a project in Xcode.
@@ -262,7 +262,7 @@ For unattended use (e.g. on CI), you can disable the package and macro validatio
 _Note: This implicitly trusts all Xcode package plugins and macros in packages and bypasses Xcode's package validation
        dialogs, which has security implications._
 
-#### Swift Package
+#### Swift Package Projects
 
 You can integrate SwiftLint as a Swift Package Manager Plugin if you're working with
 a Swift Package with a `Package.swift` manifest.

--- a/README.md
+++ b/README.md
@@ -269,6 +269,26 @@ Add SwiftLint to a target using the `plugins` parameter.
 ),
 ```
 
+#### SwiftLint Command Plugin
+
+You can also use SwiftLint as a Swift Package Command Plugin. After adding
+SwiftLint as a package dependency to your `Package.swift` file, simply add
+the `SwiftLintCommand` to a target using the `plugins` parameter.
+
+```swift
+.target(
+    ...
+    plugins: [.plugin(name: "SwiftLintCommand", package: "SwiftLint")]
+),
+```
+
+You can then execute the plugin via the command line from the root of your
+Swift Package directory. For example:
+
+```
+swift package plugin swiftlint lint
+```
+
 ### Visual Studio Code
 
 To integrate SwiftLint with [vscode](https://code.visualstudio.com), install the

--- a/README.md
+++ b/README.md
@@ -216,6 +216,9 @@ swift package plugin swiftlint
 
 ### Swift Package Build Tool Plugins
 
+SwiftLint can be used as a build tool plugin for both [Xcode projects](#xcode-projects) and
+[Swift Package projects](#swift-package-projects).
+
 The build tool plugin determines the SwiftLint working directory by locating 
 the topmost config file within the package/project directory. If a config file
 is not found therein, the package/project directory is used as the working 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ If you've installed SwiftLint via CocoaPods the script should look like this:
 "${PODS_ROOT}/SwiftLint/swiftlint"
 ```
 
-### Plug-in Support
+### Plugin Support
 
 SwiftLint can be used as a build tool plugin for both Swift Package projects 
 and Xcode projects.
@@ -233,14 +233,14 @@ plugin, please consider one of the following options:
 
 #### Xcode
 
-You can integrate SwiftLint as an Xcode Build Tool Plug-in if you're working
+You can integrate SwiftLint as an Xcode Build Tool Plugin if you're working
 with a project in Xcode.
 
 Add SwiftLint as a package dependency to your project without linking any of the
 products.
 
 Select the target you want to add linting to and open the `Build Phases` inspector.
-Open `Run Build Tool Plug-ins` and select the `+` button.
+Open `Run Build Tool Plugins` and select the `+` button.
 Select `SwiftLintBuildToolPlugin` from the list and add it to the project.
 
 ![](https://raw.githubusercontent.com/realm/SwiftLint/main/assets/select-swiftlint-plugin.png)
@@ -256,7 +256,7 @@ _Note: This implicitly trusts all Xcode package plugins and macros in packages a
 
 #### Swift Package
 
-You can integrate SwiftLint as a Swift Package Manager Plug-in if you're working with
+You can integrate SwiftLint as a Swift Package Manager Plugin if you're working with
 a Swift Package with a `Package.swift` manifest.
 
 Add SwiftLint as a package dependency to your `Package.swift` file.  

--- a/README.md
+++ b/README.md
@@ -208,8 +208,12 @@ If you've installed SwiftLint via CocoaPods the script should look like this:
 
 ### Swift Package Command Plugin
 
-SwiftLint can be used as a build tool plugin for both Swift Package projects 
-and Xcode projects.
+The command plugin enables running SwiftLint from the command line as follows:
+
+```shell
+swift package plugin swiftlint
+```
+
 
 The build tool plugin determines the SwiftLint working directory by locating 
 the topmost config file within the package/project directory. If a config file


### PR DESCRIPTION
## Changelog

- Introduce `SwiftLintCommandPlugin`
- Rename `SwiftLintBuildToolPlugin`
- Add Swift Package Manager installation instructions
- Improve README.md

## Benefits

- Allows running SwiftLint from the command line when added as a package dependency
- Command line usage can be pinned to a specific version (as compared to Homebrew, for example)
- The plugins are named `SwiftLintCommandPlugin` and `SwiftLintBuildToolPlugin` for clarity
- The README now explains how to add SwiftLint as a package dependency