### PR TITLE
Fix superfluous disable command for custom rules

### DIFF
--- a/Source/SwiftLintBuiltInRules/Rules/Lint/TypesafeArrayInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/TypesafeArrayInitRule.swift
@@ -31,21 +31,21 @@ struct TypesafeArrayInitRule: AnalyzerRule {
                 func f<Seq: Sequence>(s: Seq) -> [Seq.Element] {
                     s.↓map({ $0 })
                 }
-            """),
+            """, testDisableCommand: false),
             Example("""
                 func f(array: [Int]) -> [Int] {
                     array.↓map { $0 }
                 }
-            """),
+            """, testDisableCommand: false),
             Example("""
                 let myInts = [1, 2, 3].↓map { return $0 }
-            """),
+            """, testDisableCommand: false),
             Example("""
                 struct Generator: Sequence, IteratorProtocol {
                     func next() -> Int? { nil }
                 }
                 let array = Generator().↓map { i in i }
-            """),
+            """, testDisableCommand: false),
         ],
         requiresFileOnDisk: true
     )

--- a/Source/SwiftLintCore/Extensions/Collection+Windows.swift
+++ b/Source/SwiftLintCore/Extensions/Collection+Windows.swift
@@ -142,13 +142,13 @@ extension WindowsOfCountCollection: Collection {
 
   internal func offsetForward(_ i: Index, by distance: Int) -> Index {
     guard let index = offsetForward(i, by: distance, limitedBy: endIndex)
-      else { fatalError("Index is out of bounds") }
+      else { queudFatalError("Index is out of bounds") }
     return index
   }
 
   internal func offsetBackward(_ i: Index, by distance: Int) -> Index {
     guard let index = offsetBackward(i, by: distance, limitedBy: startIndex)
-      else { fatalError("Index is out of bounds") }
+      else { queudFatalError("Index is out of bounds") }
     return index
   }
 

--- a/Source/SwiftLintCore/Extensions/Collection+Windows.swift
+++ b/Source/SwiftLintCore/Extensions/Collection+Windows.swift
@@ -142,13 +142,13 @@ extension WindowsOfCountCollection: Collection {
 
   internal func offsetForward(_ i: Index, by distance: Int) -> Index {
     guard let index = offsetForward(i, by: distance, limitedBy: endIndex)
-      else { queuedFatalError("Index is out of bounds") }
+      else { fatalError("Index is out of bounds") }
     return index
   }
 
   internal func offsetBackward(_ i: Index, by distance: Int) -> Index {
     guard let index = offsetBackward(i, by: distance, limitedBy: startIndex)
-      else { queuedFatalError("Index is out of bounds") }
+      else { fatalError("Index is out of bounds") }
     return index
   }
 

--- a/Source/SwiftLintCore/Extensions/Collection+Windows.swift
+++ b/Source/SwiftLintCore/Extensions/Collection+Windows.swift
@@ -142,13 +142,13 @@ extension WindowsOfCountCollection: Collection {
 
   internal func offsetForward(_ i: Index, by distance: Int) -> Index {
     guard let index = offsetForward(i, by: distance, limitedBy: endIndex)
-      else { queudFatalError("Index is out of bounds") }
+      else { queuedFatalError("Index is out of bounds") }
     return index
   }
 
   internal func offsetBackward(_ i: Index, by distance: Int) -> Index {
     guard let index = offsetBackward(i, by: distance, limitedBy: startIndex)
-      else { queudFatalError("Index is out of bounds") }
+      else { queuedFatalError("Index is out of bounds") }
     return index
   }
 

--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -16,42 +16,57 @@ private struct LintResult {
 }
 
 private extension Rule {
-    static func superfluousDisableCommandViolations(regions: [Region],
-                                                    superfluousDisableCommandRule: SuperfluousDisableCommandRule?,
-                                                    allViolations: [StyleViolation]) -> [StyleViolation] {
+    func superfluousDisableCommandViolations(regions: [Region],
+                                             superfluousDisableCommandRule: SuperfluousDisableCommandRule?,
+                                             allViolations: [StyleViolation]) -> [StyleViolation] {
         guard regions.isNotEmpty, let superfluousDisableCommandRule else {
             return []
         }
 
-        let regionsDisablingCurrentRule = regions.filter { region in
-            return region.isRuleDisabled(self.init())
-        }
         let regionsDisablingSuperfluousDisableRule = regions.filter { region in
             return region.isRuleDisabled(superfluousDisableCommandRule)
         }
 
-        return regionsDisablingCurrentRule.compactMap { region -> StyleViolation? in
-            let isSuperfluousRuleDisabled = regionsDisablingSuperfluousDisableRule.contains {
-                $0.contains(region.start)
+        let regionsWithIdentifiers: [(String, [Region])] = {
+            if let customRules = self as? CustomRules {
+                return customRules.configuration.customRuleConfigurations.map { configuration in
+                    let regionsDisablingCurrentRule = regions.filter { region in
+                        return region.isRuleDisabled(customRuleIdentifier: configuration.identifier)
+                    }
+                    return (configuration.identifier, regionsDisablingCurrentRule)
+                }
+            } else {
+                let regionsDisablingCurrentRule = regions.filter { region in
+                    return region.isRuleDisabled(self)
+                }
+                return [(Self.description.identifier, regionsDisablingCurrentRule)]
             }
+        }()
 
-            guard !isSuperfluousRuleDisabled else {
-                return nil
-            }
+        return regionsWithIdentifiers.flatMap { ruleIdentifier, regionsDisablingCurrentRule in
+            regionsDisablingCurrentRule.compactMap { region -> StyleViolation? in
+                let isSuperfluousRuleDisabled = regionsDisablingSuperfluousDisableRule.contains {
+                    $0.contains(region.start)
+                }
 
-            let noViolationsInDisabledRegion = !allViolations.contains { violation in
-                return region.contains(violation.location)
-            }
-            guard noViolationsInDisabledRegion else {
-                return nil
-            }
+                guard !isSuperfluousRuleDisabled else {
+                    return nil
+                }
 
-            return StyleViolation(
-                ruleDescription: type(of: superfluousDisableCommandRule).description,
-                severity: superfluousDisableCommandRule.configuration.severity,
-                location: region.start,
-                reason: superfluousDisableCommandRule.reason(for: self)
-            )
+                let noViolationsInDisabledRegion = !allViolations.contains { violation in
+                    return region.contains(violation.location) && violation.ruleIdentifier == ruleIdentifier
+                }
+                guard noViolationsInDisabledRegion else {
+                    return nil
+                }
+
+                return StyleViolation(
+                    ruleDescription: type(of: superfluousDisableCommandRule).description,
+                    severity: superfluousDisableCommandRule.configuration.severity,
+                    location: region.start,
+                    reason: superfluousDisableCommandRule.reason(forRuleIdentifier: ruleIdentifier)
+                )
+            }
         }
     }
 
@@ -96,12 +111,19 @@ private extension Rule {
             return region?.isRuleEnabled(self) ?? true
         }
 
+        let customRulesIDs: [String] = {
+            guard let customRules = self as? CustomRules else {
+                return []
+            }
+            return customRules.configuration.customRuleConfigurations.map(\.identifier)
+        }()
         let ruleIDs = Self.description.allIdentifiers +
+            customRulesIDs +
             (superfluousDisableCommandRule.map({ type(of: $0) })?.description.allIdentifiers ?? []) +
             [RuleIdentifier.all.stringRepresentation]
         let ruleIdentifiers = Set(ruleIDs.map { RuleIdentifier($0) })
 
-        let superfluousDisableCommandViolations = Self.superfluousDisableCommandViolations(
+        let superfluousDisableCommandViolations = superfluousDisableCommandViolations(
             regions: regions.count > 1 ? file.regions(restrictingRuleIdentifiers: ruleIdentifiers) : regions,
             superfluousDisableCommandRule: superfluousDisableCommandRule,
             allViolations: violations

--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -70,7 +70,7 @@ private extension Rule {
     }
 
     // As we need the configuration to get custom identifiers.
-    // swiftlint:disable:next function_parameter_count
+    // swiftlint:disable:next function_parameter_count function_body_length
     func lint(file: SwiftLintFile, regions: [Region], benchmark: Bool,
               storage: RuleStorage,
               configuration: Configuration,

--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -35,12 +35,11 @@ private extension Rule {
                     }
                     return (configuration.identifier, regionsDisablingCurrentRule)
                 }
-            } else {
-                let regionsDisablingCurrentRule = regions.filter { region in
-                    return region.isRuleDisabled(self)
-                }
-                return [(Self.description.identifier, regionsDisablingCurrentRule)]
             }
+            let regionsDisablingCurrentRule = regions.filter { region in
+                return region.isRuleDisabled(self)
+            }
+            return [(Self.description.identifier, regionsDisablingCurrentRule)]
         }()
 
         return regionsWithIdentifiers.flatMap { ruleIdentifier, regionsDisablingCurrentRule in
@@ -110,9 +109,8 @@ private extension Rule {
         }.partitioned { violation, region in
             if self is CustomRules {
                 return !(region?.isRuleDisabled(customRuleIdentifier: violation.ruleIdentifier) ?? true)
-            } else {
-                return region?.isRuleEnabled(self) ?? true
             }
+            return region?.isRuleEnabled(self) ?? true
         }
 
         let customRulesIDs: [String] = {

--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -107,8 +107,12 @@ private extension Rule {
 
         let (disabledViolationsAndRegions, enabledViolationsAndRegions) = violations.map { violation in
             return (violation, regions.first { $0.contains(violation.location) })
-        }.partitioned { _, region in
-            return region?.isRuleEnabled(self) ?? true
+        }.partitioned { violation, region in
+            if self is CustomRules {
+                return !(region?.isRuleDisabled(customRuleIdentifier: violation.ruleIdentifier) ?? true)
+            } else {
+                return region?.isRuleEnabled(self) ?? true
+            }
         }
 
         let customRulesIDs: [String] = {

--- a/Source/SwiftLintCore/Models/Region.swift
+++ b/Source/SwiftLintCore/Models/Region.swift
@@ -46,7 +46,13 @@ public struct Region: Equatable {
     ///
     /// - returns: True if the specified rule is disabled in this region.
     public func isRuleDisabled(_ rule: some Rule) -> Bool {
-        return areRulesDisabled(ruleIDs: type(of: rule).description.allIdentifiers)
+        if rule is CustomRules {
+            let customRulesConfiguration = rule.configuration as? CustomRulesConfiguration
+            let identifiers = customRulesConfiguration?.customRuleConfigurations.map { $0.identifier } ?? []
+            return areRulesDisabled(ruleIDs: identifiers)
+        } else {
+            return areRulesDisabled(ruleIDs: type(of: rule).description.allIdentifiers)
+        }
     }
 
     /// Whether the given rules are disabled in this region.

--- a/Source/SwiftLintCore/Models/Region.swift
+++ b/Source/SwiftLintCore/Models/Region.swift
@@ -50,9 +50,8 @@ public struct Region: Equatable {
             let customRulesConfiguration = rule.configuration as? CustomRulesConfiguration
             let identifiers = customRulesConfiguration?.customRuleConfigurations.map { $0.identifier } ?? []
             return areRulesDisabled(ruleIDs: identifiers)
-        } else {
-            return areRulesDisabled(ruleIDs: type(of: rule).description.allIdentifiers)
         }
+        return areRulesDisabled(ruleIDs: type(of: rule).description.allIdentifiers)
     }
 
     /// Whether the given rules are disabled in this region.

--- a/Source/SwiftLintCore/Rules/CustomRules.swift
+++ b/Source/SwiftLintCore/Rules/CustomRules.swift
@@ -79,13 +79,7 @@ struct CustomRules: Rule, CacheDescriptionProvider {
                                severity: configuration.severity,
                                location: Location(file: file, characterOffset: $0.location),
                                reason: configuration.message)
-            }).filter { violation in
-                guard let region = file.regions().first(where: { $0.contains(violation.location) }) else {
-                    return true
-                }
-
-                return !region.isRuleDisabled(customRuleIdentifier: configuration.identifier)
-            }
+            })
         }
     }
 }

--- a/Source/SwiftLintCore/Rules/CustomRules.swift
+++ b/Source/SwiftLintCore/Rules/CustomRules.swift
@@ -90,7 +90,7 @@ struct CustomRules: Rule, CacheDescriptionProvider {
     }
 }
 
-private extension Region {
+extension Region {
     func isRuleDisabled(customRuleIdentifier: String) -> Bool {
         return disabledRuleIdentifiers.contains(RuleIdentifier(customRuleIdentifier))
     }

--- a/Source/SwiftLintCore/Rules/CustomRules.swift
+++ b/Source/SwiftLintCore/Rules/CustomRules.swift
@@ -86,6 +86,7 @@ struct CustomRules: Rule, CacheDescriptionProvider {
 
 extension Region {
     func isRuleDisabled(customRuleIdentifier: String) -> Bool {
-        return disabledRuleIdentifiers.contains(RuleIdentifier(customRuleIdentifier))
+        disabledRuleIdentifiers.contains(.all) ||
+        disabledRuleIdentifiers.contains(RuleIdentifier(customRuleIdentifier))
     }
 }

--- a/Source/SwiftLintCore/Rules/SuperfluousDisableCommandRule.swift
+++ b/Source/SwiftLintCore/Rules/SuperfluousDisableCommandRule.swift
@@ -34,9 +34,9 @@ package struct SuperfluousDisableCommandRule: SourceKitFreeRule {
         return []
     }
 
-    func reason(for rule: (some Rule).Type) -> String {
+    func reason(forRuleIdentifier ruleIdentifier: String) -> String {
         """
