### PR TITLE
Enable more swiftlint rules (and fix or suppress any violations) in SwiftLint's own .swiftlint.yml

### DIFF
--- a/.sourcery/GeneratedTests.stencil
+++ b/.sourcery/GeneratedTests.stencil
@@ -7,7 +7,7 @@ import SwiftLintTestHelpers
 
 {% for rule in types.structs %}
 {% if rule.name|hasSuffix:"Rule" %}
-class {{ rule.name }}GeneratedTests: SwiftLintTestCase {
+final class {{ rule.name }}GeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule({{ rule.name }}.description)
     }

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -24,7 +24,6 @@ disabled_rules:
   - force_unwrapping
   - function_default_parameter_at_end
   - implicit_return
-  - implicitly_unwrapped_optional
   - indentation_width
   - inert_defer
   - missing_docs

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -21,7 +21,6 @@ disabled_rules:
   - explicit_top_level_acl
   - explicit_type_interface
   - file_types_order
-  - final_test_case
   - force_unwrapping
   - function_default_parameter_at_end
   - implicit_return
@@ -43,11 +42,8 @@ disabled_rules:
   - prefer_nimble
   - prefer_self_in_static_references
   - prefixed_toplevel_constant
-  - redundant_self_in_closure
   - required_deinit
-  - self_binding
   - static_over_final_class
-  - shorthand_argument
   - sorted_enum_cases
   - strict_fileprivate
   - switch_case_on_newline

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -79,7 +79,7 @@ balanced_xctest_lifecycle: &unit_test_configuration
     - XCTestCase
 empty_xctest_method: *unit_test_configuration
 single_test_class: *unit_test_configuration
-
+final_test_case: *unit_test_configuration
 function_body_length: 60
 type_body_length: 400
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ExpiringTodoRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ExpiringTodoRule.swift
@@ -59,8 +59,8 @@ struct ExpiringTodoRule: OptInRule {
                 syntaxKinds.allSatisfy({ $0.isCommentLike }),
                 checkingResult.numberOfRanges > 1,
                 case let range = checkingResult.range(at: 1),
-                let violationLevel = self.violationLevel(for: expiryDate(file: file, range: range)),
-                let severity = self.severity(for: violationLevel) else {
+                let violationLevel = violationLevel(for: expiryDate(file: file, range: range)),
+                let severity = severity(for: violationLevel) else {
                 return nil
             }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/TypeContentsOrderRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/TypeContentsOrderRule.swift
@@ -69,7 +69,7 @@ struct TypeContentsOrderRule: OptInRule {
 
     private func typeContentOffsets(in typeStructure: SourceKittenDictionary) -> [TypeContentOffset] {
         return typeStructure.substructure.compactMap { typeContentStructure in
-            guard let typeContent = self.typeContent(for: typeContentStructure) else { return nil }
+            guard let typeContent = typeContent(for: typeContentStructure) else { return nil }
             return (typeContent, typeContentStructure.offset!)
         }
     }

--- a/Source/SwiftLintCore/Extensions/Configuration+FileGraphSubtypes.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+FileGraphSubtypes.swift
@@ -95,8 +95,10 @@ internal extension Configuration.FileGraph {
 
     // MARK: - Edge
     struct Edge: Hashable {
+        // swiftlint:disable implicitly_unwrapped_optional
         var parent: Vertex!
         var child: Vertex!
+        // swiftlint:enable implicitly_unwrapped_optional
     }
 
     // MARK: - EdgeType

--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -265,7 +265,7 @@ public struct CollectedLinter {
     }
 
     private func cachedStyleViolations(benchmark: Bool = false) -> ([StyleViolation], [(id: String, time: Double)])? {
-        let start: Date! = benchmark ? Date() : nil // swiftlint:disable:this implicitly_unwrapped_optional
+        let start = Date()
         guard let cache, let file = file.path,
             let cachedViolations = cache.violations(forFile: file, configuration: configuration) else {
             return nil

--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -265,7 +265,7 @@ public struct CollectedLinter {
     }
 
     private func cachedStyleViolations(benchmark: Bool = false) -> ([StyleViolation], [(id: String, time: Double)])? {
-        let start: Date! = benchmark ? Date() : nil
+        let start: Date! = benchmark ? Date() : nil // swiftlint:disable:this implicitly_unwrapped_optional
         guard let cache, let file = file.path,
             let cachedViolations = cache.violations(forFile: file, configuration: configuration) else {
             return nil

--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -233,11 +233,11 @@ public struct CollectedLinter {
             $0 is SuperfluousDisableCommandRule
         }) as? SuperfluousDisableCommandRule
         let validationResults = rules.parallelCompactMap {
-            $0.lint(file: self.file, regions: regions, benchmark: benchmark,
+            $0.lint(file: file, regions: regions, benchmark: benchmark,
                     storage: storage,
-                    configuration: self.configuration,
+                    configuration: configuration,
                     superfluousDisableCommandRule: superfluousDisableCommandRule,
-                    compilerArguments: self.compilerArguments)
+                    compilerArguments: compilerArguments)
         }
         let undefinedSuperfluousCommandViolations = self.undefinedSuperfluousCommandViolations(
             regions: regions, configuration: configuration,

--- a/Source/SwiftLintCore/Models/RuleConfigurationDescription.swift
+++ b/Source/SwiftLintCore/Models/RuleConfigurationDescription.swift
@@ -531,8 +531,8 @@ extension ConfigurationElement: AnyConfigurationElement {
 
 extension Optional: AcceptableByConfigurationElement where Wrapped: AcceptableByConfigurationElement {
     public func asOption() -> OptionType {
-        if let value = self {
-            return value.asOption()
+        if let self {
+            return self.asOption()
         }
         return .empty
     }

--- a/Source/SwiftLintCore/Models/RuleConfigurationDescription.swift
+++ b/Source/SwiftLintCore/Models/RuleConfigurationDescription.swift
@@ -531,10 +531,7 @@ extension ConfigurationElement: AnyConfigurationElement {
 
 extension Optional: AcceptableByConfigurationElement where Wrapped: AcceptableByConfigurationElement {
     public func asOption() -> OptionType {
-        if let self {
-            return self.asOption()
-        }
-        return .empty
+        self?.asOption() ?? .empty
     }
 
     public init(fromAny value: Any, context ruleID: String) throws {

--- a/Source/SwiftLintCore/Reporters/SummaryReporter.swift
+++ b/Source/SwiftLintCore/Reporters/SummaryReporter.swift
@@ -44,6 +44,7 @@ private extension TextTable {
                 return true
             }
             if count1 == count2 {
+                // swiftlint:disable:next shorthand_argument
                 return $0 < $1
             }
             return false

--- a/Source/SwiftLintCore/Reporters/SummaryReporter.swift
+++ b/Source/SwiftLintCore/Reporters/SummaryReporter.swift
@@ -47,7 +47,7 @@ private extension TextTable {
                 return lhs.key < rhs.key
             }
             return false
-        }.map { $0.key }
+        }.map(\.key)
 
         var totalNumberOfWarnings = 0
         var totalNumberOfErrors = 0

--- a/Source/SwiftLintCore/Reporters/SummaryReporter.swift
+++ b/Source/SwiftLintCore/Reporters/SummaryReporter.swift
@@ -37,18 +37,17 @@ private extension TextTable {
         self.init(columns: columns)
 
         let ruleIdentifiersToViolationsMap = violations.group { $0.ruleIdentifier }
-        let sortedRuleIdentifiers = ruleIdentifiersToViolationsMap.keys.sorted {
-            let count1 = ruleIdentifiersToViolationsMap[$0]?.count ?? 0
-            let count2 = ruleIdentifiersToViolationsMap[$1]?.count ?? 0
+        let sortedRuleIdentifiers = ruleIdentifiersToViolationsMap.sorted { lhs, rhs in
+            let count1 = lhs.value.count
+            let count2 = rhs.value.count
             if count1 > count2 {
                 return true
             }
             if count1 == count2 {
-                // swiftlint:disable:next shorthand_argument
-                return $0 < $1
+                return lhs.key < rhs.key
             }
             return false
-        }
+        }.map { $0.key }
 
         var totalNumberOfWarnings = 0
         var totalNumberOfErrors = 0

--- a/Source/SwiftLintCore/RuleConfigurations/RegexConfiguration.swift
+++ b/Source/SwiftLintCore/RuleConfigurations/RegexConfiguration.swift
@@ -12,7 +12,7 @@ public struct RegexConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration, 
     public var message = "Regex matched"
     /// The regular expression to apply to trigger violations for this custom rule.
     @ConfigurationElement(key: "regex")
-    var regex: RegularExpression!
+    var regex: RegularExpression! // swiftlint:disable:this implicitly_unwrapped_optional
     /// Regular expressions to include when matching the file path.
     public var included: [NSRegularExpression] = []
     /// Regular expressions to exclude when matching the file path.

--- a/Source/swiftlint/Helpers/CompilerArgumentsExtractor.swift
+++ b/Source/swiftlint/Helpers/CompilerArgumentsExtractor.swift
@@ -88,14 +88,14 @@ extension Array where Element == String {
             (args, shouldContinueToFilterArguments) = partiallyFilter(arguments: args)
         }
 
-        return args.filter {
+        return args.filter { arg in
             ![
                 "-parseable-output",
                 "-incremental",
                 "-serialize-diagnostics",
                 "-emit-dependencies",
                 "-use-frontend-parseable-output"
-            ].contains($0) // swiftlint:disable:this shorthand_argument
+            ].contains(arg)
         }.map { arg in
             if arg == "-O" {
                 return "-Onone"

--- a/Source/swiftlint/Helpers/CompilerArgumentsExtractor.swift
+++ b/Source/swiftlint/Helpers/CompilerArgumentsExtractor.swift
@@ -88,7 +88,7 @@ extension Array where Element == String {
             (args, shouldContinueToFilterArguments) = partiallyFilter(arguments: args)
         }
 
-        return args.filter { $0 in
+        return args.filter {
             ![
                 "-parseable-output",
                 "-incremental",

--- a/Source/swiftlint/Helpers/CompilerArgumentsExtractor.swift
+++ b/Source/swiftlint/Helpers/CompilerArgumentsExtractor.swift
@@ -95,7 +95,7 @@ extension Array where Element == String {
                 "-serialize-diagnostics",
                 "-emit-dependencies",
                 "-use-frontend-parseable-output"
-            ].contains($0) // swiftlint:disable:this shorthand_argument
+            ].contains(arg)
         }.map {
             if $0 == "-O" {
                 return "-Onone"
@@ -103,7 +103,7 @@ extension Array where Element == String {
             if $0 == "-DNDEBUG=1" {
                 return "-DDEBUG=1"
             }
-            return $0  // swiftlint:disable:this shorthand_argument
+            return arg
         }
     }
 }

--- a/Source/swiftlint/Helpers/CompilerArgumentsExtractor.swift
+++ b/Source/swiftlint/Helpers/CompilerArgumentsExtractor.swift
@@ -88,14 +88,14 @@ extension Array where Element == String {
             (args, shouldContinueToFilterArguments) = partiallyFilter(arguments: args)
         }
 
-        return args.filter { arg in
+        return args.filter { $0 in
             ![
                 "-parseable-output",
                 "-incremental",
                 "-serialize-diagnostics",
                 "-emit-dependencies",
                 "-use-frontend-parseable-output"
-            ].contains(arg)
+            ].contains($0) // swiftlint:disable:this shorthand_argument
         }.map { arg in
             if arg == "-O" {
                 return "-Onone"

--- a/Source/swiftlint/Helpers/CompilerArgumentsExtractor.swift
+++ b/Source/swiftlint/Helpers/CompilerArgumentsExtractor.swift
@@ -88,7 +88,7 @@ extension Array where Element == String {
             (args, shouldContinueToFilterArguments) = partiallyFilter(arguments: args)
         }
 
-        return args.filter {
+        return args.filter { arg in
             ![
                 "-parseable-output",
                 "-incremental",
@@ -96,11 +96,11 @@ extension Array where Element == String {
                 "-emit-dependencies",
                 "-use-frontend-parseable-output"
             ].contains(arg)
-        }.map {
-            if $0 == "-O" {
+        }.map { arg in
+            if arg == "-O" {
                 return "-Onone"
             }
-            if $0 == "-DNDEBUG=1" {
+            if arg == "-DNDEBUG=1" {
                 return "-DDEBUG=1"
             }
             return arg

--- a/Source/swiftlint/Helpers/CompilerArgumentsExtractor.swift
+++ b/Source/swiftlint/Helpers/CompilerArgumentsExtractor.swift
@@ -95,7 +95,7 @@ extension Array where Element == String {
                 "-serialize-diagnostics",
                 "-emit-dependencies",
                 "-use-frontend-parseable-output"
-            ].contains($0)
+            ].contains($0) // swiftlint:disable:this shorthand_argument
         }.map {
             if $0 == "-O" {
                 return "-Onone"
@@ -103,7 +103,7 @@ extension Array where Element == String {
             if $0 == "-DNDEBUG=1" {
                 return "-DDEBUG=1"
             }
-            return $0
+            return $0  // swiftlint:disable:this shorthand_argument
         }
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests.swift
+++ b/Tests/GeneratedTests/GeneratedTests.swift
@@ -7,1417 +7,1417 @@ import SwiftLintTestHelpers
 // swiftlint:disable:next blanket_disable_command
 // swiftlint:disable file_length single_test_class type_name
 
-class AccessibilityLabelForImageRuleGeneratedTests: SwiftLintTestCase {
+final class AccessibilityLabelForImageRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(AccessibilityLabelForImageRule.description)
     }
 }
 
-class AccessibilityTraitForButtonRuleGeneratedTests: SwiftLintTestCase {
+final class AccessibilityTraitForButtonRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(AccessibilityTraitForButtonRule.description)
     }
 }
 
-class AnonymousArgumentInMultilineClosureRuleGeneratedTests: SwiftLintTestCase {
+final class AnonymousArgumentInMultilineClosureRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(AnonymousArgumentInMultilineClosureRule.description)
     }
 }
 
-class AnyObjectProtocolRuleGeneratedTests: SwiftLintTestCase {
+final class AnyObjectProtocolRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(AnyObjectProtocolRule.description)
     }
 }
 
-class ArrayInitRuleGeneratedTests: SwiftLintTestCase {
+final class ArrayInitRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ArrayInitRule.description)
     }
 }
 
-class AttributesRuleGeneratedTests: SwiftLintTestCase {
+final class AttributesRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(AttributesRule.description)
     }
 }
 
-class BalancedXCTestLifecycleRuleGeneratedTests: SwiftLintTestCase {
+final class BalancedXCTestLifecycleRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(BalancedXCTestLifecycleRule.description)
     }
 }
 
-class BlanketDisableCommandRuleGeneratedTests: SwiftLintTestCase {
+final class BlanketDisableCommandRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(BlanketDisableCommandRule.description)
     }
 }
 
-class BlockBasedKVORuleGeneratedTests: SwiftLintTestCase {
+final class BlockBasedKVORuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(BlockBasedKVORule.description)
     }
 }
 
-class CaptureVariableRuleGeneratedTests: SwiftLintTestCase {
+final class CaptureVariableRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(CaptureVariableRule.description)
     }
 }
 
-class ClassDelegateProtocolRuleGeneratedTests: SwiftLintTestCase {
+final class ClassDelegateProtocolRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ClassDelegateProtocolRule.description)
     }
 }
 
-class ClosingBraceRuleGeneratedTests: SwiftLintTestCase {
+final class ClosingBraceRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ClosingBraceRule.description)
     }
 }
 
-class ClosureBodyLengthRuleGeneratedTests: SwiftLintTestCase {
+final class ClosureBodyLengthRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ClosureBodyLengthRule.description)
     }
 }
 
-class ClosureEndIndentationRuleGeneratedTests: SwiftLintTestCase {
+final class ClosureEndIndentationRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ClosureEndIndentationRule.description)
     }
 }
 
-class ClosureParameterPositionRuleGeneratedTests: SwiftLintTestCase {
+final class ClosureParameterPositionRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ClosureParameterPositionRule.description)
     }
 }
 
-class ClosureSpacingRuleGeneratedTests: SwiftLintTestCase {
+final class ClosureSpacingRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ClosureSpacingRule.description)
     }
 }
 
