### PR TITLE
#5461 added ib_segue_action case in TypeContent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@
 * Support linting only provided file paths with command plugins.  
   [DanSkeel](https://github.com/DanSkeel)
 
+* Add new category for `@IBSegueAction` to `type_contents_order` rule.  
+  [dk-talks](https://github.com/dk-talks)  
+  [SimplyDanny](https://github.com/SimplyDanny)
+
 #### Bug Fixes
 
 * Ignore super calls with trailing closures in `unneeded_override` rule.  

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedDeclarationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedDeclarationRule.swift
@@ -211,6 +211,7 @@ private extension SwiftLintFile {
 
     private func shouldIgnoreEntity(_ indexEntity: SourceKittenDictionary, relatedUSRsToSkip: Set<String>) -> Bool {
         let declarationAttributesToSkip: Set<SwiftDeclarationAttributeKind> = [
+            .ibsegueaction,
             .ibaction,
             .main,
             .nsApplicationMain,

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TypeContentsOrderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TypeContentsOrderConfiguration.swift
@@ -17,6 +17,7 @@ enum TypeContent: String {
     case otherMethod = "other_method"
     case `subscript` = "subscript"
     case deinitializer = "deinitializer"
+    case ibSegueAction = "ib_segue_action"
 }
 
 @AutoConfigParser

--- a/Source/SwiftLintBuiltInRules/Rules/Style/TypeContentsOrderRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/TypeContentsOrderRule.swift
@@ -133,6 +133,9 @@ struct TypeContentsOrderRule: OptInRule {
             if typeContentStructure.enclosedSwiftAttributes.contains(SwiftDeclarationAttributeKind.ibaction) {
                 return .ibAction
             }
+            if typeContentStructure.enclosedSwiftAttributes.contains(SwiftDeclarationAttributeKind.ibsegueaction) {
+                return .ibSegueAction
+            }
             return .otherMethod
 
         case .functionSubscript:

--- a/Source/SwiftLintCore/Extensions/SwiftDeclarationAttributeKind+Swiftlint.swift
+++ b/Source/SwiftLintCore/Extensions/SwiftDeclarationAttributeKind+Swiftlint.swift
@@ -85,6 +85,7 @@ public extension SwiftDeclarationAttributeKind {
                     .nonobjc,
                     .objcMembers,
                     .ibaction,
+                    .ibsegueaction,
                     .iboutlet,
                     .ibdesignable,
                     .ibinspectable,

--- a/Tests/SwiftLintFrameworkTests/TypeContentsOrderRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TypeContentsOrderRuleTests.swift
@@ -277,6 +277,10 @@ final class TypeContentsOrderRuleTests: SwiftLintTestCase {
                     view2.layoutIfNeeded()
                     hasLayoutedView2 = true
                 }
+
+                @IBSegueAction func prepareForNextVc(_ coder: NSCoder) -> UIViewController? {
+                    getRandomVc()
+                }
             }
             """),
         ]
@@ -330,6 +334,17 @@ final class TypeContentsOrderRuleTests: SwiftLintTestCase {
                 }
             }
             """),
+            Example("""
+                class C {
+                    func f() {}
+
+                    @IBSegueAction ↓func foo(_ coder: NSCoder) -> UIViewController? {
+                        nil
+                    }
+
+                    @IBAction func bar() {}
+                }
+            """),
         ]
 
         let groupedOrderDescription = TypeContentsOrderRule.description
@@ -344,6 +359,7 @@ final class TypeContentsOrderRuleTests: SwiftLintTestCase {
                     ["type_property", "instance_property", "ib_inspectable", "ib_outlet"],
                     ["initializer", "type_method", "deinitializer"],
                     ["view_life_cycle_method", "ib_action", "other_method", "subscript"],
+                    ["ib_segue_action"],
                 ],
             ]
         )


### PR DESCRIPTION
Hey! I have added a new case to TypeContent enum for ib_segue_action. And also adapted the change in [TypeContentsOrderRule.swift](https://github.com/realm/SwiftLint/blob/main/Source/SwiftLintBuiltInRules/Rules/Style/TypeContentsOrderRule.swift). 