### PR TITLE
Report specific issues

### DIFF
--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/DeploymentTargetConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/DeploymentTargetConfiguration.swift
@@ -62,7 +62,7 @@ struct DeploymentTargetConfiguration: SeverityBasedRuleConfiguration {
         private static func parseVersion(string: String) throws -> (Int, Int, Int) {
             func parseNumber(_ string: String) throws -> Int {
                 guard let number = Int(string) else {
-                    throw Issue.unknownConfiguration(ruleID: Parent.identifier)
+                    throw Issue.invalidConfiguration(ruleID: Parent.identifier)
                 }
                 return number
             }
@@ -70,7 +70,7 @@ struct DeploymentTargetConfiguration: SeverityBasedRuleConfiguration {
             let parts = string.components(separatedBy: ".")
             switch parts.count {
             case 0:
-                throw Issue.unknownConfiguration(ruleID: Parent.identifier)
+                throw Issue.invalidConfiguration(ruleID: Parent.identifier)
             case 1:
                 return (try parseNumber(parts[0]), 0, 0)
             case 2:
@@ -131,7 +131,7 @@ struct DeploymentTargetConfiguration: SeverityBasedRuleConfiguration {
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: Any] else {
-            throw Issue.unknownConfiguration(ruleID: Parent.identifier)
+            throw Issue.invalidConfiguration(ruleID: Parent.identifier)
         }
         for (key, value) in configuration {
             if key == "severity", let value = value as? String {
@@ -139,7 +139,7 @@ struct DeploymentTargetConfiguration: SeverityBasedRuleConfiguration {
                 continue
             }
             guard let target = targets[key] else {
-                throw Issue.unknownConfiguration(ruleID: Parent.identifier)
+                throw Issue.invalidConfiguration(ruleID: Parent.identifier)
             }
             try target.update(using: value)
             if let extensionConfigurationKey = target.platform.appExtensionCounterpart?.configurationKey,

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileHeaderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileHeaderConfiguration.swift
@@ -28,7 +28,7 @@ struct FileHeaderConfiguration: SeverityBasedRuleConfiguration {
 
     mutating func apply(configuration: Any) throws {
         guard let configuration = configuration as? [String: String] else {
-            throw Issue.unknownConfiguration(ruleID: Parent.identifier)
+            throw Issue.invalidConfiguration(ruleID: Parent.identifier)
         }
 
         // Cache the created regexes if possible.

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MissingDocsConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MissingDocsConfiguration.swift
@@ -30,7 +30,7 @@ struct MissingDocsConfiguration: RuleConfiguration {
 
     mutating func apply(configuration: Any) throws {
         guard let dict = configuration as? [String: Any] else {
-            throw Issue.unknownConfiguration(ruleID: Parent.identifier)
+            throw Issue.invalidConfiguration(ruleID: Parent.identifier)
         }
 
         if let shouldExcludeExtensions = dict[$excludesExtensions.key] as? Bool {
@@ -62,7 +62,7 @@ struct MissingDocsConfiguration: RuleConfiguration {
                 let rules: [RuleParameter<AccessControlLevel>] = try array
                     .map { val -> RuleParameter<AccessControlLevel> in
                         guard let acl = AccessControlLevel(description: val) else {
-                            throw Issue.unknownConfiguration(ruleID: Parent.identifier)
+                            throw Issue.invalidConfiguration(ruleID: Parent.identifier)
                         }
                         return RuleParameter<AccessControlLevel>(severity: severity, value: acl)
                     }
@@ -76,7 +76,7 @@ struct MissingDocsConfiguration: RuleConfiguration {
         }
 
         guard parameters.count == parameters.map({ $0.value }).unique.count else {
-            throw Issue.unknownConfiguration(ruleID: Parent.identifier)
+            throw Issue.invalidConfiguration(ruleID: Parent.identifier)
         }
 
         return parameters.isNotEmpty ? parameters : nil

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ModifierOrderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ModifierOrderConfiguration.swift
@@ -28,7 +28,7 @@ extension SwiftDeclarationAttributeKind.ModifierGroup: AcceptableByConfiguration
         if let value = value as? String, let newSelf = Self(rawValue: value), newSelf != .atPrefixed {
             self = newSelf
         } else {
-            throw Issue.unknownConfiguration(ruleID: ruleID)
+            throw Issue.invalidConfiguration(ruleID: ruleID)
         }
     }
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NameConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NameConfiguration.swift
@@ -51,7 +51,7 @@ struct NameConfiguration<Parent: Rule>: RuleConfiguration, InlinableOptionType {
 
     mutating func apply(configuration: Any) throws {
         guard let configurationDict = configuration as? [String: Any] else {
-            throw Issue.unknownConfiguration(ruleID: Parent.identifier)
+            throw Issue.invalidConfiguration(ruleID: Parent.identifier)
         }
 
         if let minLengthConfiguration = configurationDict[$minLength.key] {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateUnitTestConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateUnitTestConfiguration.swift
@@ -14,7 +14,7 @@ struct PrivateUnitTestConfiguration: SeverityBasedRuleConfiguration {
 
     mutating func apply(configuration: Any) throws {
         guard let configurationDict = configuration as? [String: Any] else {
-            throw Issue.unknownConfiguration(ruleID: Parent.identifier)
+            throw Issue.invalidConfiguration(ruleID: Parent.identifier)
         }
         if let extraTestParentClasses = configurationDict[$testParentClasses.key] as? [String] {
             self.testParentClasses.formUnion(extraTestParentClasses)

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/RequiredEnumCaseConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/RequiredEnumCaseConfiguration.swift
@@ -32,7 +32,7 @@ struct RequiredEnumCaseConfiguration: RuleConfiguration {
 
     mutating func apply(configuration: Any) throws {
         guard let config = configuration as? [String: [String: String]] else {
-            throw Issue.unknownConfiguration(ruleID: Parent.identifier)
+            throw Issue.invalidConfiguration(ruleID: Parent.identifier)
         }
 
         register(protocols: config)

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedImportConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedImportConfiguration.swift
@@ -14,7 +14,7 @@ struct TransitiveModuleConfiguration<Parent: Rule>: Equatable, AcceptableByConfi
             let importedModule = configurationDict["module"] as? String,
             let transitivelyImportedModules = configurationDict["allowed_transitive_imports"] as? [String]
         else {
-            throw Issue.unknownConfiguration(ruleID: Parent.identifier)
+            throw Issue.invalidConfiguration(ruleID: Parent.identifier)
         }
         self.importedModule = importedModule
         self.transitivelyImportedModules = transitivelyImportedModules

--- a/Source/SwiftLintCore/Models/ChildOptionSeverityConfiguration.swift
+++ b/Source/SwiftLintCore/Models/ChildOptionSeverityConfiguration.swift
@@ -23,7 +23,7 @@ public struct ChildOptionSeverityConfiguration<Parent: Rule>: RuleConfiguration,
     public mutating func apply(configuration: Any) throws {
         guard let configString = configuration as? String,
             let optionSeverity = ChildOptionSeverity(rawValue: configString.lowercased()) else {
-            throw Issue.unknownConfiguration(ruleID: Parent.description.identifier)
+            throw Issue.invalidConfiguration(ruleID: Parent.description.identifier)
         }
         self.optionSeverity = optionSeverity
     }

--- a/Source/SwiftLintCore/Models/Issue.swift
+++ b/Source/SwiftLintCore/Models/Issue.swift
@@ -3,16 +3,13 @@ import Foundation
 /// All possible SwiftLint issues which are printed as warnings by default.
 public enum Issue: LocalizedError, Equatable {
     /// The configuration didn't match internal expectations.
-    case unknownConfiguration(ruleID: String)
+    case invalidConfiguration(ruleID: String)
 
     /// Rule is listed multiple times in the configuration.
     case listedMultipleTime(ruleID: String, times: Int)
 
     /// An identifier `old` has been renamed to `new`.
     case renamedIdentifier(old: String, new: String)
-
-    /// Configuration for a rule is invalid.
-    case invalidConfiguration(ruleID: String)
 
     /// Some configuration keys are invalid.
     case invalidConfigurationKeys(ruleID: String, keys: Set<String>)
@@ -92,14 +89,12 @@ public enum Issue: LocalizedError, Equatable {
 
     private var message: String {
         switch self {
-        case let .unknownConfiguration(id):
+        case let .invalidConfiguration(id):
             return "Invalid configuration for '\(id)' rule. Falling back to default."
         case let .listedMultipleTime(id, times):
             return "'\(id)' is listed \(times) times in the configuration."
         case let .renamedIdentifier(old, new):
             return "'\(old)' has been renamed to '\(new)' and will be completely removed in a future release."
-        case let .invalidConfiguration(id):
-            return "Invalid configuration for '\(id)'. Falling back to default."
         case let .invalidConfigurationKeys(id, keys):
             return "Configuration for '\(id)' rule contains the invalid key(s) \(keys.formatted)."
         case let .invalidRuleIDs(ruleIDs):

--- a/Source/SwiftLintCore/Models/Issue.swift
+++ b/Source/SwiftLintCore/Models/Issue.swift
@@ -5,6 +5,9 @@ public enum Issue: LocalizedError, Equatable {
     /// The configuration didn't match internal expectations.
     case invalidConfiguration(ruleID: String)
 
+    /// Used in configuration parsing when no changes have been applied. Use only internally!
+    case nothingApplied(ruleID: String)
+
     /// Rule is listed multiple times in the configuration.
     case listedMultipleTime(ruleID: String, times: Int)
 
@@ -91,6 +94,8 @@ public enum Issue: LocalizedError, Equatable {
         switch self {
         case let .invalidConfiguration(id):
             return "Invalid configuration for '\(id)' rule. Falling back to default."
+        case let .nothingApplied(ruleID: id):
+            return Self.invalidConfiguration(ruleID: id).message
         case let .listedMultipleTime(id, times):
             return "'\(id)' is listed \(times) times in the configuration."
         case let .renamedIdentifier(old, new):

--- a/Source/SwiftLintCore/Models/SeverityConfiguration.swift
+++ b/Source/SwiftLintCore/Models/SeverityConfiguration.swift
@@ -26,7 +26,7 @@ public struct SeverityConfiguration<Parent: Rule>: SeverityBasedRuleConfiguratio
             if let severity = ViolationSeverity(rawValue: severityString.lowercased()) {
                 self.severity = severity
             } else {
-                throw Issue.unknownConfiguration(ruleID: Parent.description.identifier)
+                throw Issue.invalidConfiguration(ruleID: Parent.description.identifier)
             }
         }
     }

--- a/Source/SwiftLintCore/Models/SeverityConfiguration.swift
+++ b/Source/SwiftLintCore/Models/SeverityConfiguration.swift
@@ -26,8 +26,10 @@ public struct SeverityConfiguration<Parent: Rule>: SeverityBasedRuleConfiguratio
             if let severity = ViolationSeverity(rawValue: severityString.lowercased()) {
                 self.severity = severity
             } else {
-                throw Issue.invalidConfiguration(ruleID: Parent.description.identifier)
+                throw Issue.invalidConfiguration(ruleID: Parent.identifier)
             }
+        } else {
+            throw Issue.nothingApplied(ruleID: Parent.identifier)
         }
     }
 }

--- a/Source/SwiftLintCore/RuleConfigurations/RegexConfiguration.swift
+++ b/Source/SwiftLintCore/RuleConfigurations/RegexConfiguration.swift
@@ -59,7 +59,7 @@ public struct RegexConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration, 
     public mutating func apply(configuration: Any) throws {
         guard let configurationDict = configuration as? [String: Any],
               let regexString = configurationDict[$regex.key] as? String else {
-            throw Issue.unknownConfiguration(ruleID: Parent.description.identifier)
+            throw Issue.invalidConfiguration(ruleID: Parent.description.identifier)
         }
 
         regex = try RegularExpression(pattern: regexString)
@@ -91,7 +91,7 @@ public struct RegexConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration, 
         }
         if let captureGroup = configurationDict["capture_group"] as? Int {
             guard (0 ... regex.numberOfCaptureGroups).contains(captureGroup) else {
-                throw Issue.unknownConfiguration(ruleID: Parent.description.identifier)
+                throw Issue.invalidConfiguration(ruleID: Parent.description.identifier)
             }
             self.captureGroup = captureGroup
         }
@@ -141,7 +141,7 @@ public struct RegexConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration, 
             if let kind = SyntaxKind(shortName: $0) {
                 return kind
             }
-            throw Issue.unknownConfiguration(ruleID: Parent.description.identifier)
+            throw Issue.invalidConfiguration(ruleID: Parent.description.identifier)
         }
         return Set(kinds)
     }

--- a/Source/SwiftLintCore/RuleConfigurations/SeverityLevelsConfiguration.swift
+++ b/Source/SwiftLintCore/RuleConfigurations/SeverityLevelsConfiguration.swift
@@ -34,7 +34,7 @@ public struct SeverityLevelsConfiguration<Parent: Rule>: RuleConfiguration, Inli
                 if let warning = warningValue as? Int {
                     self.warning = warning
                 } else {
-                    throw Issue.invalidConfiguration(ruleID: Parent.description.identifier)
+                    throw Issue.invalidConfiguration(ruleID: Parent.identifier)
                 }
             }
             if let errorValue = configDict[$error.key] {
@@ -43,11 +43,13 @@ public struct SeverityLevelsConfiguration<Parent: Rule>: RuleConfiguration, Inli
                 } else if let error = errorValue as? Int {
                     self.error = error
                 } else {
-                    throw Issue.invalidConfiguration(ruleID: Parent.description.identifier)
+                    throw Issue.invalidConfiguration(ruleID: Parent.identifier)
                 }
             } else {
                 self.error = nil
             }
+        } else {
+            throw Issue.nothingApplied(ruleID: Parent.identifier)
         }
     }
 }

--- a/Source/SwiftLintCore/Rules/CustomRules.swift
+++ b/Source/SwiftLintCore/Rules/CustomRules.swift
@@ -16,7 +16,7 @@ struct CustomRulesConfiguration: RuleConfiguration, CacheDescriptionProvider {
 
     mutating func apply(configuration: Any) throws {
         guard let configurationDict = configuration as? [String: Any] else {
-            throw Issue.unknownConfiguration(ruleID: Parent.identifier)
+            throw Issue.invalidConfiguration(ruleID: Parent.identifier)
         }
 
         for (key, value) in configurationDict {

--- a/Source/SwiftLintCoreMacros/RuleConfigurationMacros.swift
+++ b/Source/SwiftLintCoreMacros/RuleConfigurationMacros.swift
@@ -3,6 +3,7 @@ import SwiftSyntax
 import SwiftSyntaxMacros
 
 enum AutoApply: MemberMacro {
+    // swiftlint:disable:next function_body_length
     static func expansion(
         of node: AttributeSyntax,
         providingMembersOf declaration: some DeclGroupSyntax,
@@ -35,8 +36,12 @@ enum AutoApply: MemberMacro {
         }
         let inlinedOptionsUpdate = elementNames[firstIndexWithoutKey...].map {
             """
-            try \($0).apply(configuration, ruleID: Parent.identifier)
-            try $\($0).performAfterParseOperations()
+            do {
+                try \($0).apply(configuration, ruleID: Parent.identifier)
+                try $\($0).performAfterParseOperations()
+            } catch let issue as Issue where issue == Issue.nothingApplied(ruleID: Parent.identifier) {
+                // Acceptable. Continue.
+            }
             """
         }
         let nonInlinedOptionsUpdate = elementNames[..<firstIndexWithoutKey].map {

--- a/Source/SwiftLintCoreMacros/RuleConfigurationMacros.swift
+++ b/Source/SwiftLintCoreMacros/RuleConfigurationMacros.swift
@@ -93,7 +93,7 @@ enum MakeAcceptableByConfigurationElement: ExtensionMacro {
                         if let value = value as? String, let newSelf = Self(rawValue: value) {
                             self = newSelf
                         } else {
-                            throw Issue.unknownConfiguration(ruleID: ruleID)
+                            throw Issue.invalidConfiguration(ruleID: ruleID)
                         }
                     }
                 }

--- a/Tests/MacroTests/AutoApplyTests.swift
+++ b/Tests/MacroTests/AutoApplyTests.swift
@@ -122,8 +122,12 @@ final class AutoApplyTests: XCTestCase {
                 var eC = 3
 
                 mutating func apply(configuration: Any) throws {
+                    do {
                     try eB.apply(configuration, ruleID: Parent.identifier)
                     try $eB.performAfterParseOperations()
+                    } catch let issue as Issue where issue == Issue.nothingApplied(ruleID: Parent.identifier) {
+                    // Acceptable. Continue.
+                }
                     guard let configuration = configuration as? [String: Any] else {
                         return
                     }

--- a/Tests/MacroTests/MakeAcceptableByConfigurationElementTests.swift
+++ b/Tests/MacroTests/MakeAcceptableByConfigurationElementTests.swift
@@ -64,7 +64,7 @@ final class MakeAcceptableByConfigurationElementTests: XCTestCase {
                     if let value = value as? String, let newSelf = Self (rawValue: value) {
                         self = newSelf
                     } else {
-                        throw Issue.unknownConfiguration(ruleID: ruleID)
+                        throw Issue.invalidConfiguration(ruleID: ruleID)
                     }
                 }
             }
@@ -92,7 +92,7 @@ final class MakeAcceptableByConfigurationElementTests: XCTestCase {
                     if let value = value as? String, let newSelf = Self (rawValue: value) {
                         self = newSelf
                     } else {
-                        throw Issue.unknownConfiguration(ruleID: ruleID)
+                        throw Issue.invalidConfiguration(ruleID: ruleID)
                     }
                 }
             }

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -61,7 +61,7 @@ class CustomRulesTests: SwiftLintTestCase {
     func testCustomRuleConfigurationThrows() {
         let config = 17
         var customRulesConfig = CustomRulesConfiguration()
-        checkError(Issue.unknownConfiguration(ruleID: CustomRules.description.identifier)) {
+        checkError(Issue.invalidConfiguration(ruleID: CustomRules.description.identifier)) {
             try customRulesConfig.apply(configuration: config)
         }
     }

--- a/Tests/SwiftLintFrameworkTests/DeploymentTargetConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/DeploymentTargetConfigurationTests.swift
@@ -137,7 +137,7 @@ class DeploymentTargetConfigurationTests: SwiftLintTestCase {
 
         for badConfig in badConfigs {
             var configuration = DeploymentTargetConfiguration()
-            checkError(Issue.unknownConfiguration(ruleID: DeploymentTargetRule.description.identifier)) {
+            checkError(Issue.invalidConfiguration(ruleID: DeploymentTargetRule.description.identifier)) {
                 try configuration.apply(configuration: badConfig)
             }
         }

--- a/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceConfigurationTests.swift
@@ -35,7 +35,7 @@ class ExplicitTypeInterfaceConfigurationTests: SwiftLintTestCase {
 
     func testInvalidTypeOfValueInCustomConfiguration() {
         var config = ExplicitTypeInterfaceConfiguration()
-        checkError(Issue.unknownConfiguration(ruleID: ExplicitTypeInterfaceRule.description.identifier)) {
+        checkError(Issue.invalidConfiguration(ruleID: ExplicitTypeInterfaceRule.description.identifier)) {
             try config.apply(configuration: ["severity": "foo"])
         }
     }

--- a/Tests/SwiftLintFrameworkTests/ImplicitReturnConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ImplicitReturnConfigurationTests.swift
@@ -31,7 +31,7 @@ class ImplicitReturnConfigurationTests: SwiftLintTestCase {
         var configuration = ImplicitReturnConfiguration()
         let config = ["included": ["foreach"]] as [String: any Sendable]
 
-        checkError(Issue.unknownConfiguration(ruleID: ImplicitReturnRule.description.identifier)) {
+        checkError(Issue.invalidConfiguration(ruleID: ImplicitReturnRule.description.identifier)) {
             try configuration.apply(configuration: config)
         }
     }

--- a/Tests/SwiftLintFrameworkTests/ImplicitlyUnwrappedOptionalConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ImplicitlyUnwrappedOptionalConfigurationTests.swift
@@ -39,7 +39,7 @@ class ImplicitlyUnwrappedOptionalConfigurationTests: SwiftLintTestCase {
                 mode: .allExceptIBOutlets
             )
 
-            checkError(Issue.unknownConfiguration(ruleID: ImplicitlyUnwrappedOptionalRule.description.identifier)) {
+            checkError(Issue.invalidConfiguration(ruleID: ImplicitlyUnwrappedOptionalRule.description.identifier)) {
                 try configuration.apply(configuration: badConfig)
             }
         }

--- a/Tests/SwiftLintFrameworkTests/NameConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/NameConfigurationTests.swift
@@ -65,7 +65,7 @@ class NameConfigurationTests: SwiftLintTestCase {
                                     minLengthError: 0,
                                     maxLengthWarning: 0,
                                     maxLengthError: 0)
-        checkError(Issue.unknownConfiguration(ruleID: RuleMock.description.identifier)) {
+        checkError(Issue.invalidConfiguration(ruleID: RuleMock.description.identifier)) {
             try nameConfig.apply(configuration: config)
         }
     }

--- a/Tests/SwiftLintFrameworkTests/RuleConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleConfigurationTests.swift
@@ -66,17 +66,18 @@ class RuleConfigurationTests: SwiftLintTestCase {
         }
     }
 
-    func testSeverityConfigurationDoesNotChangeOnBadConfig() throws {
+    func testSeverityConfigurationThrowsNothingApplied() throws {
         let config = 17
         var severityConfig = SeverityConfiguration<RuleMock>(.error)
-        try severityConfig.apply(configuration: config)
-        XCTAssertEqual(severityConfig.severity, .error)
+        checkError(Issue.nothingApplied(ruleID: RuleMock.identifier)) {
+            try severityConfig.apply(configuration: config)
+        }
     }
 
-    func testSeverityConfigurationThrowsOnBadConfig() {
+    func testSeverityConfigurationThrowsInvalidConfiguration() {
         let config = "foo"
         var severityConfig = SeverityConfiguration<RuleMock>(.warning)
-        checkError(Issue.invalidConfiguration(ruleID: RuleMock.description.identifier)) {
+        checkError(Issue.invalidConfiguration(ruleID: RuleMock.identifier)) {
             try severityConfig.apply(configuration: config)
         }
     }

--- a/Tests/SwiftLintFrameworkTests/RuleConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleConfigurationTests.swift
@@ -76,7 +76,7 @@ class RuleConfigurationTests: SwiftLintTestCase {
     func testSeverityConfigurationThrowsOnBadConfig() {
         let config = "foo"
         var severityConfig = SeverityConfiguration<RuleMock>(.warning)
-        checkError(Issue.unknownConfiguration(ruleID: RuleMock.description.identifier)) {
+        checkError(Issue.invalidConfiguration(ruleID: RuleMock.description.identifier)) {
             try severityConfig.apply(configuration: config)
         }
     }
@@ -107,7 +107,7 @@ class RuleConfigurationTests: SwiftLintTestCase {
     func testRegexConfigurationThrows() {
         let config = 17
         var regexConfig = RegexConfiguration<RuleMock>(identifier: "")
-        checkError(Issue.unknownConfiguration(ruleID: RuleMock.description.identifier)) {
+        checkError(Issue.invalidConfiguration(ruleID: RuleMock.description.identifier)) {
             try regexConfig.apply(configuration: config)
         }
     }
@@ -311,7 +311,7 @@ class RuleConfigurationTests: SwiftLintTestCase {
         var configuration = ModifierOrderConfiguration()
         let config = ["severity": "warning", "preferred_modifier_order": ["specialize"]]  as [String: any Sendable]
 
-        checkError(Issue.unknownConfiguration(ruleID: ModifierOrderRule.description.identifier)) {
+        checkError(Issue.invalidConfiguration(ruleID: ModifierOrderRule.description.identifier)) {
             try configuration.apply(configuration: config)
         }
     }
@@ -319,7 +319,7 @@ class RuleConfigurationTests: SwiftLintTestCase {
     func testModifierOrderConfigurationThrowsOnNonModifiableGroup() {
         var configuration = ModifierOrderConfiguration()
         let config = ["severity": "warning", "preferred_modifier_order": ["atPrefixed"]]  as [String: any Sendable]
-        checkError(Issue.unknownConfiguration(ruleID: ModifierOrderRule.description.identifier)) {
+        checkError(Issue.invalidConfiguration(ruleID: ModifierOrderRule.description.identifier)) {
             try configuration.apply(configuration: config)
         }
     }


### PR DESCRIPTION
Use different issues to make inlineable configurations work in both scenarios, namely being used standalone and nested as part of another configuration. In the latter case, finding no values to parse in a raw configuration is okay, while as a standalone configuration it's not.