### PR TITLE
Use SwiftSyntax version 600.0.0-prerelease-2024-04-02

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,13 +5,13 @@ module(
     repo_name = "SwiftLint",
 )
 
-bazel_dep(name = "apple_support", version = "1.11.1", repo_name = "build_bazel_apple_support")
+bazel_dep(name = "apple_support", version = "1.13.0", repo_name = "build_bazel_apple_support")
 bazel_dep(name = "bazel_skylib", version = "1.5.0")
 bazel_dep(name = "platforms", version = "0.0.8")
-bazel_dep(name = "rules_apple", version = "3.1.1", repo_name = "build_bazel_rules_apple")
+bazel_dep(name = "rules_apple", version = "3.3.0", repo_name = "build_bazel_rules_apple")
 bazel_dep(name = "rules_swift", version = "1.16.0", repo_name = "build_bazel_rules_swift")
 bazel_dep(name = "sourcekitten", version = "0.35.0", repo_name = "com_github_jpsim_sourcekitten")
-bazel_dep(name = "swift-syntax", version = "510.0.2", repo_name = "SwiftSyntax")
+bazel_dep(name = "swift-syntax", version = "600.0.0-prerelease-2024-04-02", repo_name = "SwiftSyntax")
 bazel_dep(name = "swift_argument_parser", version = "1.3.1", repo_name = "sourcekitten_com_github_apple_swift_argument_parser")
 bazel_dep(name = "yams", version = "5.0.6", repo_name = "sourcekitten_com_github_jpsim_yams")
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "303e5c5c36d6a558407d364878df131c3546fad8",
-        "version" : "510.0.2"
+        "revision" : "55c4e4669c031d697e1924022b8ba250cfde0f2f",
+        "version" : "600.0.0-prerelease-2024-04-02"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.1"),
-        .package(url: "https://github.com/apple/swift-syntax.git", from: "510.0.2"),
+        .package(url: "https://github.com/apple/swift-syntax.git", exact: "600.0.0-prerelease-2024-04-02"),
         .package(url: "https://github.com/jpsim/SourceKitten.git", .upToNextMinor(from: "0.35.0")),
         .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.6"),
         .package(url: "https://github.com/scottrhoyt/SwiftyTextTable.git", from: "0.9.0"),

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededSynthesizedInitializerRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededSynthesizedInitializerRule.swift
@@ -234,7 +234,7 @@ private extension StructDeclSyntax {
 
 private extension InitializerDeclSyntax {
     var hasThrowsOrRethrowsKeyword: Bool {
-        signature.effectSpecifiers?.throwsSpecifier != nil
+        signature.effectSpecifiers?.throwsClause?.throwsSpecifier != nil
     }
     var isInlinable: Bool {
         attributes.contains(attributeNamed: "inlinable")

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ControlStatementRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ControlStatementRule.swift
@@ -1,4 +1,3 @@
-@_spi(SyntaxTransformVisitor)
 import SwiftSyntax
 
 @SwiftSyntaxRule(explicitRewriter: true)
@@ -166,26 +165,22 @@ private extension ControlStatementRule {
     }
 }
 
-private class TrailingClosureFinder: SyntaxTransformVisitor {
-    func visitAny(_ node: Syntax) -> Bool {
-        false
-    }
-
-    func visit(_ node: FunctionCallExprSyntax) -> Bool {
-        node.trailingClosure != nil
-    }
-
-    func visit(_ node: SequenceExprSyntax) -> Bool {
-        node.elements.contains(where: visit)
-    }
-}
-
 private extension ExprSyntax {
     var unwrapped: ExprSyntax? {
         if let expr = self.as(TupleExprSyntax.self)?.elements.onlyElement?.expression {
-            return TrailingClosureFinder().visit(expr) ? nil : expr
+            return containsTrailingClosure(Syntax(expr)) ? nil : expr
         }
         return nil
+    }
+
+   private func containsTrailingClosure(_ node: Syntax) -> Bool {
+        switch node.as(SyntaxEnum.self) {
+        case .functionCallExpr(let node):
+            node.trailingClosure != nil
+        case .sequenceExpr(let node):
+            node.elements.contains { containsTrailingClosure(Syntax($0)) }
+        default: false
+        }
     }
 }
 

--- a/Source/SwiftLintCore/Extensions/SwiftSyntax+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/SwiftSyntax+SwiftLint.swift
@@ -349,8 +349,6 @@ public extension ClosureCaptureSyntax {
     }
 }
 
-extension PrecedenceGroupDeclSyntax: BracedSyntax {}
-
 private extension String {
     var isZero: Bool {
         if self == "0" { // fast path

--- a/Source/SwiftLintCore/Extensions/SyntaxClassification+isComment.swift
+++ b/Source/SwiftLintCore/Extensions/SyntaxClassification+isComment.swift
@@ -6,7 +6,7 @@ public extension SyntaxClassification {
         switch self {
         case .lineComment, .docLineComment, .blockComment, .docBlockComment:
             return true
-        case .none, .keyword, .identifier, .type, .operator, .dollarIdentifier, .integerLiteral,
+        case .none, .keyword, .identifier, .type, .operator, .dollarIdentifier, .integerLiteral, .argumentLabel,
              .floatLiteral, .stringLiteral, .ifConfigDirective, .attribute, .editorPlaceholder, .regexLiteral:
             return false
         }

--- a/Tests/MacroTests/MakeAcceptableByConfigurationElementTests.swift
+++ b/Tests/MacroTests/MakeAcceptableByConfigurationElementTests.swift
@@ -61,7 +61,7 @@ final class MakeAcceptableByConfigurationElementTests: XCTestCase {
                     .symbol(rawValue)
                 }
                 private init(fromAny value: Any, context ruleID: String) throws {
-                    if let value = value as? String, let newSelf = Self (rawValue: value) {
+                    if let value = value as? String, let newSelf = Self(rawValue: value) {
                         self = newSelf
                     } else {
                         throw Issue.invalidConfiguration(ruleID: ruleID)
@@ -89,7 +89,7 @@ final class MakeAcceptableByConfigurationElementTests: XCTestCase {
                     .symbol(rawValue)
                 }
                 public init(fromAny value: Any, context ruleID: String) throws {
-                    if let value = value as? String, let newSelf = Self (rawValue: value) {
+                    if let value = value as? String, let newSelf = Self(rawValue: value) {
                         self = newSelf
                     } else {
                         throw Issue.invalidConfiguration(ruleID: ruleID)


### PR DESCRIPTION
We can also switch back to an exact SwiftSyntax version now with the plugins in a separate repository. In fact, using the plugin no dependency to SwiftSyntax is required whatsoever.