-class CollectionAlignmentRuleGeneratedTests: SwiftLintTestCase {
+final class CollectionAlignmentRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(CollectionAlignmentRule.description)
     }
 }
 
-class ColonRuleGeneratedTests: SwiftLintTestCase {
+final class ColonRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ColonRule.description)
     }
 }
 
-class CommaInheritanceRuleGeneratedTests: SwiftLintTestCase {
+final class CommaInheritanceRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(CommaInheritanceRule.description)
     }
 }
 
-class CommaRuleGeneratedTests: SwiftLintTestCase {
+final class CommaRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(CommaRule.description)
     }
 }
 
-class CommentSpacingRuleGeneratedTests: SwiftLintTestCase {
+final class CommentSpacingRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(CommentSpacingRule.description)
     }
 }
 
-class CompilerProtocolInitRuleGeneratedTests: SwiftLintTestCase {
+final class CompilerProtocolInitRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(CompilerProtocolInitRule.description)
     }
 }
 
-class ComputedAccessorsOrderRuleGeneratedTests: SwiftLintTestCase {
+final class ComputedAccessorsOrderRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ComputedAccessorsOrderRule.description)
     }
 }
 
-class ConditionalReturnsOnNewlineRuleGeneratedTests: SwiftLintTestCase {
+final class ConditionalReturnsOnNewlineRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ConditionalReturnsOnNewlineRule.description)
     }
 }
 
-class ContainsOverFilterCountRuleGeneratedTests: SwiftLintTestCase {
+final class ContainsOverFilterCountRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ContainsOverFilterCountRule.description)
     }
 }
 
-class ContainsOverFilterIsEmptyRuleGeneratedTests: SwiftLintTestCase {
+final class ContainsOverFilterIsEmptyRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ContainsOverFilterIsEmptyRule.description)
     }
 }
 
-class ContainsOverFirstNotNilRuleGeneratedTests: SwiftLintTestCase {
+final class ContainsOverFirstNotNilRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ContainsOverFirstNotNilRule.description)
     }
 }
 
-class ContainsOverRangeNilComparisonRuleGeneratedTests: SwiftLintTestCase {
+final class ContainsOverRangeNilComparisonRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ContainsOverRangeNilComparisonRule.description)
     }
 }
 
-class ControlStatementRuleGeneratedTests: SwiftLintTestCase {
+final class ControlStatementRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ControlStatementRule.description)
     }
 }
 
-class ConvenienceTypeRuleGeneratedTests: SwiftLintTestCase {
+final class ConvenienceTypeRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ConvenienceTypeRule.description)
     }
 }
 
-class CyclomaticComplexityRuleGeneratedTests: SwiftLintTestCase {
+final class CyclomaticComplexityRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(CyclomaticComplexityRule.description)
     }
 }
 
-class DeploymentTargetRuleGeneratedTests: SwiftLintTestCase {
+final class DeploymentTargetRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(DeploymentTargetRule.description)
     }
 }
 
-class DirectReturnRuleGeneratedTests: SwiftLintTestCase {
+final class DirectReturnRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(DirectReturnRule.description)
     }
 }
 
-class DiscardedNotificationCenterObserverRuleGeneratedTests: SwiftLintTestCase {
+final class DiscardedNotificationCenterObserverRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(DiscardedNotificationCenterObserverRule.description)
     }
 }
 
-class DiscouragedAssertRuleGeneratedTests: SwiftLintTestCase {
+final class DiscouragedAssertRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(DiscouragedAssertRule.description)
     }
 }
 
-class DiscouragedDirectInitRuleGeneratedTests: SwiftLintTestCase {
+final class DiscouragedDirectInitRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(DiscouragedDirectInitRule.description)
     }
 }
 
-class DiscouragedNoneNameRuleGeneratedTests: SwiftLintTestCase {
+final class DiscouragedNoneNameRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(DiscouragedNoneNameRule.description)
     }
 }
 
-class DiscouragedObjectLiteralRuleGeneratedTests: SwiftLintTestCase {
+final class DiscouragedObjectLiteralRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(DiscouragedObjectLiteralRule.description)
     }
 }
 
-class DiscouragedOptionalBooleanRuleGeneratedTests: SwiftLintTestCase {
+final class DiscouragedOptionalBooleanRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(DiscouragedOptionalBooleanRule.description)
     }
 }
 
-class DiscouragedOptionalCollectionRuleGeneratedTests: SwiftLintTestCase {
+final class DiscouragedOptionalCollectionRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(DiscouragedOptionalCollectionRule.description)
     }
 }
 
-class DuplicateConditionsRuleGeneratedTests: SwiftLintTestCase {
+final class DuplicateConditionsRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(DuplicateConditionsRule.description)
     }
 }
 
-class DuplicateEnumCasesRuleGeneratedTests: SwiftLintTestCase {
+final class DuplicateEnumCasesRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(DuplicateEnumCasesRule.description)
     }
 }
 
-class DuplicateImportsRuleGeneratedTests: SwiftLintTestCase {
+final class DuplicateImportsRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(DuplicateImportsRule.description)
     }
 }
 
-class DuplicatedKeyInDictionaryLiteralRuleGeneratedTests: SwiftLintTestCase {
+final class DuplicatedKeyInDictionaryLiteralRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(DuplicatedKeyInDictionaryLiteralRule.description)
     }
 }
 
-class DynamicInlineRuleGeneratedTests: SwiftLintTestCase {
+final class DynamicInlineRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(DynamicInlineRule.description)
     }
 }
 
-class EmptyCollectionLiteralRuleGeneratedTests: SwiftLintTestCase {
+final class EmptyCollectionLiteralRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(EmptyCollectionLiteralRule.description)
     }
 }
 
-class EmptyCountRuleGeneratedTests: SwiftLintTestCase {
+final class EmptyCountRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(EmptyCountRule.description)
     }
 }
 
-class EmptyEnumArgumentsRuleGeneratedTests: SwiftLintTestCase {
+final class EmptyEnumArgumentsRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(EmptyEnumArgumentsRule.description)
     }
 }
 
-class EmptyParametersRuleGeneratedTests: SwiftLintTestCase {
+final class EmptyParametersRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(EmptyParametersRule.description)
     }
 }
 
-class EmptyParenthesesWithTrailingClosureRuleGeneratedTests: SwiftLintTestCase {
+final class EmptyParenthesesWithTrailingClosureRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(EmptyParenthesesWithTrailingClosureRule.description)
     }
 }
 
-class EmptyStringRuleGeneratedTests: SwiftLintTestCase {
+final class EmptyStringRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(EmptyStringRule.description)
     }
 }
 
-class EmptyXCTestMethodRuleGeneratedTests: SwiftLintTestCase {
+final class EmptyXCTestMethodRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(EmptyXCTestMethodRule.description)
     }
 }
 
-class EnumCaseAssociatedValuesLengthRuleGeneratedTests: SwiftLintTestCase {
+final class EnumCaseAssociatedValuesLengthRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(EnumCaseAssociatedValuesLengthRule.description)
     }
 }
 
-class ExpiringTodoRuleGeneratedTests: SwiftLintTestCase {
+final class ExpiringTodoRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ExpiringTodoRule.description)
     }
 }
 
-class ExplicitACLRuleGeneratedTests: SwiftLintTestCase {
+final class ExplicitACLRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ExplicitACLRule.description)
     }
 }
 
-class ExplicitEnumRawValueRuleGeneratedTests: SwiftLintTestCase {
+final class ExplicitEnumRawValueRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ExplicitEnumRawValueRule.description)
     }
 }
 
-class ExplicitInitRuleGeneratedTests: SwiftLintTestCase {
+final class ExplicitInitRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ExplicitInitRule.description)
     }
 }
 
-class ExplicitSelfRuleGeneratedTests: SwiftLintTestCase {
+final class ExplicitSelfRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ExplicitSelfRule.description)
     }
 }
 
-class ExplicitTopLevelACLRuleGeneratedTests: SwiftLintTestCase {
+final class ExplicitTopLevelACLRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ExplicitTopLevelACLRule.description)
     }
 }
 
-class ExplicitTypeInterfaceRuleGeneratedTests: SwiftLintTestCase {
+final class ExplicitTypeInterfaceRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ExplicitTypeInterfaceRule.description)
     }
 }
 
-class ExtensionAccessModifierRuleGeneratedTests: SwiftLintTestCase {
+final class ExtensionAccessModifierRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ExtensionAccessModifierRule.description)
     }
 }
 
-class FallthroughRuleGeneratedTests: SwiftLintTestCase {
+final class FallthroughRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(FallthroughRule.description)
     }
 }
 
-class FatalErrorMessageRuleGeneratedTests: SwiftLintTestCase {
+final class FatalErrorMessageRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(FatalErrorMessageRule.description)
     }
 }
 
-class FileHeaderRuleGeneratedTests: SwiftLintTestCase {
+final class FileHeaderRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(FileHeaderRule.description)
     }
 }
 
-class FileLengthRuleGeneratedTests: SwiftLintTestCase {
+final class FileLengthRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(FileLengthRule.description)
     }
 }
 
-class FileNameNoSpaceRuleGeneratedTests: SwiftLintTestCase {
+final class FileNameNoSpaceRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(FileNameNoSpaceRule.description)
     }
 }
 