-        SwiftLint rule '\(rule.description.identifier)' did not trigger a violation in the disabled region; \
+        SwiftLint rule '\(ruleIdentifier)' did not trigger a violation in the disabled region; \
         remove the disable command
         """
     }

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -261,7 +261,7 @@ final class CustomRulesTests: SwiftLintTestCase {
             "only_rules": ["custom_rules", "superfluous_disable_command"],
             "custom_rules": [
                 "dont_print": [
-                  "regex": "print"
+                  "regex": "print\\("
                   ]
             ]
         ]

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -130,7 +130,7 @@ final class CustomRulesTests: SwiftLintTestCase {
             ]
         ]
         let example = Example("//swiftlint:disable custom \n// file with a pattern")
-        let violations = try myViolations(forExample: example, customRules: customRules)
+        let violations = try violations(forExample: example, customRules: customRules)
 
         XCTAssertTrue(violations.isEmpty)
     }
@@ -211,7 +211,7 @@ final class CustomRulesTests: SwiftLintTestCase {
         ]
 
         let example = Example("// swiftlint:disable custom1\n")
-        let violations = try myViolations(forExample: example, customRules: customRules)
+        let violations = try violations(forExample: example, customRules: customRules)
 
         XCTAssertEqual(violations.count, 1)
         XCTAssertTrue(violations.allSatisfy { $0.ruleIdentifier == "superfluous_disable_command" })
@@ -243,7 +243,7 @@ final class CustomRulesTests: SwiftLintTestCase {
             """
         )
 
