### PR TITLE
Compare rule IDs and configurations with reference

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -131,6 +131,9 @@ let package = Package(
                 "SwiftLintFramework",
                 "SwiftLintTestHelpers"
             ],
+            exclude: [
+                "default_rule_configurations.yml"
+            ],
             swiftSettings: swiftFeatures
         ),
         .testTarget(

--- a/Tests/BUILD
+++ b/Tests/BUILD
@@ -141,7 +141,10 @@ swift_library(
 
 swift_test(
     name = "IntegrationTests",
-    data = ["//:LintInputs"],
+    data = [
+        "//:LintInputs",
+        "IntegrationTests/default_rule_configurations.yml"
+    ],
     visibility = ["//visibility:public"],
     deps = [":IntegrationTests.library"],
 )

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -53,6 +53,23 @@ class IntegrationTests: SwiftLintTestCase {
         }
     }
 
+    func testDefaultConfigurations() {
+        let defaultConfig = Configuration(rulesMode: .allEnabled).rules
+            .map { type(of: $0) }
+            .filter { $0.identifier != "custom_rules" }
+            .map {
+                """
+                \($0.identifier):
+                \($0.init().configurationDescription.yaml().indent(by: 2))
+                """
+            }
+            .joined(separator: "\n")
+        let referenceFile = URL(fileURLWithPath: #file)
+            .deletingLastPathComponent()
+            .appendingPathComponent("default_rule_configurations.yml")
+        XCTAssertEqual(defaultConfig + "\n", try String(contentsOf: referenceFile))
+    }
+
     func testSimulateHomebrewTest() {
         // Since this test uses the `swiftlint` binary built while building `SwiftLintPackageTests`,
         // we run it only on macOS using SwiftPM.

--- a/Tests/IntegrationTests/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/default_rule_configurations.yml
@@ -1,0 +1,631 @@
+accessibility_label_for_image:
+  severity: warning
+accessibility_trait_for_button:
+  severity: warning
+anonymous_argument_in_multiline_closure:
+  severity: warning
+anyobject_protocol:
+  severity: warning
+array_init:
+  severity: warning
+attributes:
+  severity: warning
+  attributes_with_arguments_always_on_line_above: true
+  always_on_same_line: ["@IBAction", "@NSManaged"]
+  always_on_line_above: []
+balanced_xctest_lifecycle:
+  severity: warning
+  test_parent_classes: ["QuickSpec", "XCTestCase"]
+blanket_disable_command:
+  severity: warning
+  allowed_rules: ["file_header", "file_length", "file_name", "file_name_no_space", "single_test_class"]
+  always_blanket_disable: []
+block_based_kvo:
+  severity: warning
+capture_variable:
+  severity: warning
+class_delegate_protocol:
+  severity: warning
+closing_brace:
+  severity: warning
+closure_body_length:
+  warning: 30
+  error: 100
+closure_end_indentation:
+  severity: warning
+closure_parameter_position:
+  severity: warning
+closure_spacing:
+  severity: warning
+collection_alignment:
+  severity: warning
+  align_colons: false
+colon:
+  severity: warning
+  flexible_right_spacing: false
+  apply_to_dictionaries: true
+comma:
+  severity: warning
+comma_inheritance:
+  severity: warning
+comment_spacing:
+  severity: warning
+compiler_protocol_init:
+  severity: warning
+computed_accessors_order:
+  severity: warning
+  order: get_set
+conditional_returns_on_newline:
+  severity: warning
+  if_only: false
+contains_over_filter_count:
+  severity: warning
+contains_over_filter_is_empty:
+  severity: warning
+contains_over_first_not_nil:
+  severity: warning
+contains_over_range_nil_comparison:
+  severity: warning
+control_statement:
+  severity: warning
+convenience_type:
+  severity: warning
+cyclomatic_complexity:
+  warning: 10
+  error: 20
+  ignores_case_statements: false
+deployment_target:
+  severity: warning
+  iOSApplicationExtension_deployment_target: 7.0
+  iOS_deployment_target: 7.0
+  macOSApplicationExtension_deployment_target: 10.9
+  macOS_deployment_target: 10.9
+  tvOSApplicationExtension_deployment_target: 9.0
+  tvOS_deployment_target: 9.0
+  watchOSApplicationExtension_deployment_target: 1.0
+  watchOS_deployment_target: 1.0
+direct_return:
+  severity: warning
+discarded_notification_center_observer:
+  severity: warning
+discouraged_assert:
+  severity: warning
+discouraged_direct_init:
+  severity: warning
+  types: ["Bundle", "Bundle.init", "NSError", "NSError.init", "UIDevice", "UIDevice.init"]
+discouraged_none_name:
+  severity: warning
+discouraged_object_literal:
+  severity: warning
+  image_literal: true
+  color_literal: true
+discouraged_optional_boolean:
+  severity: warning
+discouraged_optional_collection:
+  severity: warning
+duplicate_conditions:
+  severity: error
+duplicate_enum_cases:
+  severity: error
+duplicate_imports:
+  severity: warning
+duplicated_key_in_dictionary_literal:
+  severity: warning
+dynamic_inline:
+  severity: error
+empty_collection_literal:
+  severity: warning
+empty_count:
+  severity: error
+  only_after_dot: false
+empty_enum_arguments:
+  severity: warning
+empty_parameters:
+  severity: warning
+empty_parentheses_with_trailing_closure:
+  severity: warning
+empty_string:
+  severity: warning
+empty_xctest_method:
+  severity: warning
+  test_parent_classes: ["QuickSpec", "XCTestCase"]
+enum_case_associated_values_count:
+  warning: 5
+  error: 6
+expiring_todo:
+  approaching_expiry_severity: warning
+  expired_severity: error
+  bad_formatting_severity: error
+  approaching_expiry_threshold: 15
+  date_delimiters:
+    opening: "["
+    closing: "]"
+  date_format: "MM/dd/yyyy"
+  date_separator: "/"
+explicit_acl:
+  severity: warning
+explicit_enum_raw_value:
+  severity: warning
+explicit_init:
+  severity: warning
+  include_bare_init: false
+explicit_self:
+  severity: warning
+explicit_top_level_acl:
+  severity: warning
+explicit_type_interface:
+  severity: warning
+  excluded: []
+  allow_redundancy: false
+extension_access_modifier:
+  severity: warning
+fallthrough:
+  severity: warning
+fatal_error_message:
+  severity: warning
+file_header:
+  severity: warning
+file_length:
+  warning: 400
+  error: 1000
+  ignore_comment_only_lines: false
+file_name:
+  severity: warning
+  excluded: ["LinuxMain.swift", "main.swift"]
+  prefix_pattern: ""
+  suffix_pattern: "\+.*"
+  nested_type_separator: "."
+file_name_no_space:
+  severity: warning
+  excluded: []
+file_types_order:
+  severity: warning
+  order: [[supporting_type], [main_type], [extension], [preview_provider], [library_content_provider]]
+final_test_case:
+  severity: warning
+  test_parent_classes: ["QuickSpec", "XCTestCase"]
+first_where:
+  severity: warning
+flatmap_over_map_reduce:
+  severity: warning
+for_where:
+  severity: warning
+  allow_for_as_filter: false
+force_cast:
+  severity: error
+force_try:
+  severity: error
+force_unwrapping:
+  severity: warning
+function_body_length:
+  warning: 50
+  error: 100
+function_default_parameter_at_end:
+  severity: warning
+function_parameter_count:
+  warning: 5
+  error: 8
+  ignores_default_parameters: true
+generic_type_name:
+  min_length:
+    warning: 1
+    error: 0
+  max_length:
+    warning: 20
+    error: 1000
+  excluded: []
+  allowed_symbols: []
+  unallowed_symbols_severity: error
+  validates_start_with_lowercase: error
+ibinspectable_in_extension:
+  severity: warning
+identical_operands:
+  severity: warning
+identifier_name:
+  min_length:
+    warning: 3
+    error: 2
+  max_length:
+    warning: 40
+    error: 60
+  excluded: ["^id$"]
+  allowed_symbols: []
+  unallowed_symbols_severity: error
+  validates_start_with_lowercase: error
+  additional_operators: ["!", "%", "&", "*", "+", "-", ".", "/", "<", "=", ">", "?", "^", "|", "~"]
+implicit_getter:
+  severity: warning
+implicit_return:
+  severity: warning
+  included: [closure, function, getter, initializer, subscript]
+implicitly_unwrapped_optional:
+  severity: warning
+  mode: all_except_iboutlets
+inclusive_language:
+  severity: warning
+indentation_width:
+  severity: warning
+  indentation_width: 4
+  include_comments: true
+  include_compiler_directives: true
+  include_multiline_strings: true
+inert_defer:
+  severity: warning
+invalid_swiftlint_command:
+  severity: warning
+is_disjoint:
+  severity: warning
+joined_default_parameter:
+  severity: warning
+large_tuple:
+  warning: 2
+  error: 3
+last_where:
+  severity: warning
+leading_whitespace:
+  severity: warning
+legacy_cggeometry_functions:
+  severity: warning
+legacy_constant:
+  severity: warning
+legacy_constructor:
+  severity: warning
+legacy_hashing:
+  severity: warning
+legacy_multiple:
+  severity: warning
+legacy_nsgeometry_functions:
+  severity: warning
+legacy_objc_type:
+  severity: warning
+legacy_random:
+  severity: warning
+let_var_whitespace:
+  severity: warning
+line_length:
+  warning: 120
+  error: 200
+  ignores_urls: false
+  ignores_function_declarations: false
+  ignores_comments: false
+  ignores_interpolated_strings: false
+  excluded_lines_patterns: []
+literal_expression_end_indentation:
+  severity: warning
+local_doc_comment:
+  severity: warning
+lower_acl_than_parent:
+  severity: warning
+mark:
+  severity: warning
+missing_docs:
+  warning: [open, public]
+  excludes_extensions: true
+  excludes_inherited_types: true
+  excludes_trivial_init: false
+modifier_order:
+  severity: warning
+  preferred_modifier_order: [override, acl, setterACL, dynamic, mutators, lazy, final, required, convenience, typeMethods, owned]
+multiline_arguments:
+  severity: warning
+  first_argument_location: any_line
+  only_enforce_after_first_closure_on_first_line: false
+multiline_arguments_brackets:
+  severity: warning
+multiline_function_chains:
+  severity: warning
+multiline_literal_brackets:
+  severity: warning
+multiline_parameters:
+  severity: warning
+  allows_single_line: true
+multiline_parameters_brackets:
+  severity: warning
+multiple_closures_with_trailing_closure:
+  severity: warning
+nesting:
+  type_level:
+    warning: 1
+  function_level:
+    warning: 2
+  check_nesting_in_closures_and_statements: true
+  always_allow_one_type_in_functions: false
+  ignore_typealiases_and_associatedtypes: false
+nimble_operator:
+  severity: warning
+no_extension_access_modifier:
+  severity: error
+no_fallthrough_only:
+  severity: warning
+no_grouping_extension:
+  severity: warning
+no_magic_numbers:
+  severity: warning
+  test_parent_classes: ["QuickSpec", "XCTestCase"]
+no_space_in_method_call:
+  severity: warning
+non_optional_string_data_conversion:
+  severity: warning
+non_overridable_class_declaration:
+  severity: warning
+  final_class_modifier: final class
+notification_center_detachment:
+  severity: warning
+ns_number_init_as_function_reference:
+  severity: warning
+nslocalizedstring_key:
+  severity: warning
+nslocalizedstring_require_bundle:
+  severity: warning
+nsobject_prefer_isequal:
+  severity: warning
+number_separator:
+  severity: warning
+  minimum_length: 0
+  exclude_ranges: []
+object_literal:
+  severity: warning
+  image_literal: true
+  color_literal: true
+one_declaration_per_file:
+  severity: warning
+opening_brace:
+  severity: warning
+  allow_multiline_func: false
+operator_usage_whitespace:
+  severity: warning
+  lines_look_around: 2
+  skip_aligned_constants: true
+  allowed_no_space_operators: ["...", "..<"]
+operator_whitespace:
+  severity: warning
+optional_enum_case_matching:
+  severity: warning
+orphaned_doc_comment:
+  severity: warning
+overridden_super_call:
+  severity: warning
+  excluded: []
+  included: ["*"]
+override_in_extension:
+  severity: warning
+pattern_matching_keywords:
+  severity: warning
+period_spacing:
+  severity: warning
+prefer_nimble:
+  severity: warning
+prefer_self_in_static_references:
+  severity: warning
+prefer_self_type_over_type_of_self:
+  severity: warning
+prefer_zero_over_explicit_init:
+  severity: warning
+prefixed_toplevel_constant:
+  severity: warning
+  only_private: false
+private_action:
+  severity: warning
+private_outlet:
+  severity: warning
+  allow_private_set: false
+private_over_fileprivate:
+  severity: warning
+  validate_extensions: false
+private_subject:
+  severity: warning
+private_swiftui_state:
+  severity: warning
+private_unit_test:
+  severity: warning
+  test_parent_classes: ["QuickSpec", "XCTestCase"]
+  regex: "XCTestCase"
+prohibited_interface_builder:
+  severity: warning
+prohibited_super_call:
+  severity: warning
+  excluded: []
+  included: ["*"]
+protocol_property_accessors_order:
+  severity: warning
+quick_discouraged_call:
+  severity: warning
+quick_discouraged_focused_test:
+  severity: warning
+quick_discouraged_pending_test:
+  severity: warning
+raw_value_for_camel_cased_codable_enum:
+  severity: warning
+reduce_boolean:
+  severity: warning
+reduce_into:
+  severity: warning
+redundant_discardable_let:
+  severity: warning
+redundant_nil_coalescing:
+  severity: warning
+redundant_objc_attribute:
+  severity: warning
+redundant_optional_initialization:
+  severity: warning
+redundant_self_in_closure:
+  severity: warning
+redundant_set_access_control:
+  severity: warning
+redundant_string_enum_value:
+  severity: warning
+redundant_type_annotation:
+  severity: warning
+redundant_void_return:
+  severity: warning
+  include_closures: true
+required_deinit:
+  severity: warning
+required_enum_case:
+  {Protocol Name}:
+    {Case Name 1}: {warning|error}
+    {Case Name 2}: {warning|error}
+return_arrow_whitespace:
+  severity: warning
+return_value_from_void_function:
+  severity: warning
+self_binding:
+  severity: warning
+  bind_identifier: "self"
+self_in_property_initialization:
+  severity: warning
+shorthand_argument:
+  severity: warning
+  allow_until_line_after_opening_brace: 4
+  always_disallow_more_than_one: false
+  always_disallow_member_access: false
+shorthand_operator:
+  severity: error
+shorthand_optional_binding:
+  severity: warning
+single_test_class:
+  severity: warning
+  test_parent_classes: ["QuickSpec", "XCTestCase"]
+sorted_enum_cases:
+  severity: warning
+sorted_first_last:
+  severity: warning
+sorted_imports:
+  severity: warning
+  grouping: names
+statement_position:
+  severity: warning
+  statement_mode: default
+static_operator:
+  severity: warning
+static_over_final_class:
+  severity: warning
+strict_fileprivate:
+  severity: warning
+strong_iboutlet:
+  severity: warning
+superfluous_disable_command:
+  severity: warning
+superfluous_else:
+  severity: warning
+switch_case_alignment:
+  severity: warning
+  indented_cases: false
+  ignore_one_liners: false
+switch_case_on_newline:
+  severity: warning
+syntactic_sugar:
+  severity: warning
+test_case_accessibility:
+  severity: warning
+  allowed_prefixes: []
+  test_parent_classes: ["QuickSpec", "XCTestCase"]
+todo:
+  severity: warning
+  only: [TODO, FIXME]
+toggle_bool:
+  severity: warning
+trailing_closure:
+  severity: warning
+  only_single_muted_parameter: false
+trailing_comma:
+  severity: warning
+  mandatory_comma: false
+trailing_newline:
+  severity: warning
+trailing_semicolon:
+  severity: warning
+trailing_whitespace:
+  severity: warning
+  ignores_empty_lines: false
+  ignores_comments: true
+type_body_length:
+  warning: 250
+  error: 350
+type_contents_order:
+  severity: warning
+  order: [[case], [type_alias, associated_type], [subtype], [type_property], [instance_property], [ib_inspectable], [ib_outlet], [initializer], [type_method], [view_life_cycle_method], [ib_action], [other_method], [subscript], [deinitializer]]
+type_name:
+  min_length:
+    warning: 3
+    error: 0
+  max_length:
+    warning: 40
+    error: 1000
+  excluded: []
+  allowed_symbols: []
+  unallowed_symbols_severity: error
+  validates_start_with_lowercase: error
+  validate_protocols: true
+typesafe_array_init:
+  severity: warning
+unavailable_condition:
+  severity: warning
+unavailable_function:
+  severity: warning
+unhandled_throwing_task:
+  severity: error
+unneeded_break_in_switch:
+  severity: warning
+unneeded_override:
+  severity: warning
+  affect_initializers: false
+unneeded_parentheses_in_closure_argument:
+  severity: warning
+unneeded_synthesized_initializer:
+  severity: warning
+unowned_variable_capture:
+  severity: warning
+untyped_error_in_catch:
+  severity: warning
+unused_capture_list:
+  severity: warning
+unused_closure_parameter:
+  severity: warning
+unused_control_flow_label:
+  severity: warning
+unused_declaration:
+  severity: error
+  include_public_and_open: false
+  related_usrs_to_skip: ["s:7SwiftUI15PreviewProviderP"]
+unused_enumerated:
+  severity: warning
+unused_import:
+  severity: warning
+  require_explicit_imports: false
+  allowed_transitive_imports: []
+  always_keep_imports: []
+unused_optional_binding:
+  severity: warning
+  ignore_optional_try: false
+unused_setter_value:
+  severity: warning
+valid_ibinspectable:
+  severity: warning
+vertical_parameter_alignment:
+  severity: warning
+vertical_parameter_alignment_on_call:
+  severity: warning
+vertical_whitespace:
+  severity: warning
+  max_empty_lines: 1
+vertical_whitespace_between_cases:
+  severity: warning
+vertical_whitespace_closing_braces:
+  severity: warning
+  only_enforce_before_trivial_lines: false
+vertical_whitespace_opening_braces:
+  severity: warning
+void_function_in_ternary:
+  severity: warning
+void_return:
+  severity: warning
+weak_delegate:
+  severity: warning
+xct_specific_matcher:
+  severity: warning
+  matchers: [one-argument-asserts, two-argument-asserts]
+xctfail_message:
+  severity: warning
+yoda_condition:
+  severity: warning


### PR DESCRIPTION
This new test ensures that rule IDs and their option names do not get changed inadvertently.

The reference file can easily be updated by running:

```bash
swift run swiftlint rules --config-only --default-config > Tests/IntegrationTests/default_rule_configurations.yml
```