### PR TITLE
Move “Rewrite SwiftLintPlugin” to Breaking section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 #### Breaking
 
-* None.
+* Rewrite `SwiftLintPlugin` using `BUILD_WORKSPACE_DIRECTORY` without relying
+  on the `--config` option.  
+  [Garric Nahapetian](https://github.com/garricn)
 
 #### Experimental
 
@@ -858,10 +860,6 @@
 
 * Catch more valid `no_magic_numbers` violations.  
   [JP Simard](https://github.com/jpsim)
-
-* Rewrite `SwiftLintPlugin` using `BUILD_WORKSPACE_DIRECTORY` without relying
-  on the `--config` option.  
-  [Garric Nahapetian](https://github.com/garricn)
 
 * Add `blanket_disable_command` rule that checks whether
   rules are re-enabled after being disabled.  


### PR DESCRIPTION
The CHANGELOG entry for #4758 should have been added to the Breaking section since the plugin no longer uses the `--config` option.