### PR TITLE
Enable the superfluous_disable_command when running the analyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,12 @@
   [phlippieb](https://github.com/phlippieb)
   [#5471](https://github.com/realm/SwiftLint/issues/5471)
 
+* The `superfluous_disable_command` rule will now be enabled for the `analyze`
+  command, unless it has been disabled, and will warn about superfluous
+  disablement of analyzer rules.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4792](https://github.com/realm/SwiftLint/issues/4792)
+
 #### Bug Fixes
 
 * Silence `discarded_notification_center_observer` rule in closures. Furthermore,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,6 +218,11 @@
   [woxtu](https://github.com/woxtu)
   [Martin Redington](https://github.com/mildm8nnered)
   [#4999](https://github.com/realm/SwiftLint/issues/4999)
+* The `superfluous_disable_command` rule will now be enabled for the `analyze`
+  command, unless it has been disabled, and will warn about superfluous
+  disablement of analyzer rules.
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4792](https://github.com/realm/SwiftLint/issues/4792)
 
 ## 0.54.0: Macro-Economic Forces
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,11 +224,6 @@
   [woxtu](https://github.com/woxtu)
   [Martin Redington](https://github.com/mildm8nnered)
   [#4999](https://github.com/realm/SwiftLint/issues/4999)
-* The `superfluous_disable_command` rule will now be enabled for the `analyze`
-  command, unless it has been disabled, and will warn about superfluous
-  disablement of analyzer rules.
-  [Martin Redington](https://github.com/mildm8nnered)
-  [#4792](https://github.com/realm/SwiftLint/issues/4792)
 
 ## 0.54.0: Macro-Economic Forces
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,17 @@
 * Rewrite `SwiftLintPlugin` using `BUILD_WORKSPACE_DIRECTORY` without relying
   on the `--config` option.  
   [Garric Nahapetian](https://github.com/garricn)
-  
+
 * Introduce SwiftLintCommandPlugin.
   Rename SwiftLintBuildToolPlugin.
   Add Swift Package Manager installation instructions.  
   [garricn](https://github.com/garricn)
+
+* The `superfluous_disable_command` rule will now be enabled for the `analyze`
+  command, unless it has been disabled, and will warn about superfluous
+  disablement of analyzer rules.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4792](https://github.com/realm/SwiftLint/issues/4792)
 
 #### Experimental
 
@@ -153,12 +159,6 @@
   `final class` declaration.  
   [phlippieb](https://github.com/phlippieb)
   [#5471](https://github.com/realm/SwiftLint/issues/5471)
-
-* The `superfluous_disable_command` rule will now be enabled for the `analyze`
-  command, unless it has been disabled, and will warn about superfluous
-  disablement of analyzer rules.  
-  [Martin Redington](https://github.com/mildm8nnered)
-  [#4792](https://github.com/realm/SwiftLint/issues/4792)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -160,7 +160,7 @@ public struct Linter {
             if compilerArguments.isEmpty {
                 return !(rule is any AnalyzerRule)
             }
-            return (rule is any AnalyzerRule || rule is SuperfluousDisableCommandRule)
+            return rule is any AnalyzerRule || rule is SuperfluousDisableCommandRule
         }
         self.rules = rules
         self.isCollecting = rules.contains(where: { $0 is any AnyCollectingRule })

--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -160,7 +160,7 @@ public struct Linter {
             if compilerArguments.isEmpty {
                 return !(rule is any AnalyzerRule)
             }
-            return rule is any AnalyzerRule
+            return (rule is any AnalyzerRule || rule is SuperfluousDisableCommandRule)
         }
         self.rules = rules
         self.isCollecting = rules.contains(where: { $0 is any AnyCollectingRule })

--- a/Tests/SwiftLintFrameworkTests/CommandTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CommandTests.swift
@@ -2,6 +2,7 @@
 import Foundation
 import SourceKittenFramework
 @testable import SwiftLintCore
+@testable import SwiftLintBuiltInRules
 import XCTest
 
 private extension Command {
@@ -453,5 +454,29 @@ class CommandTests: SwiftLintTestCase {
             )),
             []
         )
+    }
+
+    func testSuperfluousDisableCommandsEnabledForAnalyzer() {
+        let configuration = Configuration(
+            rulesMode: .default(disabled: [], optIn: [UnusedDeclarationRule.description.identifier])
+        )
+        let violations = violations(
+            Example("""
+            public class Foo {
+                // swiftlint:disable:next unused_declaration
+                func foo() -> Int {
+                    1
+                }
+                // swiftlint:disable:next unused_declaration
+                func bar() {
+                   foo()
+                }
+            }
+            """),
+            config: configuration,
+            requiresFileOnDisk: true
+        )
+        XCTAssertEqual(violations.count, 1)
+        XCTAssertEqual(violations.first?.ruleIdentifier, "superfluous_disable_command")
     }
 }

--- a/Tests/SwiftLintFrameworkTests/CommandTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CommandTests.swift
@@ -1,8 +1,8 @@
 // swiftlint:disable file_length
 import Foundation
 import SourceKittenFramework
-@testable import SwiftLintCore
 @testable import SwiftLintBuiltInRules
+@testable import SwiftLintCore
 import XCTest
 
 private extension Command {

--- a/Tests/SwiftLintFrameworkTests/CommandTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CommandTests.swift
@@ -478,5 +478,6 @@ class CommandTests: SwiftLintTestCase {
         )
         XCTAssertEqual(violations.count, 1)
         XCTAssertEqual(violations.first?.ruleIdentifier, "superfluous_disable_command")
+        XCTAssertEqual(violations.first?.location.line, 3)
     }
 }


### PR DESCRIPTION

Addresses #4792. Surprisingly easy.

`superfluous_disable_command` ignores rules that aren't enabled, so you can `swiftlint:disable` analyzer rules, and they will be ignored when linting. Similarly, when analyzing, `superfluous_disable_command` will ignore any non analyzer rules.
