### PR TITLE
Adds `baseline` and `write_baseline` config file options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -292,7 +292,7 @@
 * Adds `baseline` and `write_baseline` configuration file settings, equivalent
   to the `--baseline` and `--write-baseline` command line options.  
   [Martin Redington](https://github.com/mildm8nnered)
-  [#XXXX](https://github.com/realm/SwiftLint/issues/XXXX)
+  [#5552](https://github.com/realm/SwiftLint/issues/5552)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,6 +289,10 @@
   consider said types in declarations like `let i: Int = 1` or
   `let s: String = ""` as redundant.  
   [Garric Nahapetian](https://github.com/garricn)
+* Adds `baseline` and `write_baseline` configuration file settings, equivalent
+  to the `--baseline` and `--write-baseline` command line options.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#XXXX](https://github.com/realm/SwiftLint/issues/XXXX)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,6 +289,7 @@
   consider said types in declarations like `let i: Int = 1` or
   `let s: String = ""` as redundant.  
   [Garric Nahapetian](https://github.com/garricn)
+
 * Adds `baseline` and `write_baseline` configuration file settings, equivalent
   to the `--baseline` and `--write-baseline` command line options.  
   [Martin Redington](https://github.com/mildm8nnered)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@
   improvements done in the [SwiftSyntax](https://github.com/apple/swift-syntax)
   library.
 
+* Adds `baseline` and `write_baseline` configuration file settings, equivalent
+  to the `--baseline` and `--write-baseline` command line options.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#5552](https://github.com/realm/SwiftLint/issues/5552)
+
 #### Bug Fixes
 
 * Fix a few false positives and negatives by updating the parser to support
@@ -289,11 +294,6 @@
   consider said types in declarations like `let i: Int = 1` or
   `let s: String = ""` as redundant.  
   [Garric Nahapetian](https://github.com/garricn)
-
-* Adds `baseline` and `write_baseline` configuration file settings, equivalent
-  to the `--baseline` and `--write-baseline` command line options.  
-  [Martin Redington](https://github.com/mildm8nnered)
-  [#5552](https://github.com/realm/SwiftLint/issues/5552)
 
 #### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -697,6 +697,12 @@ allow_zero_lintable_files: false
 # If true, SwiftLint will treat all warnings as errors.
 strict: false
 
+# The path to a baseline file, which will be used to filter out detected violations.
+baseline: Baseline.json
+
+# The path to save detected violations to as a new baseline.
+write_baseline: Baseline.json
+
 # configurable rules can be customized from this configuration file
 # binary rules can set their severity level
 force_cast: warning # implicitly

--- a/Source/SwiftLintCore/Extensions/Configuration+Merging.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Merging.swift
@@ -25,7 +25,9 @@ extension Configuration {
             reporter: reporter,
             cachePath: cachePath,
             allowZeroLintableFiles: childConfiguration.allowZeroLintableFiles,
-            strict: childConfiguration.strict
+            strict: childConfiguration.strict,
+            baseline: childConfiguration.baseline,
+            writeBaseline: childConfiguration.writeBaseline
         )
     }
 

--- a/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
@@ -15,6 +15,8 @@ extension Configuration {
         case analyzerRules = "analyzer_rules"
         case allowZeroLintableFiles = "allow_zero_lintable_files"
         case strict = "strict"
+        case baseline = "baseline"
+        case writeBaseline = "write_baseline"
         case childConfig = "child_config"
         case parentConfig = "parent_config"
         case remoteConfigTimeout = "remote_timeout"
@@ -95,7 +97,9 @@ extension Configuration {
             cachePath: cachePath ?? dict[Key.cachePath.rawValue] as? String,
             pinnedVersion: dict[Key.swiftlintVersion.rawValue].map { ($0 as? String) ?? String(describing: $0) },
             allowZeroLintableFiles: dict[Key.allowZeroLintableFiles.rawValue] as? Bool ?? false,
-            strict: dict[Key.strict.rawValue] as? Bool ?? false
+            strict: dict[Key.strict.rawValue] as? Bool ?? false,
+            baseline: dict[Key.baseline.rawValue] as? String,
+            writeBaseline: dict[Key.writeBaseline.rawValue] as? String
         )
     }
 

--- a/Source/SwiftLintCore/Models/Configuration.swift
+++ b/Source/SwiftLintCore/Models/Configuration.swift
@@ -35,8 +35,14 @@ public struct Configuration {
     /// Allow or disallow SwiftLint to exit successfully when passed only ignored or unlintable files.
     public let allowZeroLintableFiles: Bool
 
-    /// Treat warnings as errors
+    /// Treat warnings as errors.
     public let strict: Bool
+
+    /// The path to read a baseline from.
+    public let baseline: String?
+
+    /// The path to write a baseline to.
+    public let writeBaseline: String?
 
     /// This value is `true` iff the `--config` parameter was used to specify (a) configuration file(s)
     /// In particular, this means that the value is also `true` if the `--config` parameter
@@ -73,7 +79,9 @@ public struct Configuration {
         reporter: String?,
         cachePath: String?,
         allowZeroLintableFiles: Bool,
-        strict: Bool
+        strict: Bool,
+        baseline: String?,
+        writeBaseline: String?
     ) {
         self.rulesWrapper = rulesWrapper
         self.fileGraph = fileGraph
@@ -85,6 +93,8 @@ public struct Configuration {
         self.cachePath = cachePath
         self.allowZeroLintableFiles = allowZeroLintableFiles
         self.strict = strict
+        self.baseline = baseline
+        self.writeBaseline = writeBaseline
     }
 
     /// Creates a Configuration by copying an existing configuration.
@@ -102,6 +112,8 @@ public struct Configuration {
         cachePath = configuration.cachePath
         allowZeroLintableFiles = configuration.allowZeroLintableFiles
         strict = configuration.strict
+        baseline = configuration.baseline
+        writeBaseline = configuration.writeBaseline
     }
 
     /// Creates a `Configuration` by specifying its properties directly,
@@ -122,8 +134,11 @@ public struct Configuration {
     /// - parameter reporter:               The identifier for the `Reporter` to use to report style violations.
     /// - parameter cachePath:              The location of the persisted cache to use whith this configuration.
     /// - parameter pinnedVersion:          The SwiftLint version defined in this configuration.
-    /// - parameter allowZeroLintableFiles: Allow SwiftLint to exit successfully when passed ignored or unlintable files
-    /// - parameter strict:                 Treat warnings as errors
+    /// - parameter allowZeroLintableFiles: Allow SwiftLint to exit successfully when passed ignored or unlintable
+    ///                                     files.
+    /// - parameter strict:                 Treat warnings as errors.
+    /// - parameter baseline:               The path to read a baseline from.
+    /// - parameter writeBaseline:          The path to write a baseline to.
     package init(
         rulesMode: RulesMode = .default(disabled: [], optIn: []),
         allRulesWrapped: [ConfigurationRuleWrapper]? = nil,
@@ -137,7 +152,9 @@ public struct Configuration {
         cachePath: String? = nil,
         pinnedVersion: String? = nil,
         allowZeroLintableFiles: Bool = false,
-        strict: Bool = false
+        strict: Bool = false,
+        baseline: String? = nil,
+        writeBaseline: String? = nil
     ) {
         if let pinnedVersion, pinnedVersion != Version.current.value {
             queuedPrintError(
@@ -163,7 +180,9 @@ public struct Configuration {
             reporter: reporter,
             cachePath: cachePath,
             allowZeroLintableFiles: allowZeroLintableFiles,
-            strict: strict
+            strict: strict,
+            baseline: baseline,
+            writeBaseline: writeBaseline
         )
     }
 
@@ -268,6 +287,8 @@ extension Configuration: Hashable {
         hasher.combine(reporter)
         hasher.combine(allowZeroLintableFiles)
         hasher.combine(strict)
+        hasher.combine(baseline)
+        hasher.combine(writeBaseline)
         hasher.combine(basedOnCustomConfigurationFiles)
         hasher.combine(cachePath)
         hasher.combine(rules.map { type(of: $0).description.identifier })
@@ -286,6 +307,8 @@ extension Configuration: Hashable {
             lhs.fileGraph == rhs.fileGraph &&
             lhs.allowZeroLintableFiles == rhs.allowZeroLintableFiles &&
             lhs.strict == rhs.strict &&
+            lhs.baseline == rhs.baseline &&
+            lhs.writeBaseline == rhs.writeBaseline &&
             lhs.rulesMode == rhs.rulesMode
     }
 }

--- a/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
+++ b/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
@@ -44,8 +44,7 @@ struct LintOrAnalyzeCommand {
     private static func lintOrAnalyze(_ options: LintOrAnalyzeOptions) async throws {
         let builder = LintOrAnalyzeResultBuilder(options)
         let files = try await collectViolations(builder: builder)
-        let baselineOutputPath = options.writeBaseline ?? builder.configuration.writeBaseline
-        if let baselineOutputPath {
+        if let baselineOutputPath = options.writeBaseline ?? builder.configuration.writeBaseline {
             try Baseline(violations: builder.unfilteredViolations).write(toPath: baselineOutputPath)
         }
         try Signposts.record(name: "LintOrAnalyzeCommand.PostProcessViolations") {

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -56,6 +56,8 @@ final class ConfigurationTests: SwiftLintTestCase {
         XCTAssertEqual(reporterFrom(identifier: config.reporter).identifier, "xcode")
         XCTAssertFalse(config.allowZeroLintableFiles)
         XCTAssertFalse(config.strict)
+        XCTAssertNil(config.baseline)
+        XCTAssertNil(config.writeBaseline)
     }
 
     func testInitWithRelativePathAndRootPath() {
@@ -70,6 +72,8 @@ final class ConfigurationTests: SwiftLintTestCase {
         XCTAssertEqual(config.reporter, expectedConfig.reporter)
         XCTAssertTrue(config.allowZeroLintableFiles)
         XCTAssertTrue(config.strict)
+        XCTAssertNotNil(config.baseline)
+        XCTAssertNotNil(config.writeBaseline)
     }
 
     func testEnableAllRulesConfiguration() throws {
@@ -426,6 +430,18 @@ final class ConfigurationTests: SwiftLintTestCase {
     func testStrict() throws {
         let configuration = try Configuration(dict: ["strict": true])
         XCTAssertTrue(configuration.strict)
+    }
+
+    func testBaseline() throws {
+        let baselinePath = "Baseline.json"
+        let configuration = try Configuration(dict: ["baseline": baselinePath])
+        XCTAssertEqual(configuration.baseline, baselinePath)
+    }
+
+    func testWriteBaseline() throws {
+        let baselinePath = "Baseline.json"
+        let configuration = try Configuration(dict: ["write_baseline": baselinePath])
+        XCTAssertEqual(configuration.writeBaseline, baselinePath)
     }
 }
 

--- a/Tests/SwiftLintFrameworkTests/Resources/ProjectMock/.swiftlint.yml
+++ b/Tests/SwiftLintFrameworkTests/Resources/ProjectMock/.swiftlint.yml
@@ -8,3 +8,5 @@ line_length: 10000000000
 reporter: "json"
 allow_zero_lintable_files: true
 strict: true
+baseline: Baseline.json
+write_baseline: Baseline.json


### PR DESCRIPTION
So baselines can be used by people who can't pass command line arguments (e.g. plugin users).

`baseline` and `write_baseline` - these behave exactly the same way as their command line equivalents. The command line will take preference if there is a conflict, but there is not way to "unset" the config file entries from the command line - if there is a `baseline` config file entry, you can override it to be a different value, but there is no way to tell SwiftLint "don't read a baseline at all".

This is very similar to the PR from a while ago adding a `strict` config option - #5226
