### PR TITLE
Make postprocessors non-throwing

### DIFF
--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/IndentationWidthConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/IndentationWidthConfiguration.swift
@@ -4,11 +4,18 @@ import SwiftLintCore
 struct IndentationWidthConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = IndentationWidthRule
 
+    private static let defaultIndentationWidth = 4
+
     @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>.warning
     @ConfigurationElement(
         key: "indentation_width",
-        postprocessor: { if $0 < 1 { throw Issue.invalidConfiguration(ruleID: Parent.identifier) } }
+        postprocessor: {
+            if $0 < 1 {
+                Issue.invalidConfiguration(ruleID: Parent.identifier).print()
+                $0 = Self.defaultIndentationWidth
+            }
+        }
     )
     private(set) var indentationWidth = 4
     @ConfigurationElement(key: "include_comments")

--- a/Source/SwiftLintCoreMacros/RuleConfigurationMacros.swift
+++ b/Source/SwiftLintCoreMacros/RuleConfigurationMacros.swift
@@ -60,7 +60,6 @@ enum AutoApply: MemberMacro {
                     """
                     do {
                         try \(raw: option).apply(configuration, ruleID: Parent.identifier)
-                        try $\(raw: option).performAfterParseOperations()
                     } catch let issue as Issue where issue == Issue.nothingApplied(ruleID: Parent.identifier) {
                         // Acceptable. Continue.
                     }
@@ -76,9 +75,6 @@ enum AutoApply: MemberMacro {
                 for option in nonInlinedOptions {
                     """
                     try \(raw: option).apply(configuration[$\(raw: option).key], ruleID: Parent.identifier)
-                    """
-                    """
-                    try $\(raw: option).performAfterParseOperations()
                     """
                 }
                 """

--- a/Tests/MacroTests/AutoApplyTests.swift
+++ b/Tests/MacroTests/AutoApplyTests.swift
@@ -81,9 +81,7 @@ final class AutoApplyTests: XCTestCase {
                         throw Issue.invalidConfiguration(ruleID: Parent.identifier)
                     }
                     try eA.apply(configuration[$eA.key], ruleID: Parent.identifier)
-                    try $eA.performAfterParseOperations()
                     try eB.apply(configuration[$eB.key], ruleID: Parent.identifier)
-                    try $eB.performAfterParseOperations()
                     if !supportedKeys.isSuperset(of: configuration.keys) {
                         let unknownKeys = Set(configuration.keys).subtracting(supportedKeys)
                         throw Issue.invalidConfigurationKeys(ruleID: Parent.identifier, keys: unknownKeys)
@@ -127,7 +125,6 @@ final class AutoApplyTests: XCTestCase {
                     }
                     do {
                         try eB.apply(configuration, ruleID: Parent.identifier)
-                        try $eB.performAfterParseOperations()
                     } catch let issue as Issue where issue == Issue.nothingApplied(ruleID: Parent.identifier) {
                         // Acceptable. Continue.
                     }
@@ -135,9 +132,7 @@ final class AutoApplyTests: XCTestCase {
                         return
                     }
                     try eA.apply(configuration[$eA.key], ruleID: Parent.identifier)
-                    try $eA.performAfterParseOperations()
                     try eC.apply(configuration[$eC.key], ruleID: Parent.identifier)
-                    try $eC.performAfterParseOperations()
                     if !supportedKeys.isSuperset(of: configuration.keys) {
                         let unknownKeys = Set(configuration.keys).subtracting(supportedKeys)
                         throw Issue.invalidConfigurationKeys(ruleID: Parent.identifier, keys: unknownKeys)
@@ -210,7 +205,6 @@ final class AutoApplyTests: XCTestCase {
                     }
                     do {
                         try severityConfiguration.apply(configuration, ruleID: Parent.identifier)
-                        try $severityConfiguration.performAfterParseOperations()
                     } catch let issue as Issue where issue == Issue.nothingApplied(ruleID: Parent.identifier) {
                         // Acceptable. Continue.
                     }
@@ -218,9 +212,7 @@ final class AutoApplyTests: XCTestCase {
                         return
                     }
                     try severityConfiguration.apply(configuration[$severityConfiguration.key], ruleID: Parent.identifier)
-                    try $severityConfiguration.performAfterParseOperations()
                     try foo.apply(configuration[$foo.key], ruleID: Parent.identifier)
-                    try $foo.performAfterParseOperations()
                     if !supportedKeys.isSuperset(of: configuration.keys) {
                         let unknownKeys = Set(configuration.keys).subtracting(supportedKeys)
                         throw Issue.invalidConfigurationKeys(ruleID: Parent.identifier, keys: unknownKeys)

--- a/Tests/SwiftLintFrameworkTests/IndentationWidthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IndentationWidthRuleTests.swift
@@ -3,12 +3,14 @@ import SwiftLintTestHelpers
 import XCTest
 
 class IndentationWidthRuleTests: SwiftLintTestCase {
-    func testInvalidIndentation() {
+    func testInvalidIndentation() throws {
         var testee = IndentationWidthConfiguration()
+        let defaultValue = testee.indentationWidth
         for indentation in [0, -1, -5] {
-            checkError(Issue.invalidConfiguration(ruleID: IndentationWidthRule.description.identifier)) {
-                try testee.apply(configuration: ["indentation_width": indentation])
-            }
+            try testee.apply(configuration: ["indentation_width": indentation])
+
+            // Value remains the default.
+            XCTAssertEqual(testee.indentationWidth, defaultValue)
         }
     }
 


### PR DESCRIPTION
Failing immediately when a property is invalid is too strict. It feels sufficient to allow to report an issue but otherwise continue with a default value instead of stopping execution completely.