### PR TITLE
Prohibit configuration key inference

### DIFF
--- a/Source/SwiftLintCore/Models/RuleConfigurationDescription.swift
+++ b/Source/SwiftLintCore/Models/RuleConfigurationDescription.swift
@@ -440,7 +440,7 @@ public struct ConfigurationElement<T: AcceptableByConfigurationElement & Equatab
     ///   - key: Optional name of the option. If not specified, it will be inferred from the attributed property.
     ///   - postprocessor: Function to be applied to the wrapped value after parsing to validate and modify it.
     public init(wrappedValue value: T,
-                key: String = "",
+                key: String,
                 postprocessor: @escaping (inout T) throws -> Void = { _ in }) {
         self.init(wrappedValue: value, key: key, inline: false, postprocessor: postprocessor)
 
@@ -454,7 +454,7 @@ public struct ConfigurationElement<T: AcceptableByConfigurationElement & Equatab
     ///
     /// - Parameters:
     ///   - key: Optional name of the option. If not specified, it will be inferred from the attributed property.
-    public init<Wrapped>(key: String = "") where T == Wrapped? {
+    public init<Wrapped>(key: String) where T == Wrapped? {
         self.init(wrappedValue: nil, key: key, inline: false)
     }
 
@@ -466,6 +466,7 @@ public struct ConfigurationElement<T: AcceptableByConfigurationElement & Equatab
     ///             will be inlined. Otherwise, it will be treated as a normal nested configuration with its name
     ///             inferred from the name of the attributed property.
     public init(wrappedValue value: T, inline: Bool) where T: InlinableOptionType {
+        assert(inline, "Only 'inline: true' is allowed at the moment.")
         self.init(wrappedValue: value, key: "", inline: inline)
     }
 

--- a/Tests/SwiftLintFrameworkTests/RuleConfigurationDescriptionTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleConfigurationDescriptionTests.swift
@@ -12,7 +12,7 @@ class RuleConfigurationDescriptionTests: XCTestCase {
 
         @ConfigurationElement(key: "flag")
         var flag = true
-        @ConfigurationElement
+        @ConfigurationElement(key: "string")
         var string = "value"
         @ConfigurationElement(key: "symbol")
         var symbol = try! Symbol(fromAny: "value", context: "rule") // swiftlint:disable:this force_try
@@ -20,7 +20,7 @@ class RuleConfigurationDescriptionTests: XCTestCase {
         var integer = 2
         @ConfigurationElement(key: "null")
         var null: Int?
-        @ConfigurationElement
+        @ConfigurationElement(key: "my_double")
         var myDouble = 2.1
         @ConfigurationElement(key: "severity")
         var severity = ViolationSeverity.warning


### PR DESCRIPTION
While this is already implemented, it only works when a configuration is updated by calling `apply(configuration:)` on it somewhere. This imperceptible detail could lead to confusing. So better prohibit the use of the feature for the time being as long as a good solution is found. So far, no explicit configuration keys have been removed.