### PR TITLE
Add SARIF JSON Reporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 #### Enhancements
 
 * Add a reporter that outputs SARIF format JSON for tools
-  like DataDog.  
+  like Datadog.  
   [waitButY](https://github.com/waitbutY)
 
 * Ignore absence of a non-initial local config instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@
 
 #### Enhancements
 
+* Add a reporter that outputs SARIF format JSON for tools
+  like DataDog.  
+  [waitButY](https://github.com/waitbutY)
+
 * Ignore absence of a non-initial local config instead of
   falling back to default.  
   [kohtenko](https://github.com/kohtenko)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,8 @@
 
 #### Enhancements
 
-* Add a reporter that outputs SARIF format JSON for tools
-  like Datadog.  
+* Add a reporter that outputs violations in the Static
+  Analysis Results Interchange Format (SARIF).  
   [waitButY](https://github.com/waitbutY)
 
 * Ignore absence of a non-initial local config instead of

--- a/Source/SwiftLintCore/Models/ReportersList.swift
+++ b/Source/SwiftLintCore/Models/ReportersList.swift
@@ -14,6 +14,7 @@ public let reportersList: [any Reporter.Type] = [
     JUnitReporter.self,
     MarkdownReporter.self,
     RelativePathReporter.self,
+    SARIFReporter.self,
     SonarQubeReporter.self,
     SummaryReporter.self,
     XcodeReporter.self

--- a/Source/SwiftLintCore/Reporters/SARIFReporter.swift
+++ b/Source/SwiftLintCore/Reporters/SARIFReporter.swift
@@ -1,0 +1,74 @@
+import Foundation
+import SourceKittenFramework
+
+/// SARIFReporter
+/// For some tools (i.e. DataDog), code quality findings are reported in a SARIF () format.
+/// Some documentation re: SARIF:
+///     - Full Spec: https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html
+///     - Samples: https://github.com/microsoft/sarif-tutorials/blob/main/samples/
+///     - JSON Validator: https://sarifweb.azurewebsites.net/Validation
+struct SARIFReporter: Reporter {
+    // MARK: - Reporter Conformance
+    static let identifier = "json"
+    static let isRealtime = false
+    static let description: String = "Reports violations as a SARIF compatible JSON array."
+
+    static func generateReport(_ violations: [StyleViolation]) -> String {
+        let orderedViolations = Dictionary(grouping: violations, by: { $0.ruleIdentifier })
+        let SARIFJson = [
+            "version": "2.1.0",
+            "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/cos02/schemas/sarif-schema-2.1.0.json",
+            "runs": [
+                [
+                    "tool": [
+                        "driver": [
+                            "name": "SwiftLint",
+                            "semanticVersion": Version.current.value,
+                            "informationUri": "https://github.com/realm/SwiftLint/blob/main/README.md"
+                        ]
+                    ],
+                    "results": orderedViolations.map(dictionary(for:))
+                ]
+            ]
+        ] as [String: Any]
+
+        return toJSON(SARIFJson)
+    }
+
+    // MARK: - Private
+
+    private static func dictionary(for violation: Dictionary<String, [StyleViolation]>.Element) -> [String: Any] {
+        return [
+            "level": violation.value[0].severity.rawValue,
+            "ruleId": violation.key,
+            "message": [
+                "text": violation.value[0].reason
+            ],
+            "locations": violation.value.map(dictionary(for:))
+        ]
+    }
+
+    private static func dictionary(for violation: StyleViolation) -> [String: Any] {
+        // According to SARIF specification JSON1008, minimum value for line is 1
+        guard let line = violation.location.line, line > 0 else {
+            return [
+                "physicalLocation": [
+                    "artifactLocation": [
+                        "uri": violation.location.file ?? ""
+                    ]
+                ]
+            ]
+        }
+
+        return [
+            "physicalLocation": [
+                "artifactLocation": [
+                    "uri": violation.location.file ?? ""
+                ],
+                "region": [
+                    "startLine": line
+                ]
+            ]
+        ]
+    }
+}

--- a/Source/SwiftLintCore/Reporters/SARIFReporter.swift
+++ b/Source/SwiftLintCore/Reporters/SARIFReporter.swift
@@ -10,7 +10,7 @@ struct SARIFReporter: Reporter {
     static let identifier = "sarif"
     static let isRealtime = false
     static let description = "Reports violations in the Static Analysis Results Interchange Format (SARIF)"
-
+    
     static func generateReport(_ violations: [StyleViolation]) -> String {
         let SARIFJson = [
             "version": "2.1.0",
@@ -28,12 +28,12 @@ struct SARIFReporter: Reporter {
                 ]
             ]
         ] as [String: Any]
-
+        
         return toJSON(SARIFJson)
     }
-
+    
     // MARK: - Private
-
+    
     private static func dictionary(for violation: StyleViolation) -> [String: Any] {
         return [
             "level": violation.severity.rawValue,
@@ -46,26 +46,27 @@ struct SARIFReporter: Reporter {
             ]
         ]
     }
-
+    
     private static func dictionary(for location: Location) -> [String: Any] {
         // According to SARIF specification JSON1008, minimum value for line is 1
-        guard let line = location.line, line > 0 else {
+        if let line = location.line, line > 0 {
             return [
                 "physicalLocation": [
                     "artifactLocation": [
                         "uri": location.file ?? ""
+                    ],
+                    "region": [
+                        "startLine": line,
+                        "startColumn": location.character ?? "1"
                     ]
                 ]
             ]
         }
-
+        
         return [
             "physicalLocation": [
                 "artifactLocation": [
                     "uri": location.file ?? ""
-                ],
-                "region": [
-                    "startLine": line
                 ]
             ]
         ]

--- a/Source/SwiftLintCore/Reporters/SARIFReporter.swift
+++ b/Source/SwiftLintCore/Reporters/SARIFReporter.swift
@@ -1,20 +1,18 @@
 import Foundation
 import SourceKittenFramework
 
-/// SARIFReporter
-/// For some tools (i.e. DataDog), code quality findings are reported in a SARIF () format.
-/// Some documentation re: SARIF:
+/// To some tools (i.e. Datadog), code quality findings are reported in the SARIF format:
 ///     - Full Spec: https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html
 ///     - Samples: https://github.com/microsoft/sarif-tutorials/blob/main/samples/
 ///     - JSON Validator: https://sarifweb.azurewebsites.net/Validation
 struct SARIFReporter: Reporter {
     // MARK: - Reporter Conformance
-    static let identifier = "json"
+    static let identifier = "sarif"
     static let isRealtime = false
-    static let description: String = "Reports violations as a SARIF compatible JSON array."
+    static let description = "Reports violations in the Static Analysis Results Interchange Format (SARIF)"
 
     static func generateReport(_ violations: [StyleViolation]) -> String {
-        let orderedViolations = Dictionary(grouping: violations, by: { $0.ruleIdentifier })
+        let groupedViolations = Dictionary(grouping: violations, by: \.ruleIdentifier)
         let SARIFJson = [
             "version": "2.1.0",
             "$schema": "https://docs.oasis-open.org/sarif/sarif/v2.1.0/cos02/schemas/sarif-schema-2.1.0.json",
@@ -24,7 +22,7 @@ struct SARIFReporter: Reporter {
                         "driver": [
                             "name": "SwiftLint",
                             "semanticVersion": Version.current.value,
-                            "informationUri": "https://github.com/realm/SwiftLint/blob/main/README.md"
+                            "informationUri": "https://github.com/realm/SwiftLint/blob/\(Version.current.value)/README.md"
                         ]
                     ],
                     "results": orderedViolations.map(dictionary(for:))

--- a/Source/SwiftLintCore/Reporters/SARIFReporter.swift
+++ b/Source/SwiftLintCore/Reporters/SARIFReporter.swift
@@ -10,7 +10,8 @@ struct SARIFReporter: Reporter {
     static let identifier = "sarif"
     static let isRealtime = false
     static let description = "Reports violations in the Static Analysis Results Interchange Format (SARIF)"
-    
+    static let swiftlintVersion = "https://github.com/realm/SwiftLint/blob/\(Version.current.value)/README.md"
+
     static func generateReport(_ violations: [StyleViolation]) -> String {
         let SARIFJson = [
             "version": "2.1.0",
@@ -21,19 +22,19 @@ struct SARIFReporter: Reporter {
                         "driver": [
                             "name": "SwiftLint",
                             "semanticVersion": Version.current.value,
-                            "informationUri": "https://github.com/realm/SwiftLint/blob/\(Version.current.value)/README.md"
+                            "informationUri": swiftlintVersion
                         ]
                     ],
                     "results": violations.map(dictionary(for:))
                 ]
             ]
         ] as [String: Any]
-        
+
         return toJSON(SARIFJson)
     }
-    
+
     // MARK: - Private
-    
+
     private static func dictionary(for violation: StyleViolation) -> [String: Any] {
         return [
             "level": violation.severity.rawValue,
@@ -46,7 +47,7 @@ struct SARIFReporter: Reporter {
             ]
         ]
     }
-    
+
     private static func dictionary(for location: Location) -> [String: Any] {
         // According to SARIF specification JSON1008, minimum value for line is 1
         if let line = location.line, line > 0 {
@@ -62,7 +63,7 @@ struct SARIFReporter: Reporter {
                 ]
             ]
         }
-        
+
         return [
             "physicalLocation": [
                 "artifactLocation": [

--- a/Tests/SwiftLintFrameworkTests/ReporterTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ReporterTests.swift
@@ -97,6 +97,28 @@ class ReporterTests: SwiftLintTestCase {
         XCTAssertEqual(result, expectedOutput)
     }
 
+    func testSARIFReporter() {
+        let expectedOutput = stringFromFile("CannedSARIFReporterOutput.json")
+
+        var expectedDictionary: [String: Any] = [:]
+        do {
+            let myJson = try JSONSerialization.jsonObject(with: Data(expectedOutput.utf8), options: JSONSerialization.ReadingOptions.allowFragments) as! [String: Any]
+        } catch {
+            print(error)
+        }
+
+        let result = SARIFReporter.generateReport(generateViolations())
+
+        var resultDictionary: [String: Any] = [:]
+        do {
+            let myJson = try JSONSerialization.jsonObject(with: Data(result.utf8), options: JSONSerialization.ReadingOptions.allowFragments) as! [String: Any]
+        } catch {
+            print(error)
+        }
+
+        XCTAssertTrue(resultDictionary.isEqualTo(expectedDictionary))
+    }
+
     func testJunitReporter() {
         let expectedOutput = stringFromFile("CannedJunitReporterOutput.xml")
         let result = JUnitReporter.generateReport(generateViolations())

--- a/Tests/SwiftLintFrameworkTests/ReporterTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ReporterTests.swift
@@ -100,23 +100,25 @@ class ReporterTests: SwiftLintTestCase {
     func testSARIFReporter() {
         let expectedOutput = stringFromFile("CannedSARIFReporterOutput.json")
 
-        var expectedDictionary: [String: AnyObject] = [:]
+        var expectedDictionary: [String: Any] = [:]
         do {
-            expectedDictionary = try JSONSerialization.jsonObject(with: Data(expectedOutput.utf8), options: JSONSerialization.ReadingOptions.allowFragments) as! [String: AnyObject]
+            expectedDictionary = try JSONSerialization.jsonObject(with: Data(expectedOutput.utf8),
+                                                                  options: .allowFragments) as? [String: Any] ?? [:]
         } catch {
             print(error)
         }
 
         let result = SARIFReporter.generateReport(generateViolations())
 
-        var resultDictionary: [String: AnyObject] = [:]
+        var resultDictionary: [String: Any] = [:]
         do {
-            resultDictionary = try JSONSerialization.jsonObject(with: Data(result.utf8), options: JSONSerialization.ReadingOptions.allowFragments) as! [String: AnyObject]
+            resultDictionary = try JSONSerialization.jsonObject(with: Data(result.utf8),
+                                                                options: .allowFragments) as? [String: Any] ?? [:]
         } catch {
             print(error)
         }
 
-        XCTAssertEqual(expectedDictionary as NSDictionary, resultDictionary as NSDictionary)
+        XCTAssertTrue(areEqual(expectedDictionary, resultDictionary))
     }
 
     func testJunitReporter() {
@@ -182,5 +184,42 @@ class ReporterTests: SwiftLintTestCase {
             .trimmingTrailingCharacters(in: .whitespacesAndNewlines)
         let result = SummaryReporter.generateReport([])
         XCTAssertEqual(result, expectedOutput)
+    }
+}
+
+/// Utilities used to compare [String: Any] dictionaries
+private func areEqual (_ left: Any, _ right: Any) -> Bool {
+    if  type(of: left) == type(of: right) &&
+        String(describing: left) == String(describing: right) { return true }
+    if let left = left as? [Any], let right = right as? [Any] { return left == right }
+    if let left = left as? [AnyHashable: Any], let right = right as? [AnyHashable: Any] { return left == right }
+    return false
+}
+
+private extension Array where Element: Any {
+    static func != (left: [Element], right: [Element]) -> Bool { return !(left == right) }
+    static func == (left: [Element], right: [Element]) -> Bool {
+        if left.count != right.count { return false }
+        var right = right
+        loop: for leftValue in left {
+            for (rightIndex, rightValue) in right.enumerated() where areEqual(leftValue, rightValue) {
+                right.remove(at: rightIndex)
+                continue loop
+            }
+            return false
+        }
+        return true
+    }
+}
+
+private extension Dictionary where Value: Any {
+    static func != (left: [Key: Value], right: [Key: Value]) -> Bool { return !(left == right) }
+    static func == (left: [Key: Value], right: [Key: Value]) -> Bool {
+        if left.count != right.count { return false }
+        for element in left {
+            guard   let rightValue = right[element.key],
+                areEqual(rightValue, element.value) else { return false }
+        }
+        return true
     }
 }

--- a/Tests/SwiftLintFrameworkTests/ReporterTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ReporterTests.swift
@@ -100,23 +100,23 @@ class ReporterTests: SwiftLintTestCase {
     func testSARIFReporter() {
         let expectedOutput = stringFromFile("CannedSARIFReporterOutput.json")
 
-        var expectedDictionary: [String: Any] = [:]
+        var expectedDictionary: [String: AnyObject] = [:]
         do {
-            let myJson = try JSONSerialization.jsonObject(with: Data(expectedOutput.utf8), options: JSONSerialization.ReadingOptions.allowFragments) as! [String: Any]
+            expectedDictionary = try JSONSerialization.jsonObject(with: Data(expectedOutput.utf8), options: JSONSerialization.ReadingOptions.allowFragments) as! [String: AnyObject]
         } catch {
             print(error)
         }
 
         let result = SARIFReporter.generateReport(generateViolations())
 
-        var resultDictionary: [String: Any] = [:]
+        var resultDictionary: [String: AnyObject] = [:]
         do {
-            let myJson = try JSONSerialization.jsonObject(with: Data(result.utf8), options: JSONSerialization.ReadingOptions.allowFragments) as! [String: Any]
+            resultDictionary = try JSONSerialization.jsonObject(with: Data(result.utf8), options: JSONSerialization.ReadingOptions.allowFragments) as! [String: AnyObject]
         } catch {
             print(error)
         }
 
-        XCTAssertTrue(resultDictionary.isEqualTo(expectedDictionary))
+        XCTAssertEqual(expectedDictionary as NSDictionary, resultDictionary as NSDictionary)
     }
 
     func testJunitReporter() {

--- a/Tests/SwiftLintFrameworkTests/ReporterTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ReporterTests.swift
@@ -99,26 +99,8 @@ class ReporterTests: SwiftLintTestCase {
 
     func testSARIFReporter() {
         let expectedOutput = stringFromFile("CannedSARIFReporterOutput.json")
-
-        var expectedDictionary: [String: Any] = [:]
-        do {
-            expectedDictionary = try JSONSerialization.jsonObject(with: Data(expectedOutput.utf8),
-                                                                  options: .allowFragments) as? [String: Any] ?? [:]
-        } catch {
-            print(error)
-        }
-
         let result = SARIFReporter.generateReport(generateViolations())
-
-        var resultDictionary: [String: Any] = [:]
-        do {
-            resultDictionary = try JSONSerialization.jsonObject(with: Data(result.utf8),
-                                                                options: .allowFragments) as? [String: Any] ?? [:]
-        } catch {
-            print(error)
-        }
-
-        XCTAssertTrue(areEqual(expectedDictionary, resultDictionary))
+        XCTAssertEqual(expectedOutput, result)
     }
 
     func testJunitReporter() {
@@ -184,42 +166,5 @@ class ReporterTests: SwiftLintTestCase {
             .trimmingTrailingCharacters(in: .whitespacesAndNewlines)
         let result = SummaryReporter.generateReport([])
         XCTAssertEqual(result, expectedOutput)
-    }
-}
-
-/// Utilities used to compare [String: Any] dictionaries
-private func areEqual (_ left: Any, _ right: Any) -> Bool {
-    if  type(of: left) == type(of: right) &&
-        String(describing: left) == String(describing: right) { return true }
-    if let left = left as? [Any], let right = right as? [Any] { return left == right }
-    if let left = left as? [AnyHashable: Any], let right = right as? [AnyHashable: Any] { return left == right }
-    return false
-}
-
-private extension Array where Element: Any {
-    static func != (left: [Element], right: [Element]) -> Bool { return !(left == right) }
-    static func == (left: [Element], right: [Element]) -> Bool {
-        if left.count != right.count { return false }
-        var right = right
-        loop: for leftValue in left {
-            for (rightIndex, rightValue) in right.enumerated() where areEqual(leftValue, rightValue) {
-                right.remove(at: rightIndex)
-                continue loop
-            }
-            return false
-        }
-        return true
-    }
-}
-
-private extension Dictionary where Value: Any {
-    static func != (left: [Key: Value], right: [Key: Value]) -> Bool { return !(left == right) }
-    static func == (left: [Key: Value], right: [Key: Value]) -> Bool {
-        if left.count != right.count { return false }
-        for element in left {
-            guard   let rightValue = right[element.key],
-                areEqual(rightValue, element.value) else { return false }
-        }
-        return true
     }
 }

--- a/Tests/SwiftLintFrameworkTests/Resources/CannedSARIFReporterOutput.json
+++ b/Tests/SwiftLintFrameworkTests/Resources/CannedSARIFReporterOutput.json
@@ -1,0 +1,81 @@
+("{
+  "$schema" : "https:\/\/docs.oasis-open.org\/sarif\/sarif\/v2.1.0\/cos02\/schemas\/sarif-schema-2.1.0.json",
+  "runs" : [
+    {
+      "results" : [
+        {
+          "level" : "warning",
+          "locations" : [
+            {
+              "physicalLocation" : {
+                "artifactLocation" : {
+                  "uri" : "filename"
+                },
+                "region" : {
+                  "startLine" : 1
+                }
+              }
+            },
+            {
+              "physicalLocation" : {
+                "artifactLocation" : {
+                  "uri" : "filename"
+                },
+                "region" : {
+                  "startLine" : 1
+                }
+              }
+            }
+          ],
+          "message" : {
+            "text" : "Violation Reason"
+          },
+          "ruleId" : "line_length"
+        },
+        {
+          "level" : "error",
+          "locations" : [
+            {
+              "physicalLocation" : {
+                "artifactLocation" : {
+                  "uri" : "filename"
+                },
+                "region" : {
+                  "startLine" : 1
+                }
+              }
+            }
+          ],
+          "message" : {
+            "text" : "Shorthand syntactic sugar should be used, i.e. [Int] instead of Array<Int>"
+          },
+          "ruleId" : "syntactic_sugar"
+        },
+        {
+          "level" : "error",
+          "locations" : [
+            {
+              "physicalLocation" : {
+                "artifactLocation" : {
+                  "uri" : ""
+                }
+              }
+            }
+          ],
+          "message" : {
+            "text" : "Colons should be next to the identifier when specifying a type and next to the key in dictionary literals"
+          },
+          "ruleId" : "colon"
+        }
+      ],
+      "tool" : {
+        "driver" : {
+          "informationUri" : "https:\/\/github.com\/realm\/SwiftLint\/blob\/main\/README.md",
+          "name" : "SwiftLint",
+          "semanticVersion" : "0.54.0"
+        }
+      }
+    }
+  ],
+  "version" : "2.1.0"
+}")

--- a/Tests/SwiftLintFrameworkTests/Resources/CannedSARIFReporterOutput.json
+++ b/Tests/SwiftLintFrameworkTests/Resources/CannedSARIFReporterOutput.json
@@ -12,6 +12,7 @@
                   "uri" : "filename"
                 },
                 "region" : {
+                  "startColumn" : 2,
                   "startLine" : 1
                 }
               }
@@ -31,6 +32,7 @@
                   "uri" : "filename"
                 },
                 "region" : {
+                  "startColumn" : 2,
                   "startLine" : 1
                 }
               }
@@ -50,6 +52,7 @@
                   "uri" : "filename"
                 },
                 "region" : {
+                  "startColumn" : 2,
                   "startLine" : 1
                 }
               }

--- a/Tests/SwiftLintFrameworkTests/Resources/CannedSARIFReporterOutput.json
+++ b/Tests/SwiftLintFrameworkTests/Resources/CannedSARIFReporterOutput.json
@@ -15,7 +15,16 @@
                   "startLine" : 1
                 }
               }
-            },
+            }
+          ],
+          "message" : {
+            "text" : "Violation Reason"
+          },
+          "ruleId" : "line_length"
+        },
+        {
+          "level" : "error",
+          "locations" : [
             {
               "physicalLocation" : {
                 "artifactLocation" : {
@@ -70,7 +79,7 @@
       ],
       "tool" : {
         "driver" : {
-          "informationUri" : "https:\/\/github.com\/realm\/SwiftLint\/blob\/main\/README.md",
+          "informationUri" : "https:\/\/github.com\/realm\/SwiftLint\/blob\/0.54.0\/README.md",
           "name" : "SwiftLint",
           "semanticVersion" : "0.54.0"
         }

--- a/Tests/SwiftLintFrameworkTests/Resources/CannedSARIFReporterOutput.json
+++ b/Tests/SwiftLintFrameworkTests/Resources/CannedSARIFReporterOutput.json
@@ -1,4 +1,4 @@
-("{
+{
   "$schema" : "https:\/\/docs.oasis-open.org\/sarif\/sarif\/v2.1.0\/cos02\/schemas\/sarif-schema-2.1.0.json",
   "runs" : [
     {
@@ -78,4 +78,4 @@
     }
   ],
   "version" : "2.1.0"
-}")
+}


### PR DESCRIPTION
Some tools (i.e. DataDog) require SARIF JSON format for code quality report ingestion.

This change adds a SARIF reporter to enable integration with these tools.

SARIF format documentation:
    - Full Spec: https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html
    - Samples: https://github.com/microsoft/sarif-tutorials/blob/main/samples/
    - JSON Validator: https://sarifweb.azurewebsites.net/Validation

