### PR TITLE
Disable deprecated rules

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -11,6 +11,7 @@ opt_in_rules:
   - all
 disabled_rules:
   - anonymous_argument_in_multiline_closure
+  - anyobject_protocol
   - closure_body_length
   - conditional_returns_on_newline
   - convenience_type
@@ -24,6 +25,7 @@ disabled_rules:
   - function_default_parameter_at_end
   - implicit_return
   - indentation_width
+  - inert_defer
   - missing_docs
   - multiline_arguments
   - multiline_arguments_brackets
@@ -45,6 +47,7 @@ disabled_rules:
   - todo
   - trailing_closure
   - type_contents_order
+  - unused_capture_list
   - vertical_whitespace_between_cases
 
 attributes:


### PR DESCRIPTION
Having them enabled causes warnings in the output while running SwiftLint. They will be removed entirely soon anyway.