### PR TITLE
Add new `prefer_key_path` rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -37,6 +37,7 @@ disabled_rules:
   - no_grouping_extension
   - no_magic_numbers
   - one_declaration_per_file
+  - prefer_key_path
   - prefer_nimble
   - prefixed_toplevel_constant
   - required_deinit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@
   [woxtu](https://github.com/woxtu)  
   [SimplyDanny](https://github.com/SimplyDanny)  
 
+* Add new `prefer_key_path` rule that triggers when a trailing closure on a function 
+  call is only hosting a (chained) member access expression since the closure can be
+  replaced with a key path argument.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+
 * Adds `baseline` and `write_baseline` configuration file settings, equivalent
   to the `--baseline` and `--write-baseline` command line options.  
   [Martin Redington](https://github.com/mildm8nnered)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,15 +5,15 @@ module(
     repo_name = "SwiftLint",
 )
 
-bazel_dep(name = "apple_support", version = "1.13.0", repo_name = "build_bazel_apple_support")
-bazel_dep(name = "bazel_skylib", version = "1.5.0")
-bazel_dep(name = "platforms", version = "0.0.8")
-bazel_dep(name = "rules_apple", version = "3.3.0", repo_name = "build_bazel_rules_apple")
-bazel_dep(name = "rules_swift", version = "1.16.0", repo_name = "build_bazel_rules_swift")
+bazel_dep(name = "apple_support", version = "1.16.0", repo_name = "build_bazel_apple_support")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "rules_apple", version = "3.6.0", repo_name = "build_bazel_rules_apple")
+bazel_dep(name = "rules_swift", version = "1.18.0", repo_name = "build_bazel_rules_swift")
 bazel_dep(name = "sourcekitten", version = "0.35.0", repo_name = "com_github_jpsim_sourcekitten")
 bazel_dep(name = "swift-syntax", version = "600.0.0-prerelease-2024-07-24", repo_name = "SwiftSyntax")
 bazel_dep(name = "swift_argument_parser", version = "1.3.1", repo_name = "sourcekitten_com_github_apple_swift_argument_parser")
-bazel_dep(name = "yams", version = "5.0.6", repo_name = "sourcekitten_com_github_jpsim_yams")
+bazel_dep(name = "yams", version = "5.1.3", repo_name = "sourcekitten_com_github_jpsim_yams")
 
 swiftlint_repos = use_extension("//bazel:repos.bzl", "swiftlint_repos_bzlmod")
 use_repo(

--- a/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
+++ b/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
@@ -147,6 +147,7 @@ public let builtInRules: [any Rule.Type] = [
     OverrideInExtensionRule.self,
     PatternMatchingKeywordsRule.self,
     PeriodSpacingRule.self,
+    PreferKeyPathRule.self,
     PreferNimbleRule.self,
     PreferSelfInStaticReferencesRule.self,
     PreferSelfTypeOverTypeOfSelfRule.self,

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferKeyPathRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferKeyPathRule.swift
@@ -1,0 +1,71 @@
+import SwiftLintCore
+import SwiftSyntax
+
+@SwiftSyntaxRule
+struct PreferKeyPathRule: OptInRule {
+    var configuration = SeverityConfiguration<Self>(.warning)
+
+    static var description = RuleDescription(
+        identifier: "prefer_key_path",
+        name: "Prefer Key Path",
+        description: "Use a key path argument instead of a closure with property access",
+        kind: .idiomatic,
+        minSwiftVersion: .fiveDotTwo,
+        nonTriggeringExamples: [
+            Example("f {}"),
+            Example("f { $0 }"),
+            Example("f() { g() }"),
+            Example("f { a.b.c }"),
+            Example("f { a in a }"),
+            Example("f { a, b in a.b }"),
+            Example("f { (a, b) in a.b }"),
+        ],
+        triggeringExamples: [
+            Example("f ↓{ $0.a }"),
+            Example("f ↓{ a in a.b }"),
+            Example("f ↓{ a in a.b.c }"),
+            Example("f ↓{ (a: A) in a.b }"),
+            Example("f ↓{ (a b: A) in b.c }"),
+            Example("f ↓{ $0.0.a }"),
+            Example("f(a: ↓{ $0.b })"),
+            Example("f { 1 } a: ↓{ $0.b }"),
+            Example("let f: (Int) -> Int = ↓{ $0.bigEndian }"),
+        ]
+    )
+}
+
+private extension PreferKeyPathRule {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
+        override func visitPost(_ node: ClosureExprSyntax) {
+            if case let .expr(expr) = node.statements.onlyElement?.item,
+               expr.accesses(identifier: node.onlyParameter) {
+                violations.append(node.positionAfterSkippingLeadingTrivia)
+            }
+        }
+    }
+}
+
+private extension ExprSyntax {
+    func accesses(identifier: String?) -> Bool {
+        if let base = `as`(MemberAccessExprSyntax.self)?.base {
+            if let declRef = base.as(DeclReferenceExprSyntax.self) {
+                return declRef.baseName.text == identifier ?? "$0"
+            }
+            return base.accesses(identifier: identifier)
+        }
+        return false
+    }
+}
+
+private extension ClosureExprSyntax {
+    var onlyParameter: String? {
+        switch signature?.parameterClause {
+        case let .simpleInput(params):
+            return params.onlyElement?.name.text
+        case let .parameterClause(params):
+            let param = params.parameters.onlyElement
+            return param?.secondName?.text ?? param?.firstName.text
+        case nil: return nil
+        }
+    }
+}

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PreferKeyPathConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PreferKeyPathConfiguration.swift
@@ -1,0 +1,11 @@
+import SwiftLintCore
+
+@AutoConfigParser
+struct PreferKeyPathConfiguration: SeverityBasedRuleConfiguration {
+    typealias Parent = PreferKeyPathRule
+
+    @ConfigurationElement(key: "severity")
+    private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement(key: "restrict_to_standard_functions")
+    private(set) var restrictToStandardFunctions = true
+}

--- a/Tests/GeneratedTests/GeneratedTests.swift
+++ b/Tests/GeneratedTests/GeneratedTests.swift
@@ -871,6 +871,12 @@ final class PeriodSpacingRuleGeneratedTests: SwiftLintTestCase {
     }
 }
 
+final class PreferKeyPathRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(PreferKeyPathRule.description)
+    }
+}
+
 final class PreferNimbleRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(PreferNimbleRule.description)

--- a/Tests/IntegrationTests/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/default_rule_configurations.yml
@@ -400,6 +400,7 @@ period_spacing:
   severity: warning
 prefer_key_path:
   severity: warning
+  restrict_to_standard_functions: true
 prefer_nimble:
   severity: warning
 prefer_self_in_static_references:

--- a/Tests/IntegrationTests/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/default_rule_configurations.yml
@@ -398,6 +398,8 @@ pattern_matching_keywords:
   severity: warning
 period_spacing:
   severity: warning
+prefer_key_path:
+  severity: warning
 prefer_nimble:
   severity: warning
 prefer_self_in_static_references:


### PR DESCRIPTION
This new rule triggers on code like
```swift
list.filter { $0.isValid }
```
which can be replaced by
```swift
list.filter(\.isValid)
```
as of Swift 5.2.

Automatic fixes fail once the argument label for the closure is named. The fix would need to know its name and insert it in the function call. But that's impossible for a syntax-based rule. We could do auto-fixes for simple cases like `map` and `filter` (which represent most of the findings in OSS projects and SwiftLint itself) at least. I'm not sure if partial fixes are a good thing though.