### PR TITLE
Allow to configure only the severity in a short form for every rule with a severity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@
   [Julien Baillon](https://github.com/julien-baillon)
   [#5372](https://github.com/realm/SwiftLint/issues/5372)
 
+* Allow to set the severity of rules (if they have one) in the short form
+  `rule_name: warning|error` provided that no other attributes need to be
+  configured.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+
 * Add new `ignore_one_liners` option to `switch_case_alignment`
   rule to ignore switch statements written in a single line.  
   [tonell-m](https://github.com/tonell-m)

--- a/Source/SwiftLintCoreMacros/SwiftLintCoreMacros.swift
+++ b/Source/SwiftLintCoreMacros/SwiftLintCoreMacros.swift
@@ -14,6 +14,9 @@ struct SwiftLintCoreMacros: CompilerPlugin {
 
 enum SwiftLintCoreMacroError: String, DiagnosticMessage {
     case notStruct = "Attribute can only be applied to structs"
+    case severityBasedWithoutProperty = """
+        Severity-based configuration without a 'severityConfiguration' property is invalid
+        """
     case notEnum = "Attribute can only be applied to enums"
     case noStringRawType = "Attribute can only be applied to enums with a 'String' raw type"
     case noBooleanLiteral = "Macro argument must be a boolean literal"

--- a/Tests/SwiftLintFrameworkTests/RuleConfigurationDescriptionTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleConfigurationDescriptionTests.swift
@@ -46,7 +46,7 @@ class RuleConfigurationDescriptionTests: XCTestCase {
     // swiftlint:disable:next function_body_length
     func testDescriptionFromConfiguration() throws {
         var configuration = TestConfiguration()
-        try configuration.apply(configuration: [:])
+        try configuration.apply(configuration: Void()) // Configure to set keys.
         let description = RuleConfigurationDescription.from(configuration: configuration)
 
         XCTAssertEqual(description.oneLiner(), """

--- a/Tests/SwiftLintFrameworkTests/RuleConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleConfigurationTests.swift
@@ -42,6 +42,13 @@ class RuleConfigurationTests: SwiftLintTestCase {
         }
     }
 
+    func testSeverityWorksAsOnlyParameter() throws {
+        var config = AttributesConfiguration()
+        XCTAssertEqual(config.severity, .warning)
+        try config.apply(configuration: "error")
+        XCTAssertEqual(config.severity, .error)
+    }
+
     func testSeverityConfigurationFromString() {
         let config = "Warning"
         let comp = SeverityConfiguration<RuleMock>(.warning)


### PR DESCRIPTION

The README states that a configuration like `attributes: error` is valid to only set a different severity level for a rule (the `attributes` rule here). This was previously only possible for rules that were accompanied by a plain severity configuration.

I don't think this broke with the automatic parsing code generation. For some rules it might have worked before, for others not. This change makes it consistently working for all rules.