### PR TITLE
Remove severity as a baseline key, as it interacts poorly with `--strict`

### DIFF
--- a/Source/SwiftLintCore/Models/Baseline.swift
+++ b/Source/SwiftLintCore/Models/Baseline.swift
@@ -7,7 +7,7 @@ private typealias ViolationsPerRule = [String: BaselineViolations]
 private struct BaselineViolation: Codable, Hashable {
     let violation: StyleViolation
     let text: String
-    var key: String { text + violation.reason + violation.severity.rawValue }
+    var key: String { text + violation.reason }
 
     init(violation: StyleViolation, text: String) {
         let location = violation.location


### PR DESCRIPTION

I've been dogfooding baselines, and there's an unfortunate interaction with `--strict`, because we use severity as part of the key for determining which violations are new.

The original idea behind including severity was that if some violations are warnings, and they suddenly become errors, then maybe you would want to know about that.

But of course, with `--strict`, all warning become errors, but you probably don't want to get alerted to thousands of violations.

My use case was `danger`, where I have `swiftlint.lint_files inline_mode: true, fail_on_error: true, additional_swiftlint_args: '--strict'` in my dangerfile