-        let violations = try myViolations(forExample: example, customRules: customRules)
+        let violations = try violations(forExample: example, customRules: customRules)
 
         XCTAssertEqual(violations.count, 3)
         XCTAssertEqual(violations.filter { $0.ruleIdentifier == "superfluous_disable_command" }.count, 2)
@@ -267,7 +267,7 @@ final class CustomRulesTests: SwiftLintTestCase {
                               // swiftlint:disable:next dont_print
                               print("Hello, world")
                               """)
-        XCTAssertTrue(try myViolations(forExample: example, customRules: customRules).isEmpty)
+        XCTAssertTrue(try violations(forExample: example, customRules: customRules).isEmpty)
     }
 
     private func getCustomRules(_ extraConfig: [String: Any] = [:]) -> (Configuration, CustomRules) {
@@ -329,13 +329,13 @@ final class CustomRulesTests: SwiftLintTestCase {
         return SwiftLintFile(path: "\(testResourcesPath)/test.txt")!
     }
 
-    private func myViolations(forExample example: Example, customRules: [String: Any]) throws -> [StyleViolation] {
+    private func violations(forExample example: Example, customRules: [String: Any]) throws -> [StyleViolation] {
         let configDict: [String: Any] = [
             "only_rules": ["custom_rules", "superfluous_disable_command"],
             "custom_rules": customRules
         ]
         let configuration = try SwiftLintCore.Configuration(dict: configDict)
-        return violations(
+        return SwiftLintTestHelpers.violations(
             example.skipWrappingInCommentTest(),
             config: configuration
         )

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -260,15 +260,15 @@ final class CustomRulesTests: SwiftLintTestCase {
         let configDict: [String: Any] = [
             "only_rules": ["custom_rules", "superfluous_disable_command"],
             "custom_rules": [
-                "use_stroke_colors": [
-                  "regex": "(?:border|stroke)Color = (?:(?:UI|CG)?Color)?\\.(?!stroke|always|pink)"
+                "dont_print": [
+                  "regex": "print"
                   ]
             ]
         ]
         let configuration = try SwiftLintCore.Configuration(dict: configDict)
         let example = Example("""
-                              // swiftlint:disable:next use_stroke_colors
-                              view.layer.borderColor = Color.clear.cgColor
+                              // swiftlint:disable:next dont_print
+                              print("Hello, world")
                               """)
         let violations = violations(example, config: configuration)
         XCTAssertTrue(violations.isEmpty)

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -195,6 +195,66 @@ final class CustomRulesTests: SwiftLintTestCase {
         XCTAssertEqual(violations[0].location.character, 6)
     }
 
+    func testSuperfluousDisableCommandWithCustomRules() throws {
+        let customRulesConfiguration: [String: Any] = [
+            "custom1": [
+                "regex": "pattern",
+                "match_kinds": "comment"
+            ]
+        ]
+
+        let example = Example(
+            "// swiftlint:disable custom1\n",
+            configuration: customRulesConfiguration
+        ).skipWrappingInCommentTest()
+        let configuration = try XCTUnwrap(makeConfig(["custom_rules": customRulesConfiguration], "custom_rules"))
+        let violations = violations(example, config: configuration)
+
+        XCTAssertEqual(violations.count, 1)
+        XCTAssertTrue(violations.allSatisfy { $0.ruleIdentifier == "superfluous_disable_command" })
+        XCTAssertTrue(violations.contains { violation in
+            violation.description.contains("SwiftLint rule 'custom1' did not trigger a violation")
+        })
+    }
+
+    func testSuperfluousDisableCommandWithMultipleCustomRules() throws {
+        let customRulesConfiguration: [String: Any] = [
+            "custom1": [
+                "regex": "pattern",
+                "match_kinds": "comment"
+            ],
+            "custom2": [
+                "regex": "10",
+                "match_kinds": "number"
+            ],
+            "custom3": [
+                "regex": "100",
+                "match_kinds": "number"
+            ]
+        ]
+
+        let example = Example(
+            """
+            // swiftlint:disable custom1 custom3
+            return 10
+
+            """,
+            configuration: customRulesConfiguration
+        ).skipWrappingInCommentTest()
+        let configuration = try XCTUnwrap(makeConfig(["custom_rules": customRulesConfiguration], "custom_rules"))
+        let violations = violations(example, config: configuration)
+
+        XCTAssertEqual(violations.count, 3)
+        XCTAssertEqual(violations.filter { $0.ruleIdentifier == "superfluous_disable_command" }.count, 2)
+        XCTAssertEqual(violations.filter { $0.ruleIdentifier == "custom2" }.count, 1)
+        XCTAssertTrue(violations.contains { violation in
+            violation.description.contains("SwiftLint rule 'custom1' did not trigger a violation")
+        })
+        XCTAssertTrue(violations.contains { violation in
+            violation.description.contains("SwiftLint rule 'custom3' did not trigger a violation")
+        })
+    }
+
     private func getCustomRules(_ extraConfig: [String: Any] = [:]) -> (Configuration, CustomRules) {
         var config: [String: Any] = [
             "regex": "pattern",

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -256,7 +256,6 @@ final class CustomRulesTests: SwiftLintTestCase {
         })
     }
 
-
     func testSuperfluousDisableCommandDoesNotViolate() throws {
         let customRules: [String: Any] = [
             "dont_print": [

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -126,8 +126,8 @@ final class CustomRulesTests: SwiftLintTestCase {
         let customRules: [String: Any] = [
             "custom": [
                 "regex": "pattern",
-                "match_kinds": "comment"
-            ]
+                "match_kinds": "comment",
+            ],
         ]
         let example = Example("//swiftlint:disable custom \n// file with a pattern")
         let violations = try violations(forExample: example, customRules: customRules)
@@ -206,8 +206,8 @@ final class CustomRulesTests: SwiftLintTestCase {
         let customRules: [String: Any] = [
             "custom1": [
                 "regex": "pattern",
-                "match_kinds": "comment"
-            ]
+                "match_kinds": "comment",
+            ],
         ]
 
         let example = Example("// swiftlint:disable custom1\n")
@@ -224,16 +224,16 @@ final class CustomRulesTests: SwiftLintTestCase {
         let customRules: [String: Any] = [
             "custom1": [
                 "regex": "pattern",
-                "match_kinds": "comment"
+                "match_kinds": "comment",
             ],
             "custom2": [
                 "regex": "10",
-                "match_kinds": "number"
+                "match_kinds": "number",
             ],
             "custom3": [
                 "regex": "100",
-                "match_kinds": "number"
-            ]
+                "match_kinds": "number",
+            ],
         ]
 
         let example = Example(

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -269,6 +269,19 @@ final class CustomRulesTests: SwiftLintTestCase {
         XCTAssertTrue(try violations(forExample: example, customRules: customRules).isEmpty)
     }
 
+    func testDisableAll() throws {
+        let customRules: [String: Any] = [
+            "dont_print": [
+                "regex": "print\\("
+            ]
+        ]
+        let example = Example("""
+                              // swiftlint:disable:next all
+                              print("Hello, world")
+                              """)
+        XCTAssertTrue(try violations(forExample: example, customRules: customRules).isEmpty)
+    }
+
     private func getCustomRules(_ extraConfig: [String: Any] = [:]) -> (Configuration, CustomRules) {
         var config: [String: Any] = [
             "regex": "pattern",

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -260,7 +260,7 @@ final class CustomRulesTests: SwiftLintTestCase {
         let customRules: [String: Any] = [
             "dont_print": [
                 "regex": "print\\("
-            ]
+            ],
         ]
         let example = Example("""
                               // swiftlint:disable:next dont_print
@@ -273,7 +273,7 @@ final class CustomRulesTests: SwiftLintTestCase {
         let customRules: [String: Any] = [
             "dont_print": [
                 "regex": "print\\("
-            ]
+            ],
         ]
         let example = Example("""
                               // swiftlint:disable:next all
@@ -344,7 +344,7 @@ final class CustomRulesTests: SwiftLintTestCase {
     private func violations(forExample example: Example, customRules: [String: Any]) throws -> [StyleViolation] {
         let configDict: [String: Any] = [
             "only_rules": ["custom_rules", "superfluous_disable_command"],
-            "custom_rules": customRules
+            "custom_rules": customRules,
         ]
         let configuration = try SwiftLintCore.Configuration(dict: configDict)
         return SwiftLintTestHelpers.violations(


### PR DESCRIPTION

Very much a work in progress, so please ignore for now.

This is redo of #4755 (which was reverted in #5336). 

I took the original changes from #4755 and worked from there. The changes I've made on top of the original PR can be seen at https://github.com/mildm8nnered/SwiftLint/compare/mildm8nnered-marcelos-changes-back...mildm8nnered:SwiftLint:mildm8nnered-fix-superfluous-disable-command-for-custom-rules

I thought this was good, but `custom_rules` now seems to be picking up issues that it didn't see before (`fatalError`), and there were some issues with superfluous triggering in some tests that I was not expecting either, so I think more work is required here.