-class FileNameRuleGeneratedTests: SwiftLintTestCase {
+final class FileNameRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(FileNameRule.description)
     }
 }
 
-class FileTypesOrderRuleGeneratedTests: SwiftLintTestCase {
+final class FileTypesOrderRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(FileTypesOrderRule.description)
     }
 }
 
-class FinalTestCaseRuleGeneratedTests: SwiftLintTestCase {
+final class FinalTestCaseRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(FinalTestCaseRule.description)
     }
 }
 
-class FirstWhereRuleGeneratedTests: SwiftLintTestCase {
+final class FirstWhereRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(FirstWhereRule.description)
     }
 }
 
-class FlatMapOverMapReduceRuleGeneratedTests: SwiftLintTestCase {
+final class FlatMapOverMapReduceRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(FlatMapOverMapReduceRule.description)
     }
 }
 
-class ForWhereRuleGeneratedTests: SwiftLintTestCase {
+final class ForWhereRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ForWhereRule.description)
     }
 }
 
-class ForceCastRuleGeneratedTests: SwiftLintTestCase {
+final class ForceCastRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ForceCastRule.description)
     }
 }
 
-class ForceTryRuleGeneratedTests: SwiftLintTestCase {
+final class ForceTryRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ForceTryRule.description)
     }
 }
 
-class ForceUnwrappingRuleGeneratedTests: SwiftLintTestCase {
+final class ForceUnwrappingRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ForceUnwrappingRule.description)
     }
 }
 
-class FunctionBodyLengthRuleGeneratedTests: SwiftLintTestCase {
+final class FunctionBodyLengthRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(FunctionBodyLengthRule.description)
     }
 }
 
-class FunctionDefaultParameterAtEndRuleGeneratedTests: SwiftLintTestCase {
+final class FunctionDefaultParameterAtEndRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(FunctionDefaultParameterAtEndRule.description)
     }
 }
 
-class FunctionParameterCountRuleGeneratedTests: SwiftLintTestCase {
+final class FunctionParameterCountRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(FunctionParameterCountRule.description)
     }
 }
 
-class GenericTypeNameRuleGeneratedTests: SwiftLintTestCase {
+final class GenericTypeNameRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(GenericTypeNameRule.description)
     }
 }
 
-class IBInspectableInExtensionRuleGeneratedTests: SwiftLintTestCase {
+final class IBInspectableInExtensionRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(IBInspectableInExtensionRule.description)
     }
 }
 
-class IdenticalOperandsRuleGeneratedTests: SwiftLintTestCase {
+final class IdenticalOperandsRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(IdenticalOperandsRule.description)
     }
 }
 
-class IdentifierNameRuleGeneratedTests: SwiftLintTestCase {
+final class IdentifierNameRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(IdentifierNameRule.description)
     }
 }
 
-class ImplicitGetterRuleGeneratedTests: SwiftLintTestCase {
+final class ImplicitGetterRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ImplicitGetterRule.description)
     }
 }
 
-class ImplicitReturnRuleGeneratedTests: SwiftLintTestCase {
+final class ImplicitReturnRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ImplicitReturnRule.description)
     }
 }
 
-class ImplicitlyUnwrappedOptionalRuleGeneratedTests: SwiftLintTestCase {
+final class ImplicitlyUnwrappedOptionalRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ImplicitlyUnwrappedOptionalRule.description)
     }
 }
 
-class InclusiveLanguageRuleGeneratedTests: SwiftLintTestCase {
+final class InclusiveLanguageRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(InclusiveLanguageRule.description)
     }
 }
 
-class IndentationWidthRuleGeneratedTests: SwiftLintTestCase {
+final class IndentationWidthRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(IndentationWidthRule.description)
     }
 }
 
-class InertDeferRuleGeneratedTests: SwiftLintTestCase {
+final class InertDeferRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(InertDeferRule.description)
     }
 }
 
-class InvalidSwiftLintCommandRuleGeneratedTests: SwiftLintTestCase {
+final class InvalidSwiftLintCommandRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(InvalidSwiftLintCommandRule.description)
     }
 }
 
-class IsDisjointRuleGeneratedTests: SwiftLintTestCase {
+final class IsDisjointRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(IsDisjointRule.description)
     }
 }
 
-class JoinedDefaultParameterRuleGeneratedTests: SwiftLintTestCase {
+final class JoinedDefaultParameterRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(JoinedDefaultParameterRule.description)
     }
 }
 
-class LargeTupleRuleGeneratedTests: SwiftLintTestCase {
+final class LargeTupleRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(LargeTupleRule.description)
     }
 }
 
-class LastWhereRuleGeneratedTests: SwiftLintTestCase {
+final class LastWhereRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(LastWhereRule.description)
     }
 }
 
-class LeadingWhitespaceRuleGeneratedTests: SwiftLintTestCase {
+final class LeadingWhitespaceRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(LeadingWhitespaceRule.description)
     }
 }
 
-class LegacyCGGeometryFunctionsRuleGeneratedTests: SwiftLintTestCase {
+final class LegacyCGGeometryFunctionsRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(LegacyCGGeometryFunctionsRule.description)
     }
 }
 
-class LegacyConstantRuleGeneratedTests: SwiftLintTestCase {
+final class LegacyConstantRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(LegacyConstantRule.description)
     }
 }
 
-class LegacyConstructorRuleGeneratedTests: SwiftLintTestCase {
+final class LegacyConstructorRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(LegacyConstructorRule.description)
     }
 }
 
-class LegacyHashingRuleGeneratedTests: SwiftLintTestCase {
+final class LegacyHashingRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(LegacyHashingRule.description)
     }
 }
 
-class LegacyMultipleRuleGeneratedTests: SwiftLintTestCase {
+final class LegacyMultipleRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(LegacyMultipleRule.description)
     }
 }
 
-class LegacyNSGeometryFunctionsRuleGeneratedTests: SwiftLintTestCase {
+final class LegacyNSGeometryFunctionsRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(LegacyNSGeometryFunctionsRule.description)
     }
 }
 
-class LegacyObjcTypeRuleGeneratedTests: SwiftLintTestCase {
+final class LegacyObjcTypeRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(LegacyObjcTypeRule.description)
     }
 }
 
-class LegacyRandomRuleGeneratedTests: SwiftLintTestCase {
+final class LegacyRandomRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(LegacyRandomRule.description)
     }
 }
 
-class LetVarWhitespaceRuleGeneratedTests: SwiftLintTestCase {
+final class LetVarWhitespaceRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(LetVarWhitespaceRule.description)
     }
 }
 
-class LineLengthRuleGeneratedTests: SwiftLintTestCase {
+final class LineLengthRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(LineLengthRule.description)
     }
 }
 
-class LiteralExpressionEndIndentationRuleGeneratedTests: SwiftLintTestCase {
+final class LiteralExpressionEndIndentationRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(LiteralExpressionEndIndentationRule.description)
     }
 }
 
-class LocalDocCommentRuleGeneratedTests: SwiftLintTestCase {
+final class LocalDocCommentRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(LocalDocCommentRule.description)
     }
 }
 
-class LowerACLThanParentRuleGeneratedTests: SwiftLintTestCase {
+final class LowerACLThanParentRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(LowerACLThanParentRule.description)
     }
 }
 
-class MarkRuleGeneratedTests: SwiftLintTestCase {
+final class MarkRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(MarkRule.description)
     }
 }
 
-class MissingDocsRuleGeneratedTests: SwiftLintTestCase {
+final class MissingDocsRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(MissingDocsRule.description)
     }
 }
 
-class ModifierOrderRuleGeneratedTests: SwiftLintTestCase {
+final class ModifierOrderRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ModifierOrderRule.description)
     }
 }
 
-class MultilineArgumentsBracketsRuleGeneratedTests: SwiftLintTestCase {
+final class MultilineArgumentsBracketsRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(MultilineArgumentsBracketsRule.description)
     }
 }
 
-class MultilineArgumentsRuleGeneratedTests: SwiftLintTestCase {
+final class MultilineArgumentsRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(MultilineArgumentsRule.description)
     }
 }
 
-class MultilineFunctionChainsRuleGeneratedTests: SwiftLintTestCase {
+final class MultilineFunctionChainsRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(MultilineFunctionChainsRule.description)
     }
 }
 
-class MultilineLiteralBracketsRuleGeneratedTests: SwiftLintTestCase {
+final class MultilineLiteralBracketsRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(MultilineLiteralBracketsRule.description)
     }
 }
 
-class MultilineParametersBracketsRuleGeneratedTests: SwiftLintTestCase {
+final class MultilineParametersBracketsRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(MultilineParametersBracketsRule.description)
     }
 }
 
-class MultilineParametersRuleGeneratedTests: SwiftLintTestCase {
+final class MultilineParametersRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(MultilineParametersRule.description)
     }
 }
 
-class MultipleClosuresWithTrailingClosureRuleGeneratedTests: SwiftLintTestCase {
+final class MultipleClosuresWithTrailingClosureRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(MultipleClosuresWithTrailingClosureRule.description)
     }
 }
 
-class NSLocalizedStringKeyRuleGeneratedTests: SwiftLintTestCase {
+final class NSLocalizedStringKeyRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(NSLocalizedStringKeyRule.description)
     }
 }
 
-class NSLocalizedStringRequireBundleRuleGeneratedTests: SwiftLintTestCase {
+final class NSLocalizedStringRequireBundleRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(NSLocalizedStringRequireBundleRule.description)
     }
 }
 
-class NSNumberInitAsFunctionReferenceRuleGeneratedTests: SwiftLintTestCase {
+final class NSNumberInitAsFunctionReferenceRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(NSNumberInitAsFunctionReferenceRule.description)
     }
 }
 
-class NSObjectPreferIsEqualRuleGeneratedTests: SwiftLintTestCase {
+final class NSObjectPreferIsEqualRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(NSObjectPreferIsEqualRule.description)
     }
 }
 
-class NestingRuleGeneratedTests: SwiftLintTestCase {
+final class NestingRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(NestingRule.description)
     }
 }
 
-class NimbleOperatorRuleGeneratedTests: SwiftLintTestCase {
+final class NimbleOperatorRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(NimbleOperatorRule.description)
     }
 }
 
-class NoExtensionAccessModifierRuleGeneratedTests: SwiftLintTestCase {
+final class NoExtensionAccessModifierRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(NoExtensionAccessModifierRule.description)
     }
 }
 
-class NoFallthroughOnlyRuleGeneratedTests: SwiftLintTestCase {
+final class NoFallthroughOnlyRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(NoFallthroughOnlyRule.description)
     }
 }
 
-class NoGroupingExtensionRuleGeneratedTests: SwiftLintTestCase {
+final class NoGroupingExtensionRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(NoGroupingExtensionRule.description)
     }
 }
 
-class NoMagicNumbersRuleGeneratedTests: SwiftLintTestCase {
+final class NoMagicNumbersRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(NoMagicNumbersRule.description)
     }
 }
 
-class NoSpaceInMethodCallRuleGeneratedTests: SwiftLintTestCase {
+final class NoSpaceInMethodCallRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(NoSpaceInMethodCallRule.description)
     }
 }
 
-class NonOptionalStringDataConversionRuleGeneratedTests: SwiftLintTestCase {
+final class NonOptionalStringDataConversionRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(NonOptionalStringDataConversionRule.description)
     }
 }
 
-class NonOverridableClassDeclarationRuleGeneratedTests: SwiftLintTestCase {
+final class NonOverridableClassDeclarationRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(NonOverridableClassDeclarationRule.description)
     }
 }
 
-class NotificationCenterDetachmentRuleGeneratedTests: SwiftLintTestCase {
+final class NotificationCenterDetachmentRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(NotificationCenterDetachmentRule.description)
     }
 }
 
-class NumberSeparatorRuleGeneratedTests: SwiftLintTestCase {
+final class NumberSeparatorRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(NumberSeparatorRule.description)
     }
 }
 
-class ObjectLiteralRuleGeneratedTests: SwiftLintTestCase {
+final class ObjectLiteralRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ObjectLiteralRule.description)
     }
 }
 
-class OneDelarationPerFileRuleGeneratedTests: SwiftLintTestCase {
+final class OneDelarationPerFileRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(OneDelarationPerFileRule.description)
     }
 }
 
-class OpeningBraceRuleGeneratedTests: SwiftLintTestCase {
+final class OpeningBraceRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(OpeningBraceRule.description)
     }
 }
 
-class OperatorFunctionWhitespaceRuleGeneratedTests: SwiftLintTestCase {
+final class OperatorFunctionWhitespaceRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(OperatorFunctionWhitespaceRule.description)
     }
 }
 
-class OperatorUsageWhitespaceRuleGeneratedTests: SwiftLintTestCase {
+final class OperatorUsageWhitespaceRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(OperatorUsageWhitespaceRule.description)
     }
 }
 
