### PR TITLE
Allow to set configuration elements as deprecated

### DIFF
--- a/Tests/SwiftLintFrameworkTests/IndentationWidthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IndentationWidthRuleTests.swift
@@ -1,4 +1,5 @@
 @testable import SwiftLintBuiltInRules
+@testable import SwiftLintCore
 import SwiftLintTestHelpers
 import XCTest
 
@@ -6,9 +7,12 @@ class IndentationWidthRuleTests: SwiftLintTestCase {
     func testInvalidIndentation() throws {
         var testee = IndentationWidthConfiguration()
         let defaultValue = testee.indentationWidth
-        for indentation in [0, -1, -5] {
-            try testee.apply(configuration: ["indentation_width": indentation])
 
+        for indentation in [0, -1, -5] {
+            XCTAssertEqual(
+                try Issue.captureConsole { try testee.apply(configuration: ["indentation_width": indentation]) },
+                "warning: Invalid configuration for 'indentation_width' rule. Falling back to default."
+            )
             // Value remains the default.
             XCTAssertEqual(testee.indentationWidth, defaultValue)
         }

--- a/Tests/SwiftLintFrameworkTests/RuleConfigurationDescriptionTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleConfigurationDescriptionTests.swift
@@ -29,7 +29,7 @@ class RuleConfigurationDescriptionTests: XCTestCase {
             postprocessor: { list in list = list.map { $0.uppercased() } }
         )
         var list = ["string1", "string2"]
-        @ConfigurationElement(key: "set")
+        @ConfigurationElement(key: "set", deprecationNotice: .suggestAlternative(ruleID: "my_rule", name: "other_opt"))
         var set: Set<Int> = [1, 2, 3]
         @ConfigurationElement(inline: true)
         var severityConfig = SeverityConfiguration<Parent>(.error)
@@ -488,6 +488,15 @@ class RuleConfigurationDescriptionTests: XCTestCase {
         XCTAssertEqual(configuration.renamedSeverityConfig, .error)
         XCTAssertEqual(configuration.inlinedSeverityLevels, SeverityLevelsConfiguration(warning: 12))
         XCTAssertEqual(configuration.nestedSeverityLevels, SeverityLevelsConfiguration(warning: 6, error: 7))
+    }
+
+    func testDeprecationWarning() throws {
+        var configuration = TestConfiguration()
+
+        XCTAssertEqual(
+            try Issue.captureConsole { try configuration.apply(configuration: ["set": [6, 7]]) },
+            "warning: Configuration option 'set' in 'my_rule' rule is deprecated. Use the option 'other_opt' instead."
+        )
     }
 
     func testInvalidKeys() throws {


### PR DESCRIPTION
Automatically print an appropriate warning to the console.