### PR TITLE
Build Plugin name was out of date in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Breaking
 
-* Rewrite `SwiftLintPlugin` using `BUILD_WORKSPACE_DIRECTORY` without relying
+* Rewrite `SwiftLintBuildToolPlugin` using `BUILD_WORKSPACE_DIRECTORY` without relying
   on the `--config` option.  
   [Garric Nahapetian](https://github.com/garricn)
 

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ products.
 
 Select the target you want to add linting to and open the `Build Phases` inspector.
 Open `Run Build Tool Plugins` and select the `+` button.
-Select `SwiftLintBuildToolPlugin` from the list and add it to the project.
+Select `SwiftLintPlugin` from the list and add it to the project.
 
 ![](https://raw.githubusercontent.com/realm/SwiftLint/main/assets/select-swiftlint-plugin.png)
 
@@ -283,7 +283,7 @@ Add SwiftLint to a target using the `plugins` parameter.
 ```swift
 .target(
     ...
-    plugins: [.plugin(name: "SwiftLintBuildToolPlugin", package: "SwiftLint")]
+    plugins: [.plugin(name: "SwiftLintPlugin", package: "SwiftLint")]
 ),
 ```
 

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ products.
 
 Select the target you want to add linting to and open the `Build Phases` inspector.
 Open `Run Build Tool Plugins` and select the `+` button.
-Select `SwiftLintPlugin` from the list and add it to the project.
+Select `SwiftLintBuildToolPlugin` from the list and add it to the project.
 
 ![](https://raw.githubusercontent.com/realm/SwiftLint/main/assets/select-swiftlint-plugin.png)
 
@@ -283,7 +283,7 @@ Add SwiftLint to a target using the `plugins` parameter.
 ```swift
 .target(
     ...
-    plugins: [.plugin(name: "SwiftLintPlugin", package: "SwiftLint")]
+    plugins: [.plugin(name: "SwiftLintBuildToolPlugin", package: "SwiftLint")]
 ),
 ```
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -193,7 +193,7 @@ Xcode 构建工具插件。
 
 选择要添加修正的目标，打开 `Build Phases` 检查器。
 打开 `Run Build Tool Plug-ins` 并选择 `+` 按钮。
-从列表中选择 `SwiftLintPlugin` 并将其添加到项目中。
+从列表中选择 `SwiftLintBuildToolPlugin` 并将其添加到项目中。
 
 ![](https://raw.githubusercontent.com/realm/SwiftLint/main/assets/select-swiftlint-plugin.png)
 


### PR DESCRIPTION
README stated that the Build Plugin name was `SwiftLintBuildToolPlugin` but it is actually `SwiftLintPlugin` - must have been renamed at some point, and docs weren't updated.