-class OptionalEnumCaseMatchingRuleGeneratedTests: SwiftLintTestCase {
+final class OptionalEnumCaseMatchingRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(OptionalEnumCaseMatchingRule.description)
     }
 }
 
-class OrphanedDocCommentRuleGeneratedTests: SwiftLintTestCase {
+final class OrphanedDocCommentRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(OrphanedDocCommentRule.description)
     }
 }
 
-class OverriddenSuperCallRuleGeneratedTests: SwiftLintTestCase {
+final class OverriddenSuperCallRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(OverriddenSuperCallRule.description)
     }
 }
 
-class OverrideInExtensionRuleGeneratedTests: SwiftLintTestCase {
+final class OverrideInExtensionRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(OverrideInExtensionRule.description)
     }
 }
 
-class PatternMatchingKeywordsRuleGeneratedTests: SwiftLintTestCase {
+final class PatternMatchingKeywordsRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(PatternMatchingKeywordsRule.description)
     }
 }
 
-class PeriodSpacingRuleGeneratedTests: SwiftLintTestCase {
+final class PeriodSpacingRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(PeriodSpacingRule.description)
     }
 }
 
-class PreferNimbleRuleGeneratedTests: SwiftLintTestCase {
+final class PreferNimbleRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(PreferNimbleRule.description)
     }
 }
 
-class PreferSelfInStaticReferencesRuleGeneratedTests: SwiftLintTestCase {
+final class PreferSelfInStaticReferencesRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(PreferSelfInStaticReferencesRule.description)
     }
 }
 
-class PreferSelfTypeOverTypeOfSelfRuleGeneratedTests: SwiftLintTestCase {
+final class PreferSelfTypeOverTypeOfSelfRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(PreferSelfTypeOverTypeOfSelfRule.description)
     }
 }
 
-class PreferZeroOverExplicitInitRuleGeneratedTests: SwiftLintTestCase {
+final class PreferZeroOverExplicitInitRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(PreferZeroOverExplicitInitRule.description)
     }
 }
 
-class PrefixedTopLevelConstantRuleGeneratedTests: SwiftLintTestCase {
+final class PrefixedTopLevelConstantRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(PrefixedTopLevelConstantRule.description)
     }
 }
 
-class PrivateActionRuleGeneratedTests: SwiftLintTestCase {
+final class PrivateActionRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(PrivateActionRule.description)
     }
 }
 
-class PrivateOutletRuleGeneratedTests: SwiftLintTestCase {
+final class PrivateOutletRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(PrivateOutletRule.description)
     }
 }
 
-class PrivateOverFilePrivateRuleGeneratedTests: SwiftLintTestCase {
+final class PrivateOverFilePrivateRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(PrivateOverFilePrivateRule.description)
     }
 }
 
-class PrivateSubjectRuleGeneratedTests: SwiftLintTestCase {
+final class PrivateSubjectRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(PrivateSubjectRule.description)
     }
 }
 
-class PrivateSwiftUIStatePropertyRuleGeneratedTests: SwiftLintTestCase {
+final class PrivateSwiftUIStatePropertyRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(PrivateSwiftUIStatePropertyRule.description)
     }
 }
 
-class PrivateUnitTestRuleGeneratedTests: SwiftLintTestCase {
+final class PrivateUnitTestRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(PrivateUnitTestRule.description)
     }
 }
 
-class ProhibitedInterfaceBuilderRuleGeneratedTests: SwiftLintTestCase {
+final class ProhibitedInterfaceBuilderRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ProhibitedInterfaceBuilderRule.description)
     }
 }
 
-class ProhibitedSuperRuleGeneratedTests: SwiftLintTestCase {
+final class ProhibitedSuperRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ProhibitedSuperRule.description)
     }
 }
 
-class ProtocolPropertyAccessorsOrderRuleGeneratedTests: SwiftLintTestCase {
+final class ProtocolPropertyAccessorsOrderRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ProtocolPropertyAccessorsOrderRule.description)
     }
 }
 
-class QuickDiscouragedCallRuleGeneratedTests: SwiftLintTestCase {
+final class QuickDiscouragedCallRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(QuickDiscouragedCallRule.description)
     }
 }
 
-class QuickDiscouragedFocusedTestRuleGeneratedTests: SwiftLintTestCase {
+final class QuickDiscouragedFocusedTestRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(QuickDiscouragedFocusedTestRule.description)
     }
 }
 
-class QuickDiscouragedPendingTestRuleGeneratedTests: SwiftLintTestCase {
+final class QuickDiscouragedPendingTestRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(QuickDiscouragedPendingTestRule.description)
     }
 }
 
-class RawValueForCamelCasedCodableEnumRuleGeneratedTests: SwiftLintTestCase {
+final class RawValueForCamelCasedCodableEnumRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(RawValueForCamelCasedCodableEnumRule.description)
     }
 }
 
-class ReduceBooleanRuleGeneratedTests: SwiftLintTestCase {
+final class ReduceBooleanRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ReduceBooleanRule.description)
     }
 }
 
-class ReduceIntoRuleGeneratedTests: SwiftLintTestCase {
+final class ReduceIntoRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ReduceIntoRule.description)
     }
 }
 
-class RedundantDiscardableLetRuleGeneratedTests: SwiftLintTestCase {
+final class RedundantDiscardableLetRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(RedundantDiscardableLetRule.description)
     }
 }
 
-class RedundantNilCoalescingRuleGeneratedTests: SwiftLintTestCase {
+final class RedundantNilCoalescingRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(RedundantNilCoalescingRule.description)
     }
 }
 
-class RedundantObjcAttributeRuleGeneratedTests: SwiftLintTestCase {
+final class RedundantObjcAttributeRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(RedundantObjcAttributeRule.description)
     }
 }
 
-class RedundantOptionalInitializationRuleGeneratedTests: SwiftLintTestCase {
+final class RedundantOptionalInitializationRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(RedundantOptionalInitializationRule.description)
     }
 }
 
-class RedundantSelfInClosureRuleGeneratedTests: SwiftLintTestCase {
+final class RedundantSelfInClosureRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(RedundantSelfInClosureRule.description)
     }
 }
 
-class RedundantSetAccessControlRuleGeneratedTests: SwiftLintTestCase {
+final class RedundantSetAccessControlRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(RedundantSetAccessControlRule.description)
     }
 }
 
-class RedundantStringEnumValueRuleGeneratedTests: SwiftLintTestCase {
+final class RedundantStringEnumValueRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(RedundantStringEnumValueRule.description)
     }
 }
 
-class RedundantTypeAnnotationRuleGeneratedTests: SwiftLintTestCase {
+final class RedundantTypeAnnotationRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(RedundantTypeAnnotationRule.description)
     }
 }
 
-class RedundantVoidReturnRuleGeneratedTests: SwiftLintTestCase {
+final class RedundantVoidReturnRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(RedundantVoidReturnRule.description)
     }
 }
 
-class RequiredDeinitRuleGeneratedTests: SwiftLintTestCase {
+final class RequiredDeinitRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(RequiredDeinitRule.description)
     }
 }
 
-class RequiredEnumCaseRuleGeneratedTests: SwiftLintTestCase {
+final class RequiredEnumCaseRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(RequiredEnumCaseRule.description)
     }
 }
 
-class ReturnArrowWhitespaceRuleGeneratedTests: SwiftLintTestCase {
+final class ReturnArrowWhitespaceRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ReturnArrowWhitespaceRule.description)
     }
 }
 
-class ReturnValueFromVoidFunctionRuleGeneratedTests: SwiftLintTestCase {
+final class ReturnValueFromVoidFunctionRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ReturnValueFromVoidFunctionRule.description)
     }
 }
 
-class SelfBindingRuleGeneratedTests: SwiftLintTestCase {
+final class SelfBindingRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(SelfBindingRule.description)
     }
 }
 
-class SelfInPropertyInitializationRuleGeneratedTests: SwiftLintTestCase {
+final class SelfInPropertyInitializationRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(SelfInPropertyInitializationRule.description)
     }
 }
 
-class ShorthandArgumentRuleGeneratedTests: SwiftLintTestCase {
+final class ShorthandArgumentRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ShorthandArgumentRule.description)
     }
 }
 
-class ShorthandOperatorRuleGeneratedTests: SwiftLintTestCase {
+final class ShorthandOperatorRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ShorthandOperatorRule.description)
     }
 }
 
-class ShorthandOptionalBindingRuleGeneratedTests: SwiftLintTestCase {
+final class ShorthandOptionalBindingRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ShorthandOptionalBindingRule.description)
     }
 }
 
-class SingleTestClassRuleGeneratedTests: SwiftLintTestCase {
+final class SingleTestClassRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(SingleTestClassRule.description)
     }
 }
 
-class SortedEnumCasesRuleGeneratedTests: SwiftLintTestCase {
+final class SortedEnumCasesRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(SortedEnumCasesRule.description)
     }
 }
 
-class SortedFirstLastRuleGeneratedTests: SwiftLintTestCase {
+final class SortedFirstLastRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(SortedFirstLastRule.description)
     }
 }
 
-class SortedImportsRuleGeneratedTests: SwiftLintTestCase {
+final class SortedImportsRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(SortedImportsRule.description)
     }
 }
 
-class StatementPositionRuleGeneratedTests: SwiftLintTestCase {
+final class StatementPositionRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(StatementPositionRule.description)
     }
 }
 
-class StaticOperatorRuleGeneratedTests: SwiftLintTestCase {
+final class StaticOperatorRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(StaticOperatorRule.description)
     }
 }
 
-class StaticOverFinalClassRuleGeneratedTests: SwiftLintTestCase {
+final class StaticOverFinalClassRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(StaticOverFinalClassRule.description)
     }
 }
 
-class StrictFilePrivateRuleGeneratedTests: SwiftLintTestCase {
+final class StrictFilePrivateRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(StrictFilePrivateRule.description)
     }
 }
 
-class StrongIBOutletRuleGeneratedTests: SwiftLintTestCase {
+final class StrongIBOutletRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(StrongIBOutletRule.description)
     }
 }
 
-class SuperfluousElseRuleGeneratedTests: SwiftLintTestCase {
+final class SuperfluousElseRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(SuperfluousElseRule.description)
     }
 }
 
-class SwitchCaseAlignmentRuleGeneratedTests: SwiftLintTestCase {
+final class SwitchCaseAlignmentRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(SwitchCaseAlignmentRule.description)
     }
 }
 
-class SwitchCaseOnNewlineRuleGeneratedTests: SwiftLintTestCase {
+final class SwitchCaseOnNewlineRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(SwitchCaseOnNewlineRule.description)
     }
 }
 
-class SyntacticSugarRuleGeneratedTests: SwiftLintTestCase {
+final class SyntacticSugarRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(SyntacticSugarRule.description)
     }
 }
 
-class TestCaseAccessibilityRuleGeneratedTests: SwiftLintTestCase {
+final class TestCaseAccessibilityRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(TestCaseAccessibilityRule.description)
     }
 }
 
-class TodoRuleGeneratedTests: SwiftLintTestCase {
+final class TodoRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(TodoRule.description)
     }
 }
 
-class ToggleBoolRuleGeneratedTests: SwiftLintTestCase {
+final class ToggleBoolRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ToggleBoolRule.description)
     }
 }
 
-class TrailingClosureRuleGeneratedTests: SwiftLintTestCase {
+final class TrailingClosureRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(TrailingClosureRule.description)
     }
 }
 
-class TrailingCommaRuleGeneratedTests: SwiftLintTestCase {
+final class TrailingCommaRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(TrailingCommaRule.description)
     }
 }
 
-class TrailingNewlineRuleGeneratedTests: SwiftLintTestCase {
+final class TrailingNewlineRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(TrailingNewlineRule.description)
     }
 }
 
-class TrailingSemicolonRuleGeneratedTests: SwiftLintTestCase {
+final class TrailingSemicolonRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(TrailingSemicolonRule.description)
     }
 }
 
-class TrailingWhitespaceRuleGeneratedTests: SwiftLintTestCase {
+final class TrailingWhitespaceRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(TrailingWhitespaceRule.description)
     }
 }
 
-class TypeBodyLengthRuleGeneratedTests: SwiftLintTestCase {
+final class TypeBodyLengthRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(TypeBodyLengthRule.description)
     }
 }
 
-class TypeContentsOrderRuleGeneratedTests: SwiftLintTestCase {
+final class TypeContentsOrderRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(TypeContentsOrderRule.description)
     }
 }
 
-class TypeNameRuleGeneratedTests: SwiftLintTestCase {
+final class TypeNameRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(TypeNameRule.description)
     }
 }
 
-class TypesafeArrayInitRuleGeneratedTests: SwiftLintTestCase {
+final class TypesafeArrayInitRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(TypesafeArrayInitRule.description)
     }
 }
 
