### PR TITLE
Respect array types in `redundant_type_annotation` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,6 +228,10 @@
   [Martin Redington](https://github.com/mildm8nnered)
   [#5305](https://github.com/realm/SwiftLint/pull/5305)
 
+* Take array types into account in `redundant_type_annotation` rule.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#3141](https://github.com/realm/SwiftLint/pull/3141)
+
 * Silence `pattern_matching_keywords` rule when an identifier is referenced
   in the argument list of a matching enum case.  
   [SimplyDanny](https://github.com/SimplyDanny)


### PR DESCRIPTION
Fixes #3141.

Also try to change the implementation slightly by focusing on the important aspects of the rule (i.e. extracting type names) in separate methods.