### PR TITLE
Adds `all` analyzer pseudo-rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,11 @@
   [Martin Redington](https://github.com/mildm8nnered)
   [#4858](https://github.com/realm/SwiftLint/issues/4858)
 
+* Add `all` pseudo-rule for `analyzer_rules` - enables all analyzer rules
+  that are not listed in `disabled_rules`.  
+  [woxtu](https://github.com/woxtu)
+  [#4999](https://github.com/realm/SwiftLint/issues/4999)
+
 ## 0.54.0: Macro-Economic Forces
 
 #### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,6 +216,7 @@
 * Add `all` pseudo-rule for `analyzer_rules` - enables all analyzer rules
   that are not listed in `disabled_rules`.  
   [woxtu](https://github.com/woxtu)
+  [Martin Redington](https://github.com/mildm8nnered)
   [#4999](https://github.com/realm/SwiftLint/issues/4999)
 
 ## 0.54.0: Macro-Economic Forces

--- a/README.md
+++ b/README.md
@@ -535,7 +535,8 @@ Rule inclusion:
 * `analyzer_rules`: This is an entirely separate list of rules that are only
   run by the `analyze` command. All analyzer rules are opt-in, so this is the
   only configurable rule list, there are no equivalents for `disabled_rules`
-  `only_rules`.
+  `only_rules`. The special `all` identifier can also be used here to enable
+  all analyzer rules, except the ones listed in `disabled_rules`.
 
 ```yaml
 # By default, SwiftLint uses a set of sensible default rules you can adjust:

--- a/README.md
+++ b/README.md
@@ -535,7 +535,7 @@ Rule inclusion:
 * `analyzer_rules`: This is an entirely separate list of rules that are only
   run by the `analyze` command. All analyzer rules are opt-in, so this is the
   only configurable rule list, there are no equivalents for `disabled_rules`
-  `only_rules`. The special `all` identifier can also be used here to enable
+  and `only_rules`. The special `all` identifier can also be used here to enable
   all analyzer rules, except the ones listed in `disabled_rules`.
 
 ```yaml

--- a/Source/SwiftLintCore/Extensions/Configuration+RulesMode.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+RulesMode.swift
@@ -72,8 +72,18 @@ public extension Configuration {
                     effectiveOptInRules = optInRules
                 }
 
-                warnAboutDuplicates(in: effectiveOptInRules + analyzerRules)
-                self = .default(disabled: Set(disabledRules), optIn: Set(effectiveOptInRules + analyzerRules))
+                let effectiveAnalyzerRules: [String]
+                if analyzerRules.contains(RuleIdentifier.all.stringRepresentation) {
+                    let allAnalyzerRules = RuleRegistry.shared.list.list.compactMap { ruleID, ruleType in
+                        ruleType is any AnalyzerRule.Type ? ruleID : nil
+                    }
+                    effectiveAnalyzerRules = allAnalyzerRules
+                } else {
+                    effectiveAnalyzerRules = analyzerRules
+                }
+
+                warnAboutDuplicates(in: effectiveOptInRules + effectiveAnalyzerRules)
+                self = .default(disabled: Set(disabledRules), optIn: Set(effectiveOptInRules + effectiveAnalyzerRules))
             }
         }
 


### PR DESCRIPTION

Picks up from #5035 and fixes #4999

Adds an `all` pseudo-rule for the `analyzer_rules` section of the configuration file.

individual rules can still be disabled in `disabled_rules`.

I left @woxtu 's name on the credits as they did the initial work for this.
