### PR TITLE
Add option for `opening_brace` rule not to trigger with multiline statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,12 @@
 
 #### Enhancements
 
-* None.
+* Add `ignore_multiline_type_headers` and `ignore_multiline_statement_conditions`
+  options to `opening_brace` rule to allow opening braces to be on a new line after
+  multiline type headers or statement conditions. Rename `allow_multiline_func` to
+  `ignore_multiline_function_signatures`.  
+  [leonardosrodrigues0](https://github.com/leonardosrodrigues0)
+  [#3720](https://github.com/realm/SwiftLint/issues/3720)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OpeningBraceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OpeningBraceConfiguration.swift
@@ -6,10 +6,18 @@ struct OpeningBraceConfiguration: SeverityBasedRuleConfiguration {
 
     @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    @ConfigurationElement(key: "allow_multiline_func")
-    private(set) var allowMultilineFunc = false
     @ConfigurationElement(key: "ignore_multiline_type_headers")
     private(set) var ignoreMultilineTypeHeaders = false
     @ConfigurationElement(key: "ignore_multiline_statement_conditions")
     private(set) var ignoreMultilineStatementConditions = false
+    @ConfigurationElement(key: "ignore_multiline_function_signatures")
+    private(set) var ignoreMultilineFunctionSignatures = false
+    // TODO: [08/23/2026] Remove deprecation warning after ~2 years.
+    @ConfigurationElement(key: "allow_multiline_func", deprecationNotice: .suggestAlternative(
+        ruleID: Parent.identifier, name: "ignore_multiline_function_signatures"))
+    private(set) var allowMultilineFunc = false
+
+    var shouldIgnoreMultilineFunctionSignatures: Bool {
+        ignoreMultilineFunctionSignatures || allowMultilineFunc
+    }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OpeningBraceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OpeningBraceConfiguration.swift
@@ -8,4 +8,6 @@ struct OpeningBraceConfiguration: SeverityBasedRuleConfiguration {
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "allow_multiline_func")
     private(set) var allowMultilineFunc = false
+    @ConfigurationElement(key: "ignore_multiline_type_headers")
+    private(set) var ignoreMultilineTypeHeaders = false
 }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OpeningBraceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OpeningBraceConfiguration.swift
@@ -10,4 +10,6 @@ struct OpeningBraceConfiguration: SeverityBasedRuleConfiguration {
     private(set) var allowMultilineFunc = false
     @ConfigurationElement(key: "ignore_multiline_type_headers")
     private(set) var ignoreMultilineTypeHeaders = false
+    @ConfigurationElement(key: "ignore_multiline_statement_conditions")
+    private(set) var ignoreMultilineStatementConditions = false
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/OpeningBraceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/OpeningBraceRule.swift
@@ -35,7 +35,7 @@ private extension OpeningBraceRule {
                 return
             }
 
-            collectViolations(for: node.memberBlock)
+            super.visitPost(node)
         }
 
         override func visitPost(_ node: ClassDeclSyntax) {
@@ -46,7 +46,7 @@ private extension OpeningBraceRule {
                 return
             }
 
-            collectViolations(for: node.memberBlock)
+            super.visitPost(node)
         }
 
         override func visitPost(_ node: EnumDeclSyntax) {
@@ -57,7 +57,7 @@ private extension OpeningBraceRule {
                 return
             }
 
-            collectViolations(for: node.memberBlock)
+            super.visitPost(node)
         }
 
         override func visitPost(_ node: ExtensionDeclSyntax) {
@@ -68,7 +68,7 @@ private extension OpeningBraceRule {
                 return
             }
 
-            collectViolations(for: node.memberBlock)
+            super.visitPost(node)
         }
 
         override func visitPost(_ node: ProtocolDeclSyntax) {
@@ -79,7 +79,7 @@ private extension OpeningBraceRule {
                 return
             }
 
-            collectViolations(for: node.memberBlock)
+            super.visitPost(node)
         }
 
         override func visitPost(_ node: StructDeclSyntax) {
@@ -90,8 +90,44 @@ private extension OpeningBraceRule {
                 return
             }
 
-            collectViolations(for: node.memberBlock)
+            super.visitPost(node)
         }
+
+        // MARK: - Conditional Statements
+
+        override func visitPost(_ node: ForStmtSyntax) {
+            if
+                configuration.ignoreMultilineStatementConditions,
+                hasMultilinePredecessors(node.body, keyword: node.forKeyword)
+            {
+                return
+            }
+
+            super.visitPost(node)
+        }
+
+        override func visitPost(_ node: IfExprSyntax) {
+            if
+                configuration.ignoreMultilineStatementConditions,
+                hasMultilinePredecessors(node.body, keyword: node.ifKeyword)
+            {
+                return
+            }
+
+            super.visitPost(node)
+        }
+
+        override func visitPost(_ node: WhileStmtSyntax) {
+            if
+                configuration.ignoreMultilineStatementConditions,
+                hasMultilinePredecessors(node.body, keyword: node.whileKeyword)
+            {
+                return
+            }
+
+            super.visitPost(node)
+        }
+
 
         // MARK: - Functions and Initializers
 
@@ -102,7 +138,7 @@ private extension OpeningBraceRule {
             if configuration.allowMultilineFunc, hasMultilinePredecessors(body, keyword: node.funcKeyword) {
                 return
             }
-            collectViolations(for: body)
+            super.visitPost(node)
         }
 
         override func visitPost(_ node: InitializerDeclSyntax) {
@@ -112,7 +148,7 @@ private extension OpeningBraceRule {
             if configuration.allowMultilineFunc, hasMultilinePredecessors(body, keyword: node.initKeyword) {
                 return
             }
-            collectViolations(for: body)
+            super.visitPost(node)
         }
 
         // MARK: - Auxiliar

--- a/Source/SwiftLintBuiltInRules/Rules/Style/OpeningBraceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/OpeningBraceRule.swift
@@ -28,10 +28,8 @@ private extension OpeningBraceRule {
         // MARK: - Type Declarations
 
         override func visitPost(_ node: ActorDeclSyntax) {
-            if
-                configuration.ignoreMultilineTypeHeaders,
-                hasMultilinePredecessors(node.memberBlock, keyword: node.actorKeyword)
-            {
+            if configuration.ignoreMultilineTypeHeaders,
+                hasMultilinePredecessors(node.memberBlock, keyword: node.actorKeyword) {
                 return
             }
 
@@ -39,10 +37,8 @@ private extension OpeningBraceRule {
         }
 
         override func visitPost(_ node: ClassDeclSyntax) {
-            if
-                configuration.ignoreMultilineTypeHeaders,
-                hasMultilinePredecessors(node.memberBlock, keyword: node.classKeyword)
-            {
+            if configuration.ignoreMultilineTypeHeaders,
+                hasMultilinePredecessors(node.memberBlock, keyword: node.classKeyword) {
                 return
             }
 
@@ -50,10 +46,8 @@ private extension OpeningBraceRule {
         }
 
         override func visitPost(_ node: EnumDeclSyntax) {
-            if
-                configuration.ignoreMultilineTypeHeaders,
-                hasMultilinePredecessors(node.memberBlock, keyword: node.enumKeyword)
-            {
+            if configuration.ignoreMultilineTypeHeaders,
+                hasMultilinePredecessors(node.memberBlock, keyword: node.enumKeyword) {
                 return
             }
 
@@ -61,10 +55,8 @@ private extension OpeningBraceRule {
         }
 
         override func visitPost(_ node: ExtensionDeclSyntax) {
-            if
-                configuration.ignoreMultilineTypeHeaders,
-                hasMultilinePredecessors(node.memberBlock, keyword: node.extensionKeyword)
-            {
+            if configuration.ignoreMultilineTypeHeaders,
+                hasMultilinePredecessors(node.memberBlock, keyword: node.extensionKeyword) {
                 return
             }
 
@@ -72,10 +64,8 @@ private extension OpeningBraceRule {
         }
 
         override func visitPost(_ node: ProtocolDeclSyntax) {
-            if
-                configuration.ignoreMultilineTypeHeaders,
-                hasMultilinePredecessors(node.memberBlock, keyword: node.protocolKeyword)
-            {
+            if configuration.ignoreMultilineTypeHeaders,
+                hasMultilinePredecessors(node.memberBlock, keyword: node.protocolKeyword) {
                 return
             }
 
@@ -83,10 +73,8 @@ private extension OpeningBraceRule {
         }
 
         override func visitPost(_ node: StructDeclSyntax) {
-            if
-                configuration.ignoreMultilineTypeHeaders,
-                hasMultilinePredecessors(node.memberBlock, keyword: node.structKeyword)
-            {
+            if configuration.ignoreMultilineTypeHeaders,
+                hasMultilinePredecessors(node.memberBlock, keyword: node.structKeyword) {
                 return
             }
 
@@ -96,10 +84,8 @@ private extension OpeningBraceRule {
         // MARK: - Conditional Statements
 
         override func visitPost(_ node: ForStmtSyntax) {
-            if
-                configuration.ignoreMultilineStatementConditions,
-                hasMultilinePredecessors(node.body, keyword: node.forKeyword)
-            {
+            if configuration.ignoreMultilineStatementConditions,
+                hasMultilinePredecessors(node.body, keyword: node.forKeyword) {
                 return
             }
 
@@ -107,10 +93,8 @@ private extension OpeningBraceRule {
         }
 
         override func visitPost(_ node: IfExprSyntax) {
-            if
-                configuration.ignoreMultilineStatementConditions,
-                hasMultilinePredecessors(node.body, keyword: node.ifKeyword)
-            {
+            if configuration.ignoreMultilineStatementConditions,
+                hasMultilinePredecessors(node.body, keyword: node.ifKeyword) {
                 return
             }
 
@@ -118,41 +102,41 @@ private extension OpeningBraceRule {
         }
 
         override func visitPost(_ node: WhileStmtSyntax) {
-            if
-                configuration.ignoreMultilineStatementConditions,
-                hasMultilinePredecessors(node.body, keyword: node.whileKeyword)
-            {
+            if configuration.ignoreMultilineStatementConditions,
+                hasMultilinePredecessors(node.body, keyword: node.whileKeyword) {
                 return
             }
 
             super.visitPost(node)
         }
-
 
         // MARK: - Functions and Initializers
 
         override func visitPost(_ node: FunctionDeclSyntax) {
-            guard let body = node.body else {
+            if let body = node.body,
+                configuration.shouldIgnoreMultilineFunctionSignatures,
+                hasMultilinePredecessors(body, keyword: node.funcKeyword) {
                 return
             }
-            if configuration.allowMultilineFunc, hasMultilinePredecessors(body, keyword: node.funcKeyword) {
-                return
-            }
+
             super.visitPost(node)
         }
 
         override func visitPost(_ node: InitializerDeclSyntax) {
-            guard let body = node.body else {
+            if let body = node.body,
+                configuration.shouldIgnoreMultilineFunctionSignatures,
+                hasMultilinePredecessors(body, keyword: node.initKeyword) {
                 return
             }
-            if configuration.allowMultilineFunc, hasMultilinePredecessors(body, keyword: node.initKeyword) {
-                return
-            }
+
             super.visitPost(node)
         }
 
-        // MARK: - Auxiliar
+        // MARK: - Other Methods
 
+        /// Checks if a `BracedSyntax` has a multiline predecessor.
+        /// For type declarations, the predecessor is the header. For conditional statements,
+        /// it is the condition list, and for functions, it is the signature.
         private func hasMultilinePredecessors(_ body: some BracedSyntax, keyword: TokenSyntax) -> Bool {
             guard let endToken = body.previousToken(viewMode: .sourceAccurate) else {
                 return false

--- a/Source/SwiftLintBuiltInRules/Rules/Style/OpeningBraceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/OpeningBraceRule.swift
@@ -25,11 +25,81 @@ struct OpeningBraceRule: SwiftSyntaxCorrectableRule {
 
 private extension OpeningBraceRule {
     final class Visitor: CodeBlockVisitor<ConfigurationType> {
+        // MARK: - Type Declarations
+
+        override func visitPost(_ node: ActorDeclSyntax) {
+            if
+                configuration.ignoreMultilineTypeHeaders,
+                hasMultilinePredecessors(node.memberBlock, keyword: node.actorKeyword)
+            {
+                return
+            }
+
+            collectViolations(for: node.memberBlock)
+        }
+
+        override func visitPost(_ node: ClassDeclSyntax) {
+            if
+                configuration.ignoreMultilineTypeHeaders,
+                hasMultilinePredecessors(node.memberBlock, keyword: node.classKeyword)
+            {
+                return
+            }
+
+            collectViolations(for: node.memberBlock)
+        }
+
+        override func visitPost(_ node: EnumDeclSyntax) {
+            if
+                configuration.ignoreMultilineTypeHeaders,
+                hasMultilinePredecessors(node.memberBlock, keyword: node.enumKeyword)
+            {
+                return
+            }
+
+            collectViolations(for: node.memberBlock)
+        }
+
+        override func visitPost(_ node: ExtensionDeclSyntax) {
+            if
+                configuration.ignoreMultilineTypeHeaders,
+                hasMultilinePredecessors(node.memberBlock, keyword: node.extensionKeyword)
+            {
+                return
+            }
+
+            collectViolations(for: node.memberBlock)
+        }
+
+        override func visitPost(_ node: ProtocolDeclSyntax) {
+            if
+                configuration.ignoreMultilineTypeHeaders,
+                hasMultilinePredecessors(node.memberBlock, keyword: node.protocolKeyword)
+            {
+                return
+            }
+
+            collectViolations(for: node.memberBlock)
+        }
+
+        override func visitPost(_ node: StructDeclSyntax) {
+            if
+                configuration.ignoreMultilineTypeHeaders,
+                hasMultilinePredecessors(node.memberBlock, keyword: node.structKeyword)
+            {
+                return
+            }
+
+            collectViolations(for: node.memberBlock)
+        }
+
+        // MARK: - Functions and Initializers
+
         override func visitPost(_ node: FunctionDeclSyntax) {
             guard let body = node.body else {
                 return
             }
-            if configuration.allowMultilineFunc, refersToMultilineFunction(body, functionIndicator: node.funcKeyword) {
+            if configuration.allowMultilineFunc, hasMultilinePredecessors(body, keyword: node.funcKeyword) {
                 return
             }
             collectViolations(for: body)
@@ -39,17 +109,19 @@ private extension OpeningBraceRule {
             guard let body = node.body else {
                 return
             }
-            if configuration.allowMultilineFunc, refersToMultilineFunction(body, functionIndicator: node.initKeyword) {
+            if configuration.allowMultilineFunc, hasMultilinePredecessors(body, keyword: node.initKeyword) {
                 return
             }
             collectViolations(for: body)
         }
 
-        private func refersToMultilineFunction(_ body: CodeBlockSyntax, functionIndicator: TokenSyntax) -> Bool {
+        // MARK: - Auxiliar
+
+        private func hasMultilinePredecessors(_ body: some BracedSyntax, keyword: TokenSyntax) -> Bool {
             guard let endToken = body.previousToken(viewMode: .sourceAccurate) else {
                 return false
             }
-            let startLocation = functionIndicator.endLocation(converter: locationConverter)
+            let startLocation = keyword.endLocation(converter: locationConverter)
             let endLocation = endToken.endLocation(converter: locationConverter)
             let braceLocation = body.leftBrace.endLocation(converter: locationConverter)
             return startLocation.line != endLocation.line && endLocation.line != braceLocation.line

--- a/Tests/IntegrationTests/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/default_rule_configurations.yml
@@ -375,6 +375,9 @@ one_declaration_per_file:
   severity: warning
 opening_brace:
   severity: warning
+  ignore_multiline_type_headers: false
+  ignore_multiline_statement_conditions: false
+  ignore_multiline_function_signatures: false
   allow_multiline_func: false
 operator_usage_whitespace:
   severity: warning

--- a/Tests/SwiftLintFrameworkTests/OpeningBraceRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/OpeningBraceRuleTests.swift
@@ -89,6 +89,41 @@ final class OpeningBraceRuleTests: SwiftLintTestCase {
 
         verifyRule(description, ruleConfiguration: ["allow_multiline_func": true])
     }
+
+    func testWithIgnoreMultilineTypeHeadersTrue() {
+        let nonTriggeringExamples = [
+            Example("""
+                extension A
+                    where B: Equatable
+                {}
+                """),
+            Example("""
+                struct S {
+                    init() {}
+                }
+                """),
+        ]
+
+        let triggeringExamples = [
+            Example("""
+                struct S
+                ↓{}
+                """),
+            Example("""
+                extension A where B: Equatable
+                ↓{
+
+                }
+                """),
+        ]
+
+        let description = OpeningBraceRule.description
+            .with(nonTriggeringExamples: nonTriggeringExamples)
+            .with(triggeringExamples: triggeringExamples)
+            .with(corrections: [:])
+
+        verifyRule(description, ruleConfiguration: ["ignore_multiline_type_headers": true])
+    }
 }
 
 private extension Array where Element == Example {

--- a/Tests/SwiftLintFrameworkTests/OpeningBraceRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/OpeningBraceRuleTests.swift
@@ -124,6 +124,58 @@ final class OpeningBraceRuleTests: SwiftLintTestCase {
 
         verifyRule(description, ruleConfiguration: ["ignore_multiline_type_headers": true])
     }
+
+    func testWithIgnoreMultilineStatementConditionsTrue() {
+        let nonTriggeringExamples = [
+            Example("""
+                while
+                    abc
+                {}
+                """),
+            Example("""
+                if x {
+
+                } else if 
+                    y,
+                    z
+                {
+
+                }
+                """),
+            Example("""
+                if
+                    condition1,
+                    let var1 = var1
+                {}
+                """)
+        ]
+
+        let triggeringExamples = [
+            Example("""
+                if x
+                {}
+                """),
+            Example("""
+                if x {
+
+                } else if y, z
+                {}
+                """),
+            Example("""
+                if x {
+
+                } else
+                {}
+                """),
+        ]
+
+        let description = OpeningBraceRule.description
+            .with(nonTriggeringExamples: nonTriggeringExamples)
+            .with(triggeringExamples: triggeringExamples)
+            .with(corrections: [:])
+
+        verifyRule(description, ruleConfiguration: ["ignore_multiline_statement_conditions": true])
+    }
 }
 
 private extension Array where Element == Example {

--- a/Tests/SwiftLintFrameworkTests/OpeningBraceRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/OpeningBraceRuleTests.swift
@@ -1,25 +1,120 @@
 @testable import SwiftLintBuiltInRules
 
 final class OpeningBraceRuleTests: SwiftLintTestCase {
-    func testDefaultExamplesRunInMultilineMode() {
+    func testDefaultNonTriggeringExamplesWithMultilineOptionsTrue() {
         let description = OpeningBraceRule.description
-            .with(triggeringExamples: OpeningBraceRule.description.triggeringExamples.removing([
-                Example("func abc(a: A,\n\tb: B)\n↓{"),
-                Example("""
-                    internal static func getPointer()
-                      -> UnsafeMutablePointer<_ThreadLocalStorage>
-                    ↓{
-                        return _swift_stdlib_threadLocalStorageGet().assumingMemoryBound(
-                            to: _ThreadLocalStorage.self)
-                    }
-                    """),
-            ]))
+            .with(triggeringExamples: [])
+            .with(corrections: [:])
 
-        verifyRule(description, ruleConfiguration: ["allow_multiline_func": true])
+        verifyRule(description, ruleConfiguration: [
+            "ignore_multiline_statement_conditions": true,
+            "ignore_multiline_type_headers": true,
+            "ignore_multiline_function_signatures": true,
+        ])
+    }
+
+    func testWithIgnoreMultilineTypeHeadersTrue() {
+        let nonTriggeringExamples = [
+            Example("""
+                extension A
+                    where B: Equatable
+                {}
+                """),
+            Example("""
+                struct S: Comparable,
+                          Identifiable
+                {
+                    init() {}
+                }
+                """),
+        ]
+
+        let triggeringExamples = [
+            Example("""
+                struct S
+                ↓{}
+                """),
+            Example("""
+                extension A where B: Equatable
+                ↓{
+
+                }
+                """),
+            Example("""
+                class C
+                    // with comments
+                ↓{}
+                """),
+        ]
+
+        let description = OpeningBraceRule.description
+            .with(nonTriggeringExamples: nonTriggeringExamples)
+            .with(triggeringExamples: triggeringExamples)
+            .with(corrections: [:])
+
+        verifyRule(description, ruleConfiguration: ["ignore_multiline_type_headers": true])
+    }
+
+    func testWithIgnoreMultilineStatementConditionsTrue() {
+        let nonTriggeringExamples = [
+            Example("""
+                while
+                    abc
+                {}
+                """),
+            Example("""
+                if x {
+
+                } else if
+                    y,
+                    z
+                {
+
+                }
+                """),
+            Example("""
+                if
+                    condition1,
+                    let var1 = var1
+                {}
+                """),
+        ]
+
+        let triggeringExamples = [
+            Example("""
+                if x
+                ↓{}
+                """),
+            Example("""
+                if x {
+
+                } else if y, z
+                ↓{}
+                """),
+            Example("""
+                if x {
+
+                } else
+                ↓{}
+                """),
+            Example("""
+                while abc
+                    // comments
+                ↓{
+                }
+                """),
+        ]
+
+        let description = OpeningBraceRule.description
+            .with(nonTriggeringExamples: nonTriggeringExamples)
+            .with(triggeringExamples: triggeringExamples)
+            .with(corrections: [:])
+
+        verifyRule(description, ruleConfiguration: ["ignore_multiline_statement_conditions": true])
     }
 
     // swiftlint:disable:next function_body_length
-    func testWithAllowMultilineTrue() {
+    func testWithIgnoreMultilineFunctionSignaturesTrue() {
         let nonTriggeringExamples = [
             Example("""
                 func abc(
@@ -80,39 +175,11 @@ final class OpeningBraceRuleTests: SwiftLintTestCase {
                     }
                 }
                 """),
-        ]
-
-        let description = OpeningBraceRule.description
-            .with(nonTriggeringExamples: nonTriggeringExamples)
-            .with(triggeringExamples: triggeringExamples)
-            .with(corrections: [:])
-
-        verifyRule(description, ruleConfiguration: ["allow_multiline_func": true])
-    }
-
-    func testWithIgnoreMultilineTypeHeadersTrue() {
-        let nonTriggeringExamples = [
             Example("""
-                extension A
-                    where B: Equatable
-                {}
-                """),
-            Example("""
-                struct S {
-                    init() {}
-                }
-                """),
-        ]
-
-        let triggeringExamples = [
-            Example("""
-                struct S
-                ↓{}
-                """),
-            Example("""
-                extension A where B: Equatable
-                ↓{
-
+                class C {
+                    init(a: Int)
+                        // with comments
+                    ↓{}
                 }
                 """),
         ]
@@ -122,59 +189,7 @@ final class OpeningBraceRuleTests: SwiftLintTestCase {
             .with(triggeringExamples: triggeringExamples)
             .with(corrections: [:])
 
-        verifyRule(description, ruleConfiguration: ["ignore_multiline_type_headers": true])
-    }
-
-    func testWithIgnoreMultilineStatementConditionsTrue() {
-        let nonTriggeringExamples = [
-            Example("""
-                while
-                    abc
-                {}
-                """),
-            Example("""
-                if x {
-
-                } else if 
-                    y,
-                    z
-                {
-
-                }
-                """),
-            Example("""
-                if
-                    condition1,
-                    let var1 = var1
-                {}
-                """)
-        ]
-
-        let triggeringExamples = [
-            Example("""
-                if x
-                {}
-                """),
-            Example("""
-                if x {
-
-                } else if y, z
-                {}
-                """),
-            Example("""
-                if x {
-
-                } else
-                {}
-                """),
-        ]
-
-        let description = OpeningBraceRule.description
-            .with(nonTriggeringExamples: nonTriggeringExamples)
-            .with(triggeringExamples: triggeringExamples)
-            .with(corrections: [:])
-
-        verifyRule(description, ruleConfiguration: ["ignore_multiline_statement_conditions": true])
+        verifyRule(description, ruleConfiguration: ["ignore_multiline_function_signatures": true])
     }
 }
 


### PR DESCRIPTION
In case of multiline `if` and `while` statements, many adopt the style of putting the opening brace in a new line. This change add a new option to the rule to allow that style.

Closes #3720 