### PR TITLE
Allow to infer option names

### DIFF
--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/CyclomaticComplexityConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/CyclomaticComplexityConfiguration.swift
@@ -5,7 +5,7 @@ import SwiftLintCore
 struct CyclomaticComplexityConfiguration: RuleConfiguration {
     typealias Parent = CyclomaticComplexityRule
 
-    @ConfigurationElement
+    @ConfigurationElement(inline: true)
     private(set) var length = SeverityLevelsConfiguration<Parent>(warning: 10, error: 20)
     @ConfigurationElement(key: "ignores_case_statements")
     private(set) var ignoresCaseStatements = false

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileLengthConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileLengthConfiguration.swift
@@ -4,7 +4,7 @@ import SwiftLintCore
 struct FileLengthConfiguration: RuleConfiguration {
     typealias Parent = FileLengthRule
 
-    @ConfigurationElement
+    @ConfigurationElement(inline: true)
     private(set) var severityConfiguration = SeverityLevelsConfiguration<Parent>(warning: 400, error: 1000)
     @ConfigurationElement(key: "ignore_comment_only_lines")
     private(set) var ignoreCommentOnlyLines = false

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FunctionParameterCountConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FunctionParameterCountConfiguration.swift
@@ -4,7 +4,7 @@ import SwiftLintCore
 struct FunctionParameterCountConfiguration: RuleConfiguration {
     typealias Parent = FunctionParameterCountRule
 
-    @ConfigurationElement
+    @ConfigurationElement(inline: true)
     private(set) var severityConfiguration = SeverityLevelsConfiguration<Parent>(warning: 5, error: 8)
     @ConfigurationElement(key: "ignores_default_parameters")
     private(set) var ignoresDefaultParameters = true

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/IdentifierNameConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/IdentifierNameConfiguration.swift
@@ -6,7 +6,7 @@ struct IdentifierNameConfiguration: RuleConfiguration {
 
     private static let defaultOperators = ["/", "=", "-", "+", "!", "*", "|", "^", "~", "?", ".", "%", "<", ">", "&"]
 
-    @ConfigurationElement
+    @ConfigurationElement(inline: true)
     private(set) var nameConfiguration = NameConfiguration<Parent>(minLengthWarning: 3,
                                                                    minLengthError: 2,
                                                                    maxLengthWarning: 40,

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/LineLengthConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/LineLengthConfiguration.swift
@@ -4,7 +4,7 @@ import SwiftLintCore
 struct LineLengthConfiguration: RuleConfiguration {
     typealias Parent = LineLengthRule
 
-    @ConfigurationElement
+    @ConfigurationElement(inline: true)
     private(set) var length = SeverityLevelsConfiguration<Parent>(warning: 120, error: 200)
     @ConfigurationElement(key: "ignores_urls")
     private(set) var ignoresURLs = false

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NameConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NameConfiguration.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftLintCore
 
-struct NameConfiguration<Parent: Rule>: RuleConfiguration {
+struct NameConfiguration<Parent: Rule>: RuleConfiguration, InlinableOptionType {
     typealias Severity = SeverityConfiguration<Parent>
     typealias SeverityLevels = SeverityLevelsConfiguration<Parent>
     typealias StartWithLowercaseConfiguration = ChildOptionSeverityConfiguration<Parent>

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TypeNameConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TypeNameConfiguration.swift
@@ -4,7 +4,7 @@ import SwiftLintCore
 struct TypeNameConfiguration: RuleConfiguration {
     typealias Parent = TypeNameRule
 
-    @ConfigurationElement
+    @ConfigurationElement(inline: true)
     private(set) var nameConfiguration = NameConfiguration<Parent>(minLengthWarning: 3,
                                                                    minLengthError: 0,
                                                                    maxLengthWarning: 40,

--- a/Source/SwiftLintCore/Models/ChildOptionSeverityConfiguration.swift
+++ b/Source/SwiftLintCore/Models/ChildOptionSeverityConfiguration.swift
@@ -1,6 +1,6 @@
 /// A rule configuration that allows to disable (`off`) an option of a rule or specify its severity level in which
 /// case it's active.
-public struct ChildOptionSeverityConfiguration<Parent: Rule>: RuleConfiguration {
+public struct ChildOptionSeverityConfiguration<Parent: Rule>: RuleConfiguration, AcceptableByConfigurationElement {
     /// Configuration with a warning severity.
     public static var error: Self { Self(optionSeverity: .error) }
     /// Configuration with an error severity.

--- a/Source/SwiftLintCore/Models/RuleConfigurationDescription.swift
+++ b/Source/SwiftLintCore/Models/RuleConfigurationDescription.swift
@@ -350,7 +350,16 @@ public extension AcceptableByConfigurationElement {
     }
 }
 
-/// An option type that does not need a key when used in a ``ConfigurationElement``. Its value will be inlined.
+/// An option type that can appear inlined into its using configuration.
+///
+/// The ``ConfigurationElement`` must opt into this behavior. In this case, the option does not have a key. This is
+/// almost exclusively useful for common ``RuleConfiguration``s that are used in many other rules as child
+/// configurations.
+///
+/// > Warning: A type conforming to this protocol is assumed to throw an issue in its `apply` method only when it's
+/// absolutely clear that there is an error in the YAML configuration passed in. Since it may be used in a nested
+/// context and doesn't know about the outer configuration, it's not always clear if a certain key-value is really
+/// unacceptable.
 public protocol InlinableOptionType: AcceptableByConfigurationElement {}
 
 /// A single parameter of a rule configuration.
@@ -613,7 +622,7 @@ extension RegularExpression: AcceptableByConfigurationElement {
 
 // MARK: RuleConfiguration conformances
 
-public extension RuleConfiguration {
+public extension AcceptableByConfigurationElement where Self: RuleConfiguration {
     func asOption() -> OptionType {
         .nested(.from(configuration: self))
     }

--- a/Source/SwiftLintCore/Models/RuleConfigurationDescription.swift
+++ b/Source/SwiftLintCore/Models/RuleConfigurationDescription.swift
@@ -332,7 +332,7 @@ public protocol AcceptableByConfigurationElement {
     func asDescription(with key: String) -> RuleConfigurationDescription
 
     /// Update the object.
-    /// 
+    ///
     /// - Parameter value: New underlying data for the object.
     mutating func apply(_ value: Any?, ruleID: String) throws
 }
@@ -402,7 +402,12 @@ public struct ConfigurationElement<T: AcceptableByConfigurationElement & Equatab
     }
 
     /// Name of this configuration entry.
-    public let key: String
+    public var key: String
+
+    /// Whether this configuration element will be inlined into its description.
+    public var inlinable: Bool {
+        T.self is any InlinableOptionType.Type && key.isEmpty
+    }
 
     private let postprocessor: (inout T) throws -> Void
 
@@ -412,7 +417,9 @@ public struct ConfigurationElement<T: AcceptableByConfigurationElement & Equatab
     ///   - value: Value to be wrapped.
     ///   - key: Name of the option.
     ///   - postprocessor: Function to be applied to the wrapped value after parsing to validate and modify it.
-    public init(wrappedValue value: T, key: String, postprocessor: @escaping (inout T) throws -> Void = { _ in }) {
+    public init(wrappedValue value: T,
+                key: String = "",
+                postprocessor: @escaping (inout T) throws -> Void = { _ in }) {
         self.wrappedValue = value
         self.key = key
         self.postprocessor = postprocessor
@@ -426,7 +433,7 @@ public struct ConfigurationElement<T: AcceptableByConfigurationElement & Equatab
     /// It allows to skip explicit initialization with `nil` of the property.
     ///
     /// - Parameter value: Value to be wrapped.
-    public init<Wrapped>(key: String) where T == Wrapped? {
+    public init<Wrapped>(key: String = "") where T == Wrapped? {
         self.init(wrappedValue: nil, key: key)
     }
 

--- a/Source/SwiftLintCore/Models/SeverityConfiguration.swift
+++ b/Source/SwiftLintCore/Models/SeverityConfiguration.swift
@@ -22,10 +22,12 @@ public struct SeverityConfiguration<Parent: Rule>: SeverityBasedRuleConfiguratio
     public mutating func apply(configuration: Any) throws {
         let configString = configuration as? String
         let configDict = configuration as? [String: Any]
-        guard let severityString: String = configString ?? configDict?[$severity.key] as? String,
-            let severity = ViolationSeverity(rawValue: severityString.lowercased()) else {
-            throw Issue.unknownConfiguration(ruleID: Parent.description.identifier)
+        if let severityString: String = configString ?? configDict?[$severity.key] as? String {
+            if let severity = ViolationSeverity(rawValue: severityString.lowercased()) {
+                self.severity = severity
+            } else {
+                throw Issue.unknownConfiguration(ruleID: Parent.description.identifier)
+            }
         }
-        self.severity = severity
     }
 }

--- a/Source/SwiftLintCore/Models/SeverityConfiguration.swift
+++ b/Source/SwiftLintCore/Models/SeverityConfiguration.swift
@@ -1,5 +1,5 @@
 /// A rule configuration that allows specifying the desired severity level for violations.
-public struct SeverityConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration {
+public struct SeverityConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration, InlinableOptionType {
     /// Configuration with a warning severity.
     public static var error: Self { Self(.error) }
     /// Configuration with an error severity.

--- a/Source/SwiftLintCore/Protocols/RuleConfiguration.swift
+++ b/Source/SwiftLintCore/Protocols/RuleConfiguration.swift
@@ -1,5 +1,5 @@
 /// A configuration value for a rule to allow users to modify its behavior.
-public protocol RuleConfiguration: InlinableOptionType, Equatable {
+public protocol RuleConfiguration: Equatable {
     /// The type of the rule that's using this configuration.
     associatedtype Parent: Rule
 

--- a/Source/SwiftLintCore/RuleConfigurations/RegexConfiguration.swift
+++ b/Source/SwiftLintCore/RuleConfigurations/RegexConfiguration.swift
@@ -2,7 +2,8 @@ import Foundation
 import SourceKittenFramework
 
 /// A rule configuration used for defining custom rules in yaml.
-public struct RegexConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration, Hashable, CacheDescriptionProvider {
+public struct RegexConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration, Hashable,
+                                                CacheDescriptionProvider, InlinableOptionType {
     /// The identifier for this custom rule.
     public let identifier: String
     /// The name for this custom rule.

--- a/Source/SwiftLintCore/RuleConfigurations/SeverityLevelsConfiguration.swift
+++ b/Source/SwiftLintCore/RuleConfigurations/SeverityLevelsConfiguration.swift
@@ -1,5 +1,5 @@
 /// A rule configuration that allows specifying thresholds for `warning` and `error` severities.
-public struct SeverityLevelsConfiguration<Parent: Rule>: RuleConfiguration {
+public struct SeverityLevelsConfiguration<Parent: Rule>: RuleConfiguration, InlinableOptionType {
     /// The threshold for a violation to be a warning.
     @ConfigurationElement(key: "warning")
     public var warning: Int = 12

--- a/Source/SwiftLintCore/RuleConfigurations/SeverityLevelsConfiguration.swift
+++ b/Source/SwiftLintCore/RuleConfigurations/SeverityLevelsConfiguration.swift
@@ -48,8 +48,6 @@ public struct SeverityLevelsConfiguration<Parent: Rule>: RuleConfiguration, Inli
             } else {
                 self.error = nil
             }
-        } else {
-            throw Issue.invalidConfiguration(ruleID: Parent.description.identifier)
         }
     }
 }

--- a/Source/SwiftLintCoreMacros/RuleConfigurationMacros.swift
+++ b/Source/SwiftLintCoreMacros/RuleConfigurationMacros.swift
@@ -24,7 +24,7 @@ enum AutoApply: MemberMacro {
             }
         let inlinedOptionsUpdate = elementNames.map {
             """
-            if $\($0).inlinable {
+            if $\($0).inline {
                 inlinableOptionsExist = true
                 try \($0).apply(configuration, ruleID: Parent.identifier)
                 try $\($0).performAfterParseOperations()
@@ -33,7 +33,7 @@ enum AutoApply: MemberMacro {
         }
         let nonInlinedOptionsUpdate = elementNames.map {
             """
-            if !$\($0).inlinable {
+            if !$\($0).inline {
                 if $\($0).key.isEmpty {
                     $\($0).key = "\($0.snakeCased)"
                 }

--- a/Tests/MacroTests/AutoApplyTests.swift
+++ b/Tests/MacroTests/AutoApplyTests.swift
@@ -79,12 +79,12 @@ final class AutoApplyTests: XCTestCase {
 
                 mutating func apply(configuration: Any) throws {
                     var inlinableOptionsExist = false
-                    if $eA.inlinable {
+                    if $eA.inline {
                     inlinableOptionsExist = true
                     try eA.apply(configuration, ruleID: Parent.identifier)
                     try $eA.performAfterParseOperations()
                     }
-                    if $eB.inlinable {
+                    if $eB.inline {
                         inlinableOptionsExist = true
                         try eB.apply(configuration, ruleID: Parent.identifier)
                         try $eB.performAfterParseOperations()
@@ -96,14 +96,14 @@ final class AutoApplyTests: XCTestCase {
                             throw Issue.invalidConfiguration(ruleID: Parent.description.identifier)
                         }
                     }
-                    if !$eA.inlinable {
+                    if !$eA.inline {
                     if $eA.key.isEmpty {
                         $eA.key = "e_a"
                     }
                     try eA.apply(configuration[$eA.key], ruleID: Parent.identifier)
                     try $eA.performAfterParseOperations()
                     }
-                    if !$eB.inlinable {
+                    if !$eB.inline {
                         if $eB.key.isEmpty {
                             $eB.key = "e_b"
                         }
@@ -142,12 +142,12 @@ final class AutoApplyTests: XCTestCase {
 
                 mutating func apply(configuration: Any) throws {
                     var inlinableOptionsExist = false
-                    if $eA.inlinable {
+                    if $eA.inline {
                     inlinableOptionsExist = true
                     try eA.apply(configuration, ruleID: Parent.identifier)
                     try $eA.performAfterParseOperations()
                     }
-                    if $eB.inlinable {
+                    if $eB.inline {
                         inlinableOptionsExist = true
                         try eB.apply(configuration, ruleID: Parent.identifier)
                         try $eB.performAfterParseOperations()
@@ -159,14 +159,14 @@ final class AutoApplyTests: XCTestCase {
                             throw Issue.invalidConfiguration(ruleID: Parent.description.identifier)
                         }
                     }
-                    if !$eA.inlinable {
+                    if !$eA.inline {
                     if $eA.key.isEmpty {
                         $eA.key = "e_a"
                     }
                     try eA.apply(configuration[$eA.key], ruleID: Parent.identifier)
                     try $eA.performAfterParseOperations()
                     }
-                    if !$eB.inlinable {
+                    if !$eB.inline {
                         if $eB.key.isEmpty {
                             $eB.key = "e_b"
                         }

--- a/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceConfigurationTests.swift
@@ -36,7 +36,7 @@ class ExplicitTypeInterfaceConfigurationTests: SwiftLintTestCase {
     func testInvalidTypeOfValueInCustomConfiguration() {
         var config = ExplicitTypeInterfaceConfiguration()
         checkError(Issue.unknownConfiguration(ruleID: ExplicitTypeInterfaceRule.description.identifier)) {
-            try config.apply(configuration: ["severity": 1])
+            try config.apply(configuration: ["severity": "foo"])
         }
     }
 

--- a/Tests/SwiftLintFrameworkTests/LineLengthConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LineLengthConfigurationTests.swift
@@ -69,7 +69,7 @@ class LineLengthConfigurationTests: SwiftLintTestCase {
     }
 
     func testLineLengthConfigurationThrowsOnBadConfig() {
-        let config = "unknown"
+        let config = ["warning": "unknown"]
         var configuration = LineLengthConfiguration(length: severityLevels)
         checkError(Issue.invalidConfiguration(ruleID: LineLengthRule.description.identifier)) {
             try configuration.apply(configuration: config)

--- a/Tests/SwiftLintFrameworkTests/RuleConfigurationDescriptionTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleConfigurationDescriptionTests.swift
@@ -12,7 +12,7 @@ class RuleConfigurationDescriptionTests: XCTestCase {
 
         @ConfigurationElement(key: "flag")
         var flag = true
-        @ConfigurationElement(key: "string")
+        @ConfigurationElement
         var string = "value"
         @ConfigurationElement(key: "symbol")
         var symbol = try! Symbol(fromAny: "value", context: "rule") // swiftlint:disable:this force_try
@@ -20,8 +20,8 @@ class RuleConfigurationDescriptionTests: XCTestCase {
         var integer = 2
         @ConfigurationElement(key: "null")
         var null: Int?
-        @ConfigurationElement(key: "double")
-        var double = 2.1
+        @ConfigurationElement
+        var myDouble = 2.1
         @ConfigurationElement(key: "severity")
         var severity = ViolationSeverity.warning
         @ConfigurationElement(
@@ -54,7 +54,7 @@ class RuleConfigurationDescriptionTests: XCTestCase {
             string: "value"; \
             symbol: value; \
             integer: 2; \
-            double: 2.1; \
+            my_double: 2.1; \
             severity: warning; \
             list: ["STRING1", "STRING2"]; \
             set: [1, 2, 3]; \
@@ -104,7 +104,7 @@ class RuleConfigurationDescriptionTests: XCTestCase {
             </tr>
             <tr>
             <td>
-            double
+            my_double
             </td>
             <td>
             2.1
@@ -197,7 +197,7 @@ class RuleConfigurationDescriptionTests: XCTestCase {
             string: "value"
             symbol: value
             integer: 2
-            double: 2.1
+            my_double: 2.1
             severity: warning
             list: ["STRING1", "STRING2"]
             set: [1, 2, 3]
@@ -466,7 +466,7 @@ class RuleConfigurationDescriptionTests: XCTestCase {
             "symbol": "new symbol",
             "integer": 5,
             "null": 0,
-            "double": 5.1,
+            "my_double": 5.1,
             "severity": "error",
             "list": ["string3", "string4"],
             "set": [4, 5, 6],
@@ -480,7 +480,7 @@ class RuleConfigurationDescriptionTests: XCTestCase {
         XCTAssertEqual(configuration.symbol, try Symbol(fromAny: "new symbol", context: "rule"))
         XCTAssertEqual(configuration.integer, 5)
         XCTAssertEqual(configuration.null, 0)
-        XCTAssertEqual(configuration.double, 5.1)
+        XCTAssertEqual(configuration.myDouble, 5.1)
         XCTAssertEqual(configuration.severity, .error)
         XCTAssertEqual(configuration.list, ["STRING3", "STRING4"])
         XCTAssertEqual(configuration.set, [4, 5, 6])

--- a/Tests/SwiftLintFrameworkTests/RuleConfigurationDescriptionTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleConfigurationDescriptionTests.swift
@@ -36,16 +36,18 @@ class RuleConfigurationDescriptionTests: XCTestCase {
         @ConfigurationElement(key: "SEVERITY")
         var renamedSeverityConfig = SeverityConfiguration<Parent>(.warning)
         @ConfigurationElement(inline: true)
-        var inlinedSeverityLevels = SeverityLevelsConfiguration<Parent>(warning: 1, error: 2)
+        var inlinedSeverityLevels = SeverityLevelsConfiguration<Parent>(warning: 1, error: nil)
         @ConfigurationElement(key: "levels")
-        var nestedSeverityLevels = SeverityLevelsConfiguration<Parent>(warning: 3, error: nil)
+        var nestedSeverityLevels = SeverityLevelsConfiguration<Parent>(warning: 3, error: 2)
 
         func isEqualTo(_ ruleConfiguration: some RuleConfiguration) -> Bool { false }
     }
 
     // swiftlint:disable:next function_body_length
-    func testDescriptionFromConfiguration() {
-        let description = RuleConfigurationDescription.from(configuration: TestConfiguration())
+    func testDescriptionFromConfiguration() throws {
+        var configuration = TestConfiguration()
+        try configuration.apply(configuration: [:])
+        let description = RuleConfigurationDescription.from(configuration: configuration)
 
         XCTAssertEqual(description.oneLiner(), """
             flag: true; \
@@ -59,8 +61,7 @@ class RuleConfigurationDescriptionTests: XCTestCase {
             severity: error; \
             SEVERITY: warning; \
             warning: 1; \
-            error: 2; \
-            levels: warning: 3
+            levels: warning: 3, error: 2
             """)
 
         XCTAssertEqual(description.markdown(), """
@@ -159,14 +160,6 @@ class RuleConfigurationDescriptionTests: XCTestCase {
             </tr>
             <tr>
             <td>
-            error
-            </td>
-            <td>
-            2
-            </td>
-            </tr>
-            <tr>
-            <td>
             levels
             </td>
             <td>
@@ -181,6 +174,14 @@ class RuleConfigurationDescriptionTests: XCTestCase {
             </td>
             <td>
             3
+            </td>
+            </tr>
+            <tr>
+            <td>
+            error
+            </td>
+            <td>
+            2
             </td>
             </tr>
             </tbody>
@@ -203,9 +204,9 @@ class RuleConfigurationDescriptionTests: XCTestCase {
             severity: error
             SEVERITY: warning
             warning: 1
-            error: 2
             levels:
               warning: 3
+              error: 2
             """)
     }
 

--- a/Tests/SwiftLintFrameworkTests/RuleConfigurationDescriptionTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleConfigurationDescriptionTests.swift
@@ -31,11 +31,11 @@ class RuleConfigurationDescriptionTests: XCTestCase {
         var list = ["string1", "string2"]
         @ConfigurationElement(key: "set")
         var set: Set<Int> = [1, 2, 3]
-        @ConfigurationElement
+        @ConfigurationElement(inline: true)
         var severityConfig = SeverityConfiguration<Parent>(.error)
         @ConfigurationElement(key: "SEVERITY")
         var renamedSeverityConfig = SeverityConfiguration<Parent>(.warning)
-        @ConfigurationElement
+        @ConfigurationElement(inline: true)
         var inlinedSeverityLevels = SeverityLevelsConfiguration<Parent>(warning: 1, error: 2)
         @ConfigurationElement(key: "levels")
         var nestedSeverityLevels = SeverityLevelsConfiguration<Parent>(warning: 3, error: nil)

--- a/Tests/SwiftLintFrameworkTests/RuleConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleConfigurationTests.swift
@@ -66,8 +66,15 @@ class RuleConfigurationTests: SwiftLintTestCase {
         }
     }
 
-    func testSeverityConfigurationThrowsOnBadConfig() {
+    func testSeverityConfigurationDoesNotChangeOnBadConfig() throws {
         let config = 17
+        var severityConfig = SeverityConfiguration<RuleMock>(.error)
+        try severityConfig.apply(configuration: config)
+        XCTAssertEqual(severityConfig.severity, .error)
+    }
+
+    func testSeverityConfigurationThrowsOnBadConfig() {
+        let config = "foo"
         var severityConfig = SeverityConfiguration<RuleMock>(.warning)
         checkError(Issue.unknownConfiguration(ruleID: RuleMock.description.identifier)) {
             try severityConfig.apply(configuration: config)


### PR DESCRIPTION
This allows to infer names of options from their names in a configuration. CamelCase is translated into snake_case automatically when `apply` is triggered.

* Don't have all `RuleConfiguration`s conform to `InlinableOptionType`. Mark types that must have this capability explicitly. Same for `AcceptableByConfigurationElement`.
* A type being an `InlinableOptionType` doesn't mean it's automatically inlined. This also doesn't depend on the fact of having a name for its key configured any longer. Instead, an `inline` attribute must explicitly be set to `true` in `@ConfigurationElement`.
* Key name inference is optional and can be overwritten by specifying a key name in the attribute.
* Inlined configurations only fail in `apply` when they are really sure that something is odd. Otherwise, they accept to not being updated.