-class UnavailableConditionRuleGeneratedTests: SwiftLintTestCase {
+final class UnavailableConditionRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(UnavailableConditionRule.description)
     }
 }
 
-class UnavailableFunctionRuleGeneratedTests: SwiftLintTestCase {
+final class UnavailableFunctionRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(UnavailableFunctionRule.description)
     }
 }
 
-class UnhandledThrowingTaskRuleGeneratedTests: SwiftLintTestCase {
+final class UnhandledThrowingTaskRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(UnhandledThrowingTaskRule.description)
     }
 }
 
-class UnneededBreakInSwitchRuleGeneratedTests: SwiftLintTestCase {
+final class UnneededBreakInSwitchRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(UnneededBreakInSwitchRule.description)
     }
 }
 
-class UnneededOverrideRuleGeneratedTests: SwiftLintTestCase {
+final class UnneededOverrideRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(UnneededOverrideRule.description)
     }
 }
 
-class UnneededParenthesesInClosureArgumentRuleGeneratedTests: SwiftLintTestCase {
+final class UnneededParenthesesInClosureArgumentRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(UnneededParenthesesInClosureArgumentRule.description)
     }
 }
 
-class UnneededSynthesizedInitializerRuleGeneratedTests: SwiftLintTestCase {
+final class UnneededSynthesizedInitializerRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(UnneededSynthesizedInitializerRule.description)
     }
 }
 
-class UnownedVariableCaptureRuleGeneratedTests: SwiftLintTestCase {
+final class UnownedVariableCaptureRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(UnownedVariableCaptureRule.description)
     }
 }
 
-class UntypedErrorInCatchRuleGeneratedTests: SwiftLintTestCase {
+final class UntypedErrorInCatchRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(UntypedErrorInCatchRule.description)
     }
 }
 
-class UnusedCaptureListRuleGeneratedTests: SwiftLintTestCase {
+final class UnusedCaptureListRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(UnusedCaptureListRule.description)
     }
 }
 
-class UnusedClosureParameterRuleGeneratedTests: SwiftLintTestCase {
+final class UnusedClosureParameterRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(UnusedClosureParameterRule.description)
     }
 }
 
-class UnusedControlFlowLabelRuleGeneratedTests: SwiftLintTestCase {
+final class UnusedControlFlowLabelRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(UnusedControlFlowLabelRule.description)
     }
 }
 
-class UnusedDeclarationRuleGeneratedTests: SwiftLintTestCase {
+final class UnusedDeclarationRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(UnusedDeclarationRule.description)
     }
 }
 
-class UnusedEnumeratedRuleGeneratedTests: SwiftLintTestCase {
+final class UnusedEnumeratedRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(UnusedEnumeratedRule.description)
     }
 }
 
-class UnusedImportRuleGeneratedTests: SwiftLintTestCase {
+final class UnusedImportRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(UnusedImportRule.description)
     }
 }
 
-class UnusedOptionalBindingRuleGeneratedTests: SwiftLintTestCase {
+final class UnusedOptionalBindingRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(UnusedOptionalBindingRule.description)
     }
 }
 
-class UnusedSetterValueRuleGeneratedTests: SwiftLintTestCase {
+final class UnusedSetterValueRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(UnusedSetterValueRule.description)
     }
 }
 
-class ValidIBInspectableRuleGeneratedTests: SwiftLintTestCase {
+final class ValidIBInspectableRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ValidIBInspectableRule.description)
     }
 }
 
-class VerticalParameterAlignmentOnCallRuleGeneratedTests: SwiftLintTestCase {
+final class VerticalParameterAlignmentOnCallRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(VerticalParameterAlignmentOnCallRule.description)
     }
 }
 
-class VerticalParameterAlignmentRuleGeneratedTests: SwiftLintTestCase {
+final class VerticalParameterAlignmentRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(VerticalParameterAlignmentRule.description)
     }
 }
 
-class VerticalWhitespaceBetweenCasesRuleGeneratedTests: SwiftLintTestCase {
+final class VerticalWhitespaceBetweenCasesRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(VerticalWhitespaceBetweenCasesRule.description)
     }
 }
 
-class VerticalWhitespaceClosingBracesRuleGeneratedTests: SwiftLintTestCase {
+final class VerticalWhitespaceClosingBracesRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(VerticalWhitespaceClosingBracesRule.description)
     }
 }
 
-class VerticalWhitespaceOpeningBracesRuleGeneratedTests: SwiftLintTestCase {
+final class VerticalWhitespaceOpeningBracesRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(VerticalWhitespaceOpeningBracesRule.description)
     }
 }
 
-class VerticalWhitespaceRuleGeneratedTests: SwiftLintTestCase {
+final class VerticalWhitespaceRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(VerticalWhitespaceRule.description)
     }
 }
 
-class VoidFunctionInTernaryConditionRuleGeneratedTests: SwiftLintTestCase {
+final class VoidFunctionInTernaryConditionRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(VoidFunctionInTernaryConditionRule.description)
     }
 }
 
-class VoidReturnRuleGeneratedTests: SwiftLintTestCase {
+final class VoidReturnRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(VoidReturnRule.description)
     }
 }
 
-class WeakDelegateRuleGeneratedTests: SwiftLintTestCase {
+final class WeakDelegateRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(WeakDelegateRule.description)
     }
 }
 
-class XCTFailMessageRuleGeneratedTests: SwiftLintTestCase {
+final class XCTFailMessageRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(XCTFailMessageRule.description)
     }
 }
 
-class XCTSpecificMatcherRuleGeneratedTests: SwiftLintTestCase {
+final class XCTSpecificMatcherRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(XCTSpecificMatcherRule.description)
     }
 }
 
-class YodaConditionRuleGeneratedTests: SwiftLintTestCase {
+final class YodaConditionRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(YodaConditionRule.description)
     }

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -13,7 +13,7 @@ private let config: Configuration = {
     return Configuration(configurationFiles: [Configuration.defaultFileName])
 }()
 
