### PR TITLE
Ignore but report invalid keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,11 @@
 
 #### Bug Fixes
 
+* Invalid keys in a configuration don't lead to the default configuration being
+  used anymore. The invalid key will just be reported but otherwise ignored.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#5565](https://github.com/realm/SwiftLint/issues/5565)
+
 * Fix version comparison algorithm which caused some version-dependent rules to
   misbehave with Swift 5.10.  
   [chandlerwall](https://github.com/chandlerwall)

--- a/Source/SwiftLintCore/Models/Issue.swift
+++ b/Source/SwiftLintCore/Models/Issue.swift
@@ -86,7 +86,7 @@ public enum Issue: LocalizedError, Equatable {
     /// - returns: The collected messages produced while running the code in the runner.
     static func captureConsole(runner: () throws -> Void) rethrows -> String {
         var console = ""
-        messageConsumer = { console += $0 }
+        messageConsumer = { console += (console.isEmpty ? "" : "\n") + $0 }
         defer { messageConsumer = nil }
         try runner()
         return console

--- a/Source/SwiftLintCoreMacros/RuleConfigurationMacros.swift
+++ b/Source/SwiftLintCoreMacros/RuleConfigurationMacros.swift
@@ -80,7 +80,7 @@ enum AutoApply: MemberMacro {
                 """
                 if !supportedKeys.isSuperset(of: configuration.keys) {
                     let unknownKeys = Set(configuration.keys).subtracting(supportedKeys)
-                    throw Issue.invalidConfigurationKeys(ruleID: Parent.identifier, keys: unknownKeys)
+                    Issue.invalidConfigurationKeys(ruleID: Parent.identifier, keys: unknownKeys).print()
                 }
                 """
             })

--- a/Tests/MacroTests/AutoApplyTests.swift
+++ b/Tests/MacroTests/AutoApplyTests.swift
@@ -42,7 +42,7 @@ final class AutoApplyTests: XCTestCase {
                     }
                     if !supportedKeys.isSuperset(of: configuration.keys) {
                         let unknownKeys = Set(configuration.keys).subtracting(supportedKeys)
-                        throw Issue.invalidConfigurationKeys(ruleID: Parent.identifier, keys: unknownKeys)
+                        Issue.invalidConfigurationKeys(ruleID: Parent.identifier, keys: unknownKeys).print()
                     }
                 }
             }
@@ -84,7 +84,7 @@ final class AutoApplyTests: XCTestCase {
                     try eB.apply(configuration[$eB.key], ruleID: Parent.identifier)
                     if !supportedKeys.isSuperset(of: configuration.keys) {
                         let unknownKeys = Set(configuration.keys).subtracting(supportedKeys)
-                        throw Issue.invalidConfigurationKeys(ruleID: Parent.identifier, keys: unknownKeys)
+                        Issue.invalidConfigurationKeys(ruleID: Parent.identifier, keys: unknownKeys).print()
                     }
                 }
             }
@@ -135,7 +135,7 @@ final class AutoApplyTests: XCTestCase {
                     try eC.apply(configuration[$eC.key], ruleID: Parent.identifier)
                     if !supportedKeys.isSuperset(of: configuration.keys) {
                         let unknownKeys = Set(configuration.keys).subtracting(supportedKeys)
-                        throw Issue.invalidConfigurationKeys(ruleID: Parent.identifier, keys: unknownKeys)
+                        Issue.invalidConfigurationKeys(ruleID: Parent.identifier, keys: unknownKeys).print()
                     }
                 }
             }
@@ -161,7 +161,7 @@ final class AutoApplyTests: XCTestCase {
                     }
                     if !supportedKeys.isSuperset(of: configuration.keys) {
                         let unknownKeys = Set(configuration.keys).subtracting(supportedKeys)
-                        throw Issue.invalidConfigurationKeys(ruleID: Parent.identifier, keys: unknownKeys)
+                        Issue.invalidConfigurationKeys(ruleID: Parent.identifier, keys: unknownKeys).print()
                     }
                 }
             }
@@ -215,7 +215,7 @@ final class AutoApplyTests: XCTestCase {
                     try foo.apply(configuration[$foo.key], ruleID: Parent.identifier)
                     if !supportedKeys.isSuperset(of: configuration.keys) {
                         let unknownKeys = Set(configuration.keys).subtracting(supportedKeys)
-                        throw Issue.invalidConfigurationKeys(ruleID: Parent.identifier, keys: unknownKeys)
+                        Issue.invalidConfigurationKeys(ruleID: Parent.identifier, keys: unknownKeys).print()
                     }
                 }
             }

--- a/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceConfigurationTests.swift
@@ -21,9 +21,10 @@ final class ExplicitTypeInterfaceConfigurationTests: SwiftLintTestCase {
 
     func testInvalidKeyInCustomConfiguration() {
         var config = ExplicitTypeInterfaceConfiguration()
-        checkError(Issue.invalidConfigurationKeys(ruleID: ExplicitTypeInterfaceRule.identifier, keys: ["invalidKey"])) {
-            try config.apply(configuration: ["invalidKey": "error"])
-        }
+        XCTAssertEqual(
+            try Issue.captureConsole { try config.apply(configuration: ["invalidKey": "error"]) },
+            "warning: Configuration for 'explicit_type_interface' rule contains the invalid key(s) 'invalidKey'."
+        )
     }
 
     func testInvalidTypeOfCustomConfiguration() {

--- a/Tests/SwiftLintFrameworkTests/RuleConfigurationDescriptionTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleConfigurationDescriptionTests.swift
@@ -502,14 +502,20 @@ final class RuleConfigurationDescriptionTests: XCTestCase {
     func testInvalidKeys() throws {
         var configuration = TestConfiguration()
 
-        checkError(Issue.invalidConfigurationKeys(ruleID: "RuleMock", keys: ["unknown", "unsupported"])) {
-            try configuration.apply(configuration: [
-                "severity": "error",
-                "warning": 3,
-                "unknown": 1,
-                "unsupported": true
-            ])
-        }
+        XCTAssertEqual(
+            try Issue.captureConsole {
+                try configuration.apply(configuration: [
+                    "severity": "error",
+                    "warning": 3,
+                    "unknown": 1,
+                    "unsupported": true
+                ])
+            },
+            """
+            warning: Configuration option 'set' in 'my_rule' rule is deprecated. Use the option 'other_opt' instead.
+            warning: Configuration for 'RuleMock' rule contains the invalid key(s) 'unknown', 'unsupported'.
+            """
+        )
     }
 
     private func description(@RuleConfigurationDescriptionBuilder _ content: () -> RuleConfigurationDescription)


### PR DESCRIPTION
In other words, don't fall back to the default configuration due to invalid keys.

Fixes #5565.