### PR TITLE
Updated blanket_disable_command reasons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,11 @@
   [woxtu](https://github.com/woxtu)
   [Martin Redington](https://github.com/mildm8nnered)
   [#4999](https://github.com/realm/SwiftLint/issues/4999)
+* Updates the reasons provided by violations of the `blanket_disable_command`
+  to omit language about the end of the file, and to direct users to
+  re-enable the rule as soon as possible.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#5450](https://github.com/realm/SwiftLint/issues/5450)
 
 ## 0.54.0: Macro-Economic Forces
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,6 +224,7 @@
   [woxtu](https://github.com/woxtu)
   [Martin Redington](https://github.com/mildm8nnered)
   [#4999](https://github.com/realm/SwiftLint/issues/4999)
+
 * Updates the reasons provided by violations of the `blanket_disable_command`
   to omit language about the end of the file, and to direct users to
   re-enable the rule as soon as possible.  

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/BlanketDisableCommandRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/BlanketDisableCommandRule.swift
@@ -5,8 +5,8 @@ struct BlanketDisableCommandRule: Rule, SourceKitFreeRule {
         identifier: "blanket_disable_command",
         name: "Blanket Disable Command",
         description: """
-                     `swiftlint:disable` commands should use `next`, `this` or `previous` to disable rules for a
-                     single line, or `swiftlint:enable` to re-enable the rules immediately after the violations
+                     `swiftlint:disable` commands should use `next`, `this` or `previous` to disable rules for a \
+                     single line, or `swiftlint:enable` to re-enable the rules immediately after the violations \
                      to be ignored, instead of disabling the rule for the rest of the file
                      """,
         kind: .lint,
@@ -148,9 +148,11 @@ struct BlanketDisableCommandRule: Rule, SourceKitFreeRule {
             }
 
             if let command = ruleIdentifierToCommandMap[disabledRuleIdentifier] {
-                let reason = "Use 'next', 'this' or 'previous' instead to disable the " +
-                              "'\(disabledRuleIdentifier.stringRepresentation)' rule once " +
-                              " or re-enable it as soon as possible"
+                let reason = """
+                             Use 'next', 'this' or 'previous' instead to disable the \
+                             '\(disabledRuleIdentifier.stringRepresentation)' rule once, \
+                             or re-enable it as soon as possible`
+                             """
                 return violation(for: command, ruleIdentifier: disabledRuleIdentifier, in: file, reason: reason)
             }
             return nil

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/BlanketDisableCommandRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/BlanketDisableCommandRule.swift
@@ -4,7 +4,9 @@ struct BlanketDisableCommandRule: Rule, SourceKitFreeRule {
     static let description = RuleDescription(
         identifier: "blanket_disable_command",
         name: "Blanket Disable Command",
-        description: "swiftlint:disable commands should be re-enabled before the end of the file",
+        description: "'swiftlint:disable' commands should use 'next', 'this' or 'previous' to disable rules for a " +
+                     "single line, or 'swiftlint:enable' to re-enable the rules immediately after the violations " +
+                     "to be ignored",
         kind: .lint,
         nonTriggeringExamples: [
             Example("""
@@ -144,8 +146,9 @@ struct BlanketDisableCommandRule: Rule, SourceKitFreeRule {
             }
 
             if let command = ruleIdentifierToCommandMap[disabledRuleIdentifier] {
-                let reason = "The disabled '\(disabledRuleIdentifier.stringRepresentation)' rule " +
-                             "should be re-enabled before the end of the file"
+                let reason = "Use 'next', 'this' or 'previous' to disable the " +
+                             "'\(disabledRuleIdentifier.stringRepresentation)' rule for a single line or " +
+                             "'swiftlint:enable' to re-enable the rule immediately after the violations to be ignored"
                 return violation(for: command, ruleIdentifier: disabledRuleIdentifier, in: file, reason: reason)
             }
             return nil

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/BlanketDisableCommandRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/BlanketDisableCommandRule.swift
@@ -148,10 +148,9 @@ struct BlanketDisableCommandRule: Rule, SourceKitFreeRule {
             }
 
             if let command = ruleIdentifierToCommandMap[disabledRuleIdentifier] {
-                let reason = "Use 'next', 'this' or 'previous' to disable the " +
-                             "'\(disabledRuleIdentifier.stringRepresentation)' rule for a single line or " +
-                             "'swiftlint:enable' to re-enable it as soon as possible"
-
+                let reason = "Use 'next', 'this' or 'previous' instead to disable the " +
+                              "'\(disabledRuleIdentifier.stringRepresentation)' rule once " +
+                              " or re-enable it as soon as possible"
                 return violation(for: command, ruleIdentifier: disabledRuleIdentifier, in: file, reason: reason)
             }
             return nil

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/BlanketDisableCommandRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/BlanketDisableCommandRule.swift
@@ -4,9 +4,11 @@ struct BlanketDisableCommandRule: Rule, SourceKitFreeRule {
     static let description = RuleDescription(
         identifier: "blanket_disable_command",
         name: "Blanket Disable Command",
-        description: "`swiftlint:disable` commands should use `next`, `this` or `previous` to disable rules for a " +
-                     "single line, or `swiftlint:enable` to re-enable the rules immediately after the violations " +
-                     "to be ignored",
+        description: """
+                     `swiftlint:disable` commands should use `next`, `this` or `previous` to disable rules for a
+                     single line only, or `swiftlint:enable` to re-enable the rules immediately after the violations
+                     to be ignored.
+                     """,
         kind: .lint,
         nonTriggeringExamples: [
             Example("""

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/BlanketDisableCommandRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/BlanketDisableCommandRule.swift
@@ -7,7 +7,7 @@ struct BlanketDisableCommandRule: Rule, SourceKitFreeRule {
         description: """
                      `swiftlint:disable` commands should use `next`, `this` or `previous` to disable rules for a \
                      single line, or `swiftlint:enable` to re-enable the rules immediately after the violations \
-                     to be ignored, instead of disabling the rule for the rest of the file
+                     to be ignored, instead of disabling the rule for the rest of the file.
                      """,
         kind: .lint,
         nonTriggeringExamples: [

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/BlanketDisableCommandRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/BlanketDisableCommandRule.swift
@@ -4,8 +4,8 @@ struct BlanketDisableCommandRule: Rule, SourceKitFreeRule {
     static let description = RuleDescription(
         identifier: "blanket_disable_command",
         name: "Blanket Disable Command",
-        description: "'swiftlint:disable' commands should use 'next', 'this' or 'previous' to disable rules for a " +
-                     "single line, or 'swiftlint:enable' to re-enable the rules immediately after the violations " +
+        description: "`swiftlint:disable` commands should use `next`, `this` or `previous` to disable rules for a " +
+                     "single line, or `swiftlint:enable` to re-enable the rules immediately after the violations " +
                      "to be ignored",
         kind: .lint,
         nonTriggeringExamples: [
@@ -148,7 +148,8 @@ struct BlanketDisableCommandRule: Rule, SourceKitFreeRule {
             if let command = ruleIdentifierToCommandMap[disabledRuleIdentifier] {
                 let reason = "Use 'next', 'this' or 'previous' to disable the " +
                              "'\(disabledRuleIdentifier.stringRepresentation)' rule for a single line or " +
-                             "'swiftlint:enable' to re-enable the rule immediately after the violations to be ignored"
+                             "'swiftlint:enable' to re-enable it as soon as possible"
+
                 return violation(for: command, ruleIdentifier: disabledRuleIdentifier, in: file, reason: reason)
             }
             return nil

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/BlanketDisableCommandRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/BlanketDisableCommandRule.swift
@@ -6,8 +6,8 @@ struct BlanketDisableCommandRule: Rule, SourceKitFreeRule {
         name: "Blanket Disable Command",
         description: """
                      `swiftlint:disable` commands should use `next`, `this` or `previous` to disable rules for a
-                     single line only, or `swiftlint:enable` to re-enable the rules immediately after the violations
-                     to be ignored.
+                     single line, or `swiftlint:enable` to re-enable the rules immediately after the violations
+                     to be ignored, instead of disabling the rule for the rest of the file
                      """,
         kind: .lint,
         nonTriggeringExamples: [


### PR DESCRIPTION
Updates the rule description and a reason for the `blanket_disable_rule`, avoiding language about the end of the file.

Partly addresses #5450 

New top level rule description (I think this will only appear in the documentation perhaps).

old: "swiftlint:disable commands should be re-enabled before the end of the file"

new: "`swiftlint:disable` commands should use `next`, `this` or `previous` to disable rules for a
                     single line, or `swiftlint:enable` to re-enable the rules immediately after the violations
                     to be ignored, instead of disabling the rule for the rest of the file"

and the reason:

old: "The disabled 'XXXX' rule should be re-enabled before the end of the file"

new: "Use 'next', 'this' or 'previous' instead to disable the 'XXXX' rule once or re-enable it as soon as possible"

The OSS violations and fixes should match exactly - they've just been triggered by the reason change.