-class IntegrationTests: SwiftLintTestCase {
+final class IntegrationTests: SwiftLintTestCase {
     func testSwiftLintLints() {
         // This is as close as we're ever going to get to a self-hosting linter.
         let swiftFiles = config.lintableFiles(

--- a/Tests/SwiftLintFrameworkTests/AccessControlLevelTests.swift
+++ b/Tests/SwiftLintFrameworkTests/AccessControlLevelTests.swift
@@ -1,7 +1,7 @@
 import SwiftLintCore
 import XCTest
 
-class AccessControlLevelTests: SwiftLintTestCase {
+final class AccessControlLevelTests: SwiftLintTestCase {
     func testDescription() {
         XCTAssertEqual(AccessControlLevel.private.description, "private")
         XCTAssertEqual(AccessControlLevel.fileprivate.description, "fileprivate")

--- a/Tests/SwiftLintFrameworkTests/AttributesRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/AttributesRuleTests.swift
@@ -1,6 +1,6 @@
 @testable import SwiftLintBuiltInRules
 
-class AttributesRuleTests: SwiftLintTestCase {
+final class AttributesRuleTests: SwiftLintTestCase {
     func testAttributesWithAlwaysOnSameLine() {
         // Test with custom `always_on_same_line`
         let nonTriggeringExamples = [

--- a/Tests/SwiftLintFrameworkTests/BlanketDisableCommandRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/BlanketDisableCommandRuleTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftLintBuiltInRules
 import XCTest
 
-class BlanketDisableCommandRuleTests: SwiftLintTestCase {
+final class BlanketDisableCommandRuleTests: SwiftLintTestCase {
     private lazy var emptyDescription = BlanketDisableCommandRule.description
         .with(triggeringExamples: [])
         .with(nonTriggeringExamples: [])

--- a/Tests/SwiftLintFrameworkTests/ChildOptionSeverityConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ChildOptionSeverityConfigurationTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftLintBuiltInRules
 import XCTest
 
-class ChildOptionSeverityConfigurationTests: SwiftLintTestCase {
+final class ChildOptionSeverityConfigurationTests: SwiftLintTestCase {
     typealias TesteeType = ChildOptionSeverityConfiguration<RuleMock>
 
     func testSeverity() {

--- a/Tests/SwiftLintFrameworkTests/CodeIndentingRewriterTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CodeIndentingRewriterTests.swift
@@ -3,7 +3,7 @@ import SwiftParser
 import SwiftSyntax
 import XCTest
 
-class CodeIndentingRewriterTests: XCTestCase {
+final class CodeIndentingRewriterTests: XCTestCase {
     func testIndentDefaultStyle() {
         assertIndent(
             source: """

--- a/Tests/SwiftLintFrameworkTests/CollectingRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CollectingRuleTests.swift
@@ -2,7 +2,7 @@
 import SwiftLintTestHelpers
 import XCTest
 
-class CollectingRuleTests: SwiftLintTestCase {
+final class CollectingRuleTests: SwiftLintTestCase {
     func testCollectsIntoStorage() {
         struct Spec: MockCollectingRule {
             var configuration = SeverityConfiguration<Self>(.warning)

--- a/Tests/SwiftLintFrameworkTests/CollectionAlignmentRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CollectionAlignmentRuleTests.swift
@@ -1,6 +1,6 @@
 @testable import SwiftLintBuiltInRules
 
-class CollectionAlignmentRuleTests: SwiftLintTestCase {
+final class CollectionAlignmentRuleTests: SwiftLintTestCase {
     func testCollectionAlignmentWithAlignLeft() {
         let baseDescription = CollectionAlignmentRule.description
         let examples = CollectionAlignmentRule.Examples(alignColons: false)

--- a/Tests/SwiftLintFrameworkTests/ColonRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ColonRuleTests.swift
@@ -1,6 +1,6 @@
 @testable import SwiftLintBuiltInRules
 
-class ColonRuleTests: SwiftLintTestCase {
+final class ColonRuleTests: SwiftLintTestCase {
     func testColonWithFlexibleRightSpace() {
         // Verify Colon rule with test values for when flexible_right_spacing
         // is true.

--- a/Tests/SwiftLintFrameworkTests/CommandTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CommandTests.swift
@@ -15,7 +15,7 @@ private extension Command {
 }
 
 // swiftlint:disable:next type_body_length
-class CommandTests: SwiftLintTestCase {
+final class CommandTests: SwiftLintTestCase {
     // MARK: Command Creation
 
     func testNoCommandsInEmptyFile() {

--- a/Tests/SwiftLintFrameworkTests/CompilerProtocolInitRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CompilerProtocolInitRuleTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftLintBuiltInRules
 import XCTest
 
-class CompilerProtocolInitRuleTests: SwiftLintTestCase {
+final class CompilerProtocolInitRuleTests: SwiftLintTestCase {
     private let ruleID = CompilerProtocolInitRule.description.identifier
 
     func testViolationMessageForExpressibleByIntegerLiteral() throws {

--- a/Tests/SwiftLintFrameworkTests/ComputedAccessorsOrderRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ComputedAccessorsOrderRuleTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftLintBuiltInRules
 import XCTest
 
-class ComputedAccessorsOrderRuleTests: SwiftLintTestCase {
+final class ComputedAccessorsOrderRuleTests: SwiftLintTestCase {
     func testSetGetConfiguration() {
         let nonTriggeringExamples = [
             Example("""

--- a/Tests/SwiftLintFrameworkTests/ConditionalReturnsOnNewlineRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConditionalReturnsOnNewlineRuleTests.swift
@@ -1,6 +1,6 @@
 @testable import SwiftLintBuiltInRules
 
-class ConditionalReturnsOnNewlineRuleTests: SwiftLintTestCase {
+final class ConditionalReturnsOnNewlineRuleTests: SwiftLintTestCase {
     func testConditionalReturnsOnNewlineWithIfOnly() {
         // Test with `if_only` set to true
         let nonTriggeringExamples = [

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 private let optInRules = RuleRegistry.shared.list.list.filter({ $0.1.init() is any OptInRule }).map({ $0.0 })
 
-class ConfigurationTests: SwiftLintTestCase {
+final class ConfigurationTests: SwiftLintTestCase {
     // MARK: Setup & Teardown
     private var previousWorkingDir: String! // swiftlint:disable:this implicitly_unwrapped_optional
 

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -9,7 +9,7 @@ private let optInRules = RuleRegistry.shared.list.list.filter({ $0.1.init() is a
 
 class ConfigurationTests: SwiftLintTestCase {
     // MARK: Setup & Teardown
-    private var previousWorkingDir: String!
+    private var previousWorkingDir: String! // swiftlint:disable:this implicitly_unwrapped_optional
 
     override func setUp() {
         super.setUp()

--- a/Tests/SwiftLintFrameworkTests/ContainsOverFirstNotNilRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ContainsOverFirstNotNilRuleTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftLintBuiltInRules
 import XCTest
 
-class ContainsOverFirstNotNilRuleTests: SwiftLintTestCase {
+final class ContainsOverFirstNotNilRuleTests: SwiftLintTestCase {
     func testFirstReason() {
         let example = Example("↓myList.first { $0 % 2 == 0 } != nil")
         let violations = self.violations(example)

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -2,7 +2,7 @@ import SourceKittenFramework
 @testable import SwiftLintCore
 import XCTest
 
-class CustomRulesTests: SwiftLintTestCase {
+final class CustomRulesTests: SwiftLintTestCase {
     typealias Configuration = RegexConfiguration<CustomRules>
     func testCustomRuleConfigurationSetsCorrectlyWithMatchKinds() {
         let configDict = [

--- a/Tests/SwiftLintFrameworkTests/CyclomaticComplexityConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CyclomaticComplexityConfigurationTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftLintBuiltInRules
 import XCTest
 
-class CyclomaticComplexityConfigurationTests: SwiftLintTestCase {
+final class CyclomaticComplexityConfigurationTests: SwiftLintTestCase {
     func testCyclomaticComplexityConfigurationInitializerSetsLevels() {
         let warning = 10
         let error = 30

--- a/Tests/SwiftLintFrameworkTests/CyclomaticComplexityRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CyclomaticComplexityRuleTests.swift
@@ -1,6 +1,6 @@
 @testable import SwiftLintBuiltInRules
 
-class CyclomaticComplexityRuleTests: SwiftLintTestCase {
+final class CyclomaticComplexityRuleTests: SwiftLintTestCase {
     private lazy var complexSwitchExample: Example = {
         var example = "func switcheroo() {\n"
         example += "    switch foo {\n"

--- a/Tests/SwiftLintFrameworkTests/DeploymentTargetConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/DeploymentTargetConfigurationTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftLintBuiltInRules
 import XCTest
 
-class DeploymentTargetConfigurationTests: SwiftLintTestCase {
+final class DeploymentTargetConfigurationTests: SwiftLintTestCase {
     private typealias Version = DeploymentTargetConfiguration.Version
 
     // swiftlint:disable:next function_body_length

--- a/Tests/SwiftLintFrameworkTests/DeploymentTargetRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/DeploymentTargetRuleTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftLintBuiltInRules
 import XCTest
 
-class DeploymentTargetRuleTests: SwiftLintTestCase {
+final class DeploymentTargetRuleTests: SwiftLintTestCase {
     func testMacOSAttributeReason() {
         let example = Example("@available(macOS 10.11, *)\nclass A {}")
         let violations = self.violations(example, config: ["macOS_deployment_target": "10.14.0"])

--- a/Tests/SwiftLintFrameworkTests/DisableAllTests.swift
+++ b/Tests/SwiftLintFrameworkTests/DisableAllTests.swift
@@ -1,7 +1,7 @@
 import SwiftLintFramework
 import XCTest
 
-class DisableAllTests: SwiftLintTestCase {
+final class DisableAllTests: SwiftLintTestCase {
     /// Example violations. Could be replaced with other single violations.
     private let violatingPhrases = [
         Example("let r = 0"), // Violates identifier_name

--- a/Tests/SwiftLintFrameworkTests/DiscouragedDirectInitRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/DiscouragedDirectInitRuleTests.swift
@@ -1,6 +1,6 @@
 @testable import SwiftLintBuiltInRules
 
-class DiscouragedDirectInitRuleTests: SwiftLintTestCase {
+final class DiscouragedDirectInitRuleTests: SwiftLintTestCase {
     private let baseDescription = DiscouragedDirectInitRule.description
 
     func testDiscouragedDirectInitWithConfiguredSeverity() {

--- a/Tests/SwiftLintFrameworkTests/DiscouragedObjectLiteralRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/DiscouragedObjectLiteralRuleTests.swift
@@ -1,6 +1,6 @@
 @testable import SwiftLintBuiltInRules
 
-class DiscouragedObjectLiteralRuleTests: SwiftLintTestCase {
+final class DiscouragedObjectLiteralRuleTests: SwiftLintTestCase {
     func testWithImageLiteral() {
         let baseDescription = DiscouragedObjectLiteralRule.description
         let nonTriggeringExamples = baseDescription.nonTriggeringExamples + [

--- a/Tests/SwiftLintFrameworkTests/DuplicateImportsRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/DuplicateImportsRuleTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftLintBuiltInRules
 import XCTest
 
-class DuplicateImportsRuleTests: XCTestCase {
+final class DuplicateImportsRuleTests: XCTestCase {
     func testDisableCommand() {
         let content = """
             import InspireAPI

--- a/Tests/SwiftLintFrameworkTests/EmptyCountRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/EmptyCountRuleTests.swift
@@ -1,6 +1,6 @@
 @testable import SwiftLintBuiltInRules
 
-class EmptyCountRuleTests: SwiftLintTestCase {
+final class EmptyCountRuleTests: SwiftLintTestCase {
     func testEmptyCountWithOnlyAfterDot() {
         // Test with `only_after_dot` set to true
         let nonTriggeringExamples = [

--- a/Tests/SwiftLintFrameworkTests/ExampleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExampleTests.swift
@@ -1,7 +1,7 @@
 import SwiftLintFramework
 import XCTest
 
-class ExampleTests: SwiftLintTestCase {
+final class ExampleTests: SwiftLintTestCase {
     func testEquatableDoesNotLookAtFile() {
         let first = Example("foo", file: "a", line: 1)
         let second = Example("foo", file: "b", line: 1)

--- a/Tests/SwiftLintFrameworkTests/ExpiringTodoRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExpiringTodoRuleTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftLintBuiltInRules
 import XCTest
 
-class ExpiringTodoRuleTests: SwiftLintTestCase {
+final class ExpiringTodoRuleTests: SwiftLintTestCase {
     private lazy var config: Configuration = makeConfiguration()
 
     func testExpiringTodo() {

--- a/Tests/SwiftLintFrameworkTests/ExplicitInitRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExplicitInitRuleTests.swift
@@ -1,6 +1,6 @@
 @testable import SwiftLintBuiltInRules
 
-class ExplicitInitRuleTests: SwiftLintTestCase {
+final class ExplicitInitRuleTests: SwiftLintTestCase {
     func testIncludeBareInit() {
         let nonTriggeringExamples = [
             Example("let foo = Foo()"),

--- a/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceConfigurationTests.swift
@@ -2,7 +2,7 @@
 @testable import SwiftLintCore
 import XCTest
 
-class ExplicitTypeInterfaceConfigurationTests: SwiftLintTestCase {
+final class ExplicitTypeInterfaceConfigurationTests: SwiftLintTestCase {
     func testDefaultConfiguration() {
         let config = ExplicitTypeInterfaceConfiguration()
         XCTAssertEqual(config.severityConfiguration.severity, .warning)

--- a/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceRuleTests.swift
@@ -1,6 +1,6 @@
 @testable import SwiftLintBuiltInRules
 
-class ExplicitTypeInterfaceRuleTests: SwiftLintTestCase {
+final class ExplicitTypeInterfaceRuleTests: SwiftLintTestCase {
     func testLocalVars() {
         let nonTriggeringExamples = [
             Example("func foo() {\nlet intVal: Int = 1\n}"),

--- a/Tests/SwiftLintFrameworkTests/ExtendedNSStringTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExtendedNSStringTests.swift
@@ -1,7 +1,7 @@
 import SourceKittenFramework
 import XCTest
 
-class ExtendedNSStringTests: SwiftLintTestCase {
+final class ExtendedNSStringTests: SwiftLintTestCase {
     func testLineAndCharacterForByteOffset_forContentsContainingMultibyteCharacters() {
         let contents = "" +
         "import Foundation\n" +                               // 18 characters

--- a/Tests/SwiftLintFrameworkTests/ExtendedStringTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExtendedStringTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 
-class ExtendedStringTests: SwiftLintTestCase {
+final class ExtendedStringTests: SwiftLintTestCase {
     func testCountOccurrences() {
         XCTAssertEqual("aabbabaaba".countOccurrences(of: "a"), 6)
         XCTAssertEqual("".countOccurrences(of: "a"), 0)

--- a/Tests/SwiftLintFrameworkTests/FileHeaderRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FileHeaderRuleTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 private let fixturesDirectory = "\(TestResources.path)/FileHeaderRuleFixtures"
 
-class FileHeaderRuleTests: SwiftLintTestCase {
+final class FileHeaderRuleTests: SwiftLintTestCase {
     private func validate(fileName: String, using configuration: Any) throws -> [StyleViolation] {
         let file = SwiftLintFile(path: fixturesDirectory.stringByAppendingPathComponent(fileName))!
         let rule = try FileHeaderRule(configuration: configuration)

--- a/Tests/SwiftLintFrameworkTests/FileLengthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FileLengthRuleTests.swift
@@ -1,6 +1,6 @@
 @testable import SwiftLintBuiltInRules
 
-class FileLengthRuleTests: SwiftLintTestCase {
+final class FileLengthRuleTests: SwiftLintTestCase {
     func testFileLengthWithDefaultConfiguration() {
         verifyRule(FileLengthRule.description, commentDoesntViolate: false,
                    testMultiByteOffsets: false, testShebang: false)

--- a/Tests/SwiftLintFrameworkTests/FileNameNoSpaceRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FileNameNoSpaceRuleTests.swift
@@ -6,7 +6,7 @@ private let fixturesDirectory = #file.bridge()
     .deletingLastPathComponent.bridge()
     .appendingPathComponent("Resources/FileNameNoSpaceRuleFixtures")
 
-class FileNameNoSpaceRuleTests: SwiftLintTestCase {
+final class FileNameNoSpaceRuleTests: SwiftLintTestCase {
     private func validate(fileName: String, excludedOverride: [String]? = nil) throws -> [StyleViolation] {
         let file = SwiftLintFile(path: fixturesDirectory.stringByAppendingPathComponent(fileName))!
         let rule: FileNameNoSpaceRule

--- a/Tests/SwiftLintFrameworkTests/FileNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FileNameRuleTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 private let fixturesDirectory = "\(TestResources.path)/FileNameRuleFixtures"
 
-class FileNameRuleTests: SwiftLintTestCase {
+final class FileNameRuleTests: SwiftLintTestCase {
     private func validate(fileName: String, excludedOverride: [String]? = nil,
                           prefixPattern: String? = nil, suffixPattern: String? = nil,
                           nestedTypeSeparator: String? = nil) throws -> [StyleViolation] {

--- a/Tests/SwiftLintFrameworkTests/FileTypesOrderRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FileTypesOrderRuleTests.swift
@@ -1,6 +1,6 @@
 @testable import SwiftLintBuiltInRules
 
-class FileTypesOrderRuleTests: SwiftLintTestCase {
+final class FileTypesOrderRuleTests: SwiftLintTestCase {
     // swiftlint:disable:next function_body_length
     func testFileTypesOrderReversedOrder() {
         // Test with reversed `order` entries

--- a/Tests/SwiftLintFrameworkTests/FunctionBodyLengthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FunctionBodyLengthRuleTests.swift
@@ -13,7 +13,7 @@ private func violatingFuncWithBody(_ body: String, file: StaticString = #file, l
     return funcWithBody(body, violates: true, file: file, line: line)
 }
 
-class FunctionBodyLengthRuleTests: SwiftLintTestCase {
+final class FunctionBodyLengthRuleTests: SwiftLintTestCase {
     func testFunctionBodyLengths() {
         let longFunctionBody = funcWithBody(repeatElement("x = 0\n", count: 49).joined())
         XCTAssertEqual(self.violations(longFunctionBody), [])

--- a/Tests/SwiftLintFrameworkTests/FunctionParameterCountRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FunctionParameterCountRuleTests.swift
@@ -9,7 +9,7 @@ private func funcWithParameters(_ parameters: String,
     return Example("func \(marker)abc(\(parameters)) {}\n", file: file, line: line)
 }
 
-class FunctionParameterCountRuleTests: SwiftLintTestCase {
+final class FunctionParameterCountRuleTests: SwiftLintTestCase {
     func testFunctionParameterCount() {
         let baseDescription = FunctionParameterCountRule.description
         let nonTriggeringExamples = [

--- a/Tests/SwiftLintFrameworkTests/GenericTypeNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/GenericTypeNameRuleTests.swift
@@ -1,6 +1,6 @@
 @testable import SwiftLintBuiltInRules
 
-class GenericTypeNameRuleTests: SwiftLintTestCase {
+final class GenericTypeNameRuleTests: SwiftLintTestCase {
     func testGenericTypeNameWithExcluded() {
         let baseDescription = GenericTypeNameRule.description
         let nonTriggeringExamples = baseDescription.nonTriggeringExamples + [

--- a/Tests/SwiftLintFrameworkTests/IdentifierNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IdentifierNameRuleTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftLintBuiltInRules
 import XCTest
 
-class IdentifierNameRuleTests: SwiftLintTestCase {
+final class IdentifierNameRuleTests: SwiftLintTestCase {
     func testIdentifierNameWithExcluded() {
         let baseDescription = IdentifierNameRule.description
         let nonTriggeringExamples = baseDescription.nonTriggeringExamples + [

--- a/Tests/SwiftLintFrameworkTests/ImplicitReturnConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ImplicitReturnConfigurationTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftLintBuiltInRules
 import XCTest
 
-class ImplicitReturnConfigurationTests: SwiftLintTestCase {
+final class ImplicitReturnConfigurationTests: SwiftLintTestCase {
     func testImplicitReturnConfigurationFromDictionary() throws {
         var configuration = ImplicitReturnConfiguration(includedKinds: Set<ImplicitReturnConfiguration.ReturnKind>())
         let config: [String: Any] = [

--- a/Tests/SwiftLintFrameworkTests/ImplicitReturnRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ImplicitReturnRuleTests.swift
@@ -1,6 +1,6 @@
 @testable import SwiftLintBuiltInRules
 
-class ImplicitReturnRuleTests: SwiftLintTestCase {
+final class ImplicitReturnRuleTests: SwiftLintTestCase {
     func testOnlyClosureKindIncluded() {
         var nonTriggeringExamples = ImplicitReturnRuleExamples.nonTriggeringExamples +
                                     ImplicitReturnRuleExamples.triggeringExamples

--- a/Tests/SwiftLintFrameworkTests/ImplicitlyUnwrappedOptionalConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ImplicitlyUnwrappedOptionalConfigurationTests.swift
@@ -2,7 +2,7 @@
 import XCTest
 
 // swiftlint:disable:next type_name
-class ImplicitlyUnwrappedOptionalConfigurationTests: SwiftLintTestCase {
+final class ImplicitlyUnwrappedOptionalConfigurationTests: SwiftLintTestCase {
     func testImplicitlyUnwrappedOptionalConfigurationProperlyAppliesConfigurationFromDictionary() throws {
         var configuration = ImplicitlyUnwrappedOptionalConfiguration(
             severityConfiguration: SeverityConfiguration(.warning),

--- a/Tests/SwiftLintFrameworkTests/ImplicitlyUnwrappedOptionalRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ImplicitlyUnwrappedOptionalRuleTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftLintBuiltInRules
 import XCTest
 
-class ImplicitlyUnwrappedOptionalRuleTests: SwiftLintTestCase {
+final class ImplicitlyUnwrappedOptionalRuleTests: SwiftLintTestCase {
     func testImplicitlyUnwrappedOptionalRuleDefaultConfiguration() {
         let rule = ImplicitlyUnwrappedOptionalRule()
         XCTAssertEqual(rule.configuration.mode, .allExceptIBOutlets)

--- a/Tests/SwiftLintFrameworkTests/InclusiveLanguageRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/InclusiveLanguageRuleTests.swift
@@ -1,6 +1,6 @@
 @testable import SwiftLintBuiltInRules
 
-class InclusiveLanguageRuleTests: SwiftLintTestCase {
+final class InclusiveLanguageRuleTests: SwiftLintTestCase {
     func testNonTriggeringExamplesWithNonDefaultConfig() {
         InclusiveLanguageRuleExamples.nonTriggeringExamplesWithConfig.forEach { example in
             let description = InclusiveLanguageRule.description

--- a/Tests/SwiftLintFrameworkTests/IndentationWidthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IndentationWidthRuleTests.swift
@@ -1,4 +1,5 @@
 @testable import SwiftLintBuiltInRules
+@testable import SwiftLintCore
 import SwiftLintTestHelpers
 import XCTest
 

--- a/Tests/SwiftLintFrameworkTests/IndentationWidthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IndentationWidthRuleTests.swift
@@ -3,12 +3,17 @@ import SwiftLintTestHelpers
 import XCTest
 
 final class IndentationWidthRuleTests: SwiftLintTestCase {
-    func testInvalidIndentation() {
+    func testInvalidIndentation() throws {
         var testee = IndentationWidthConfiguration()
+        let defaultValue = testee.indentationWidth
+
         for indentation in [0, -1, -5] {
-            checkError(Issue.invalidConfiguration(ruleID: IndentationWidthRule.description.identifier)) {
-                try testee.apply(configuration: ["indentation_width": indentation])
-            }
+            XCTAssertEqual(
+                try Issue.captureConsole { try testee.apply(configuration: ["indentation_width": indentation]) },
+                "warning: Invalid configuration for 'indentation_width' rule. Falling back to default."
+            )
+            // Value remains the default.
+            XCTAssertEqual(testee.indentationWidth, defaultValue)
         }
     }
 

--- a/Tests/SwiftLintFrameworkTests/IndentationWidthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IndentationWidthRuleTests.swift
@@ -1,20 +1,14 @@
 @testable import SwiftLintBuiltInRules
-@testable import SwiftLintCore
 import SwiftLintTestHelpers
 import XCTest
 
-class IndentationWidthRuleTests: SwiftLintTestCase {
-    func testInvalidIndentation() throws {
+final class IndentationWidthRuleTests: SwiftLintTestCase {
+    func testInvalidIndentation() {
         var testee = IndentationWidthConfiguration()
-        let defaultValue = testee.indentationWidth
-
         for indentation in [0, -1, -5] {
-            XCTAssertEqual(
-                try Issue.captureConsole { try testee.apply(configuration: ["indentation_width": indentation]) },
-                "warning: Invalid configuration for 'indentation_width' rule. Falling back to default."
-            )
-            // Value remains the default.
-            XCTAssertEqual(testee.indentationWidth, defaultValue)
+            checkError(Issue.invalidConfiguration(ruleID: IndentationWidthRule.description.identifier)) {
+                try testee.apply(configuration: ["indentation_width": indentation])
+            }
         }
     }
 

--- a/Tests/SwiftLintFrameworkTests/LineEndingTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LineEndingTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftLintBuiltInRules
 import XCTest
 
-class LineEndingTests: SwiftLintTestCase {
+final class LineEndingTests: SwiftLintTestCase {
     func testCarriageReturnDoesNotCauseError() {
         XCTAssert(
             violations(

--- a/Tests/SwiftLintFrameworkTests/LineLengthConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LineLengthConfigurationTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftLintBuiltInRules
 import XCTest
 
-class LineLengthConfigurationTests: SwiftLintTestCase {
+final class LineLengthConfigurationTests: SwiftLintTestCase {
     private let severityLevels = SeverityLevelsConfiguration<LineLengthRule>(warning: 100, error: 150)
 
     func testLineLengthConfigurationInitializerSetsLength() {

--- a/Tests/SwiftLintFrameworkTests/LineLengthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LineLengthRuleTests.swift
@@ -1,6 +1,6 @@
 @testable import SwiftLintBuiltInRules
 
-class LineLengthRuleTests: SwiftLintTestCase {
+final class LineLengthRuleTests: SwiftLintTestCase {
     private let longFunctionDeclarations = [
         Example("public func superDuperLongFunctionDeclaration(a: String, b: String, " +
             "c: String, d: String, e: String, f: String, g: String, h: String, i: String, " +

--- a/Tests/SwiftLintFrameworkTests/LinterCacheTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LinterCacheTests.swift
@@ -68,7 +68,7 @@ private class TestFileManager: LintableFileManager {
     }
 }
 
-class LinterCacheTests: SwiftLintTestCase {
+final class LinterCacheTests: SwiftLintTestCase {
     // MARK: Test Helpers
 
     private var cache = LinterCache(fileManager: TestFileManager())

--- a/Tests/SwiftLintFrameworkTests/MissingDocsRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/MissingDocsRuleTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftLintBuiltInRules
 import XCTest
 
-class MissingDocsRuleTests: SwiftLintTestCase {
+final class MissingDocsRuleTests: SwiftLintTestCase {
     func testDescriptionEmpty() {
         let configuration = MissingDocsConfiguration()
         XCTAssertEqual(

--- a/Tests/SwiftLintFrameworkTests/ModifierOrderTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ModifierOrderTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftLintBuiltInRules
 import XCTest
 
-class ModifierOrderTests: SwiftLintTestCase {
+final class ModifierOrderTests: SwiftLintTestCase {
     func testAttributeTypeMethod() {
         let descriptionOverride = ModifierOrderRule.description
             .with(nonTriggeringExamples: [

--- a/Tests/SwiftLintFrameworkTests/MultilineArgumentsRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/MultilineArgumentsRuleTests.swift
@@ -1,6 +1,6 @@
 @testable import SwiftLintBuiltInRules
 
-class MultilineArgumentsRuleTests: SwiftLintTestCase {
+final class MultilineArgumentsRuleTests: SwiftLintTestCase {
     func testMultilineArgumentsWithWithNextLine() {
         let nonTriggeringExamples = [
             Example("foo()"),

--- a/Tests/SwiftLintFrameworkTests/NameConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/NameConfigurationTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftLintBuiltInRules
 import XCTest
 
-class NameConfigurationTests: SwiftLintTestCase {
+final class NameConfigurationTests: SwiftLintTestCase {
     typealias TesteeType = NameConfiguration<RuleMock>
 
     func testNameConfigurationSetsCorrectly() {

--- a/Tests/SwiftLintFrameworkTests/NestingRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/NestingRuleTests.swift
@@ -5,7 +5,7 @@
 private let detectingTypes = ["actor", "class", "struct", "enum"]
 
 // swiftlint:disable:next type_body_length
-class NestingRuleTests: SwiftLintTestCase {
+final class NestingRuleTests: SwiftLintTestCase {
     // swiftlint:disable:next function_body_length
     func testNestingWithAlwaysAllowOneTypeInFunctions() {
         var nonTriggeringExamples = NestingRule.description.nonTriggeringExamples

--- a/Tests/SwiftLintFrameworkTests/NumberSeparatorRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/NumberSeparatorRuleTests.swift
@@ -2,7 +2,7 @@
 import SwiftParser
 import XCTest
 
-class NumberSeparatorRuleTests: SwiftLintTestCase {
+final class NumberSeparatorRuleTests: SwiftLintTestCase {
     func testNumberSeparatorWithMinimumLength() {
         let nonTriggeringExamples = [
             Example("let foo = 10_000"),

--- a/Tests/SwiftLintFrameworkTests/ObjectLiteralRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ObjectLiteralRuleTests.swift
@@ -1,6 +1,6 @@
 @testable import SwiftLintBuiltInRules
 
-class ObjectLiteralRuleTests: SwiftLintTestCase {
+final class ObjectLiteralRuleTests: SwiftLintTestCase {
     // MARK: - Instance Properties
     private let imageLiteralTriggeringExamples = ["", ".init"].flatMap { (method: String) -> [Example] in
         ["UI", "NS"].flatMap { (prefix: String) -> [Example] in

--- a/Tests/SwiftLintFrameworkTests/OpeningBraceRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/OpeningBraceRuleTests.swift
@@ -1,6 +1,6 @@
 @testable import SwiftLintBuiltInRules
 
-class OpeningBraceRuleTests: SwiftLintTestCase {
+final class OpeningBraceRuleTests: SwiftLintTestCase {
     func testDefaultExamplesRunInMultilineMode() {
         let description = OpeningBraceRule.description
             .with(triggeringExamples: OpeningBraceRule.description.triggeringExamples.removing([

--- a/Tests/SwiftLintFrameworkTests/PrivateOverFilePrivateRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/PrivateOverFilePrivateRuleTests.swift
@@ -1,6 +1,6 @@
 @testable import SwiftLintBuiltInRules
 
-class PrivateOverFilePrivateRuleTests: SwiftLintTestCase {
+final class PrivateOverFilePrivateRuleTests: SwiftLintTestCase {
     func testPrivateOverFilePrivateValidatingExtensions() {
         let baseDescription = PrivateOverFilePrivateRule.description
         let triggeringExamples = baseDescription.triggeringExamples + [

--- a/Tests/SwiftLintFrameworkTests/RegexConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RegexConfigurationTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftLintCore
 import XCTest
 
-class RegexConfigurationTests: SwiftLintTestCase {
+final class RegexConfigurationTests: SwiftLintTestCase {
     func testShouldValidateIsTrueByDefault() {
         let config = RegexConfiguration<RuleMock>(identifier: "example")
         XCTAssertTrue(config.shouldValidate(filePath: "App/file.swift"))

--- a/Tests/SwiftLintFrameworkTests/RegionTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RegionTests.swift
@@ -1,7 +1,7 @@
 import SwiftLintCore
 import XCTest
 
-class RegionTests: SwiftLintTestCase {
+final class RegionTests: SwiftLintTestCase {
     // MARK: Regions From Files
 
     func testNoRegionsInEmptyFile() {

--- a/Tests/SwiftLintFrameworkTests/ReporterTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ReporterTests.swift
@@ -4,7 +4,7 @@ import SourceKittenFramework
 @testable import SwiftLintCore
 import XCTest
 
-class ReporterTests: SwiftLintTestCase {
+final class ReporterTests: SwiftLintTestCase {
     func testReporterFromString() {
         for reporter in reportersList {
             XCTAssertEqual(reporter.identifier, reporterFrom(identifier: reporter.identifier).identifier)

--- a/Tests/SwiftLintFrameworkTests/RequiredEnumCaseConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RequiredEnumCaseConfigurationTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftLintBuiltInRules
 import XCTest
 
-class RequiredEnumCaseConfigurationTests: SwiftLintTestCase {
+final class RequiredEnumCaseConfigurationTests: SwiftLintTestCase {
     private typealias RuleConfiguration = RequiredEnumCaseConfiguration
     private typealias RequiredCase = RuleConfiguration.RequiredCase
 

--- a/Tests/SwiftLintFrameworkTests/Resources/FileNameRuleFixtures/BoolExtensionTests.swift
+++ b/Tests/SwiftLintFrameworkTests/Resources/FileNameRuleFixtures/BoolExtensionTests.swift
@@ -1,7 +1,7 @@
 @testable import SomeModule
 import XCTest
 
-class BoolExtensionTests: SwiftLintTestCase {
+final class BoolExtensionTests: SwiftLintTestCase {
     func testExample() {
         // some code
     }

--- a/Tests/SwiftLintFrameworkTests/RuleConfigurationDescriptionTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleConfigurationDescriptionTests.swift
@@ -5,7 +5,7 @@ import XCTest
 // swiftlint:disable file_length
 
 // swiftlint:disable:next type_body_length
-class RuleConfigurationDescriptionTests: XCTestCase {
+final class RuleConfigurationDescriptionTests: XCTestCase {
     @AutoApply
     private struct TestConfiguration: RuleConfiguration {
         typealias Parent = RuleMock // swiftlint:disable:this nesting

--- a/Tests/SwiftLintFrameworkTests/RuleConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleConfigurationTests.swift
@@ -3,7 +3,7 @@ import SourceKittenFramework
 @testable import SwiftLintCore
 import XCTest
 
-class RuleConfigurationTests: SwiftLintTestCase {
+final class RuleConfigurationTests: SwiftLintTestCase {
     private let defaultNestingConfiguration = NestingConfiguration(
         typeLevel: SeverityLevelsConfiguration(warning: 0),
         functionLevel: SeverityLevelsConfiguration(warning: 0)

--- a/Tests/SwiftLintFrameworkTests/RuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleTests.swift
@@ -19,7 +19,7 @@ struct RuleWithLevelsMock: Rule {
     func validate(file: SwiftLintFile) -> [StyleViolation] { return [] }
 }
 
-class RuleTests: SwiftLintTestCase {
+final class RuleTests: SwiftLintTestCase {
     fileprivate struct RuleMock1: Rule {
         var configuration = SeverityConfiguration<Self>(.warning)
         var configurationDescription: some Documentable { RuleConfigurationOption.noOptions }

--- a/Tests/SwiftLintFrameworkTests/RulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RulesTests.swift
@@ -1,6 +1,6 @@
 @testable import SwiftLintBuiltInRules
 
-class RulesTests: SwiftLintTestCase {
+final class RulesTests: SwiftLintTestCase {
     func testLeadingWhitespace() {
         verifyRule(LeadingWhitespaceRule.description, skipDisableCommandTests: true,
                    testMultiByteOffsets: false, testShebang: false)

--- a/Tests/SwiftLintFrameworkTests/SourceKitCrashTests.swift
+++ b/Tests/SwiftLintFrameworkTests/SourceKitCrashTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftLintCore
 import XCTest
 
-class SourceKitCrashTests: SwiftLintTestCase {
+final class SourceKitCrashTests: SwiftLintTestCase {
     func testAssertHandlerIsNotCalledOnNormalFile() {
         let file = SwiftLintFile(contents: "A file didn't crash SourceKitService")
         file.sourcekitdFailed = false

--- a/Tests/SwiftLintFrameworkTests/StatementPositionRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/StatementPositionRuleTests.swift
@@ -1,6 +1,6 @@
 @testable import SwiftLintBuiltInRules
 
-class StatementPositionRuleTests: SwiftLintTestCase {
+final class StatementPositionRuleTests: SwiftLintTestCase {
     func testStatementPositionUncuddled() {
         let configuration = ["statement_mode": "uncuddled_else"]
         verifyRule(StatementPositionRule.uncuddledDescription, ruleConfiguration: configuration)

--- a/Tests/SwiftLintFrameworkTests/SwiftLintFileTests.swift
+++ b/Tests/SwiftLintFrameworkTests/SwiftLintFileTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftLintCore
 import XCTest
 
-class SwiftLintFileTests: SwiftLintTestCase {
+final class SwiftLintFileTests: SwiftLintTestCase {
     private let tempFile = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
 
     override func setUp() async throws {

--- a/Tests/SwiftLintFrameworkTests/SwitchCaseAlignmentRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/SwitchCaseAlignmentRuleTests.swift
@@ -1,6 +1,6 @@
 @testable import SwiftLintBuiltInRules
 
-class SwitchCaseAlignmentRuleTests: SwiftLintTestCase {
+final class SwitchCaseAlignmentRuleTests: SwiftLintTestCase {
     func testSwitchCaseAlignmentWithoutIndentedCases() {
         let baseDescription = SwitchCaseAlignmentRule.description
         let examples = SwitchCaseAlignmentRule.Examples(indentedCases: false)

--- a/Tests/SwiftLintFrameworkTests/TodoRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TodoRuleTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftLintBuiltInRules
 import XCTest
 
-class TodoRuleTests: SwiftLintTestCase {
+final class TodoRuleTests: SwiftLintTestCase {
     func testTodo() {
         verifyRule(TodoRule.description, commentDoesntViolate: false)
     }

--- a/Tests/SwiftLintFrameworkTests/TrailingClosureConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TrailingClosureConfigurationTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftLintBuiltInRules
 import XCTest
 
-class TrailingClosureConfigurationTests: SwiftLintTestCase {
+final class TrailingClosureConfigurationTests: SwiftLintTestCase {
     func testDefaultConfiguration() {
         let config = TrailingClosureConfiguration()
         XCTAssertEqual(config.severityConfiguration.severity, .warning)

--- a/Tests/SwiftLintFrameworkTests/TrailingClosureRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TrailingClosureRuleTests.swift
@@ -1,6 +1,6 @@
 @testable import SwiftLintBuiltInRules
 
-class TrailingClosureRuleTests: SwiftLintTestCase {
+final class TrailingClosureRuleTests: SwiftLintTestCase {
     func testWithOnlySingleMutedParameterEnabled() {
         let originalDescription = TrailingClosureRule.description
         let description = originalDescription

--- a/Tests/SwiftLintFrameworkTests/TrailingCommaRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TrailingCommaRuleTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftLintBuiltInRules
 import XCTest
 
-class TrailingCommaRuleTests: SwiftLintTestCase {
+final class TrailingCommaRuleTests: SwiftLintTestCase {
     func testTrailingCommaRuleWithDefaultConfiguration() {
         // Verify TrailingCommaRule with test values for when mandatory_comma is false (default).
         let triggeringExamples = TrailingCommaRule.description.triggeringExamples +

--- a/Tests/SwiftLintFrameworkTests/TrailingWhitespaceRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TrailingWhitespaceRuleTests.swift
@@ -1,6 +1,6 @@
 @testable import SwiftLintBuiltInRules
 
-class TrailingWhitespaceRuleTests: SwiftLintTestCase {
+final class TrailingWhitespaceRuleTests: SwiftLintTestCase {
     func testWithIgnoresEmptyLinesEnabled() {
         // Perform additional tests with the ignores_empty_lines setting enabled.
         // The set of non-triggering examples is extended by a whitespace-indented empty line

--- a/Tests/SwiftLintFrameworkTests/TypeContentsOrderRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TypeContentsOrderRuleTests.swift
@@ -1,6 +1,6 @@
 @testable import SwiftLintBuiltInRules
 
-class TypeContentsOrderRuleTests: SwiftLintTestCase {
+final class TypeContentsOrderRuleTests: SwiftLintTestCase {
     // swiftlint:disable:next function_body_length
     func testTypeContentsOrderReversedOrder() {
         // Test with reversed `order` entries

--- a/Tests/SwiftLintFrameworkTests/TypeNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TypeNameRuleTests.swift
@@ -1,6 +1,6 @@
 @testable import SwiftLintBuiltInRules
 
-class TypeNameRuleTests: SwiftLintTestCase {
+final class TypeNameRuleTests: SwiftLintTestCase {
     func testTypeNameWithExcluded() {
         let baseDescription = TypeNameRule.description
         let nonTriggeringExamples = baseDescription.nonTriggeringExamples + [

--- a/Tests/SwiftLintFrameworkTests/UnneededOverrideRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/UnneededOverrideRuleTests.swift
@@ -1,6 +1,6 @@
 @testable import SwiftLintBuiltInRules
 
-class UnneededOverrideRuleTests: SwiftLintTestCase {
+final class UnneededOverrideRuleTests: SwiftLintTestCase {
     func testIncludeAffectInits() {
         let nonTriggeringExamples = [
             Example("""

--- a/Tests/SwiftLintFrameworkTests/UnusedDeclarationConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/UnusedDeclarationConfigurationTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftLintBuiltInRules
 import XCTest
 
-class UnusedDeclarationConfigurationTests: XCTestCase {
+final class UnusedDeclarationConfigurationTests: XCTestCase {
     func testParseConfiguration() throws {
         var testee = UnusedDeclarationConfiguration()
         let config = [

--- a/Tests/SwiftLintFrameworkTests/UnusedOptionalBindingRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/UnusedOptionalBindingRuleTests.swift
@@ -1,6 +1,6 @@
 @testable import SwiftLintBuiltInRules
 
-class UnusedOptionalBindingRuleTests: SwiftLintTestCase {
+final class UnusedOptionalBindingRuleTests: SwiftLintTestCase {
     func testDefaultConfiguration() {
         let baseDescription = UnusedOptionalBindingRule.description
         let triggeringExamples = baseDescription.triggeringExamples + [

--- a/Tests/SwiftLintFrameworkTests/VerticalWhitespaceRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/VerticalWhitespaceRuleTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftLintBuiltInRules
 import XCTest
 
-class VerticalWhitespaceRuleTests: SwiftLintTestCase {
+final class VerticalWhitespaceRuleTests: SwiftLintTestCase {
     private let ruleID = VerticalWhitespaceRule.description.identifier
 
     func testAttributesWithMaxEmptyLines() {

--- a/Tests/SwiftLintFrameworkTests/XCTSpecificMatcherRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/XCTSpecificMatcherRuleTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftLintBuiltInRules
 import XCTest
 
-class XCTSpecificMatcherRuleTests: SwiftLintTestCase {
+final class XCTSpecificMatcherRuleTests: SwiftLintTestCase {
     func testEqualTrue() {
         let example = Example("XCTAssertEqual(a, true)")
         let violations = self.violations(example)

--- a/Tests/SwiftLintFrameworkTests/YamlParserTests.swift
+++ b/Tests/SwiftLintFrameworkTests/YamlParserTests.swift
@@ -1,7 +1,7 @@
 @testable import SwiftLintCore
 import XCTest
 
-class YamlParserTests: SwiftLintTestCase {
+final class YamlParserTests: SwiftLintTestCase {
     func testParseEmptyString() {
         XCTAssertEqual((try YamlParser.parse("", env: [:])).count, 0,
                        "Parsing empty YAML string should succeed")

--- a/Tests/SwiftLintFrameworkTests/YamlSwiftLintTests.swift
+++ b/Tests/SwiftLintFrameworkTests/YamlSwiftLintTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import XCTest
 import Yams
 
-class YamlSwiftLintTests: SwiftLintTestCase {
+final class YamlSwiftLintTests: SwiftLintTestCase {
     func testFlattenYaml() throws {
         do {
             guard let yamlDict = try Yams.load(yaml: try getTestYaml()) as? [String: Any] else {


### PR DESCRIPTION

Enables the following rules in .swiftlint.yml for SwiftLint itself. These all had less than 10 violations:

`final_test_case` - Fixed
`redundant_self_in_closure`- Fixed
`self_binding`- Fixed
`shorthand_argument` - Supressed
`implicitly_unwrapped_optional` - Suppressed.

I think `implicitly_unwrapped_optional` is the only one I had a question mark over in my mind - I made those changes on a separate commit so they're easy to revert.
