### PR TITLE
[New rule] Add new rule for functions parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 #### Enhancements
 
-* None.
+* [New rule] Add new rule for functions parameters.  
+  [kimdv](https://github.com/kimdv)
+  [#issue_number](https://github.com/realm/SwiftLint/issues/5564)
 
 #### Bug Fixes
 

--- a/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
+++ b/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
@@ -81,6 +81,7 @@ public let builtInRules: [any Rule.Type] = [
     FunctionBodyLengthRule.self,
     FunctionDefaultParameterAtEndRule.self,
     FunctionParameterCountRule.self,
+    FunctionParametersNewlineRule.self,
     GenericTypeNameRule.self,
     IBInspectableInExtensionRule.self,
     IdenticalOperandsRule.self,

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/FunctionParametersNewlineRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/FunctionParametersNewlineRule.swift
@@ -1,0 +1,91 @@
+import SwiftSyntax
+
+@SwiftSyntaxRule
+struct FunctionParametersNewlineRule: OptInRule {
+    var configuration = FunctionParametersNewlineConfiguration()
+
+    static let description = RuleDescription(
+        identifier: "function_parameters_newline",
+        name: "Function parameters newline",
+        description: "Function parameters should be on a new line",
+        kind: .lint,
+        nonTriggeringExamples: [
+            Example("func foo() {}", configuration: ["leading_paren_on_newline": true, "trailing_paren_on_newline": true]),
+            Example("func foo() {}"),
+            Example("""
+            func foo(bar: Bar,
+                baz: Baz) {}
+            """),
+            Example("""
+            func foo(
+                bar: Bar,
+                baz: Baz) {}
+            """),
+            Example("""
+            func foo(
+                bar: Bar,
+                baz: Baz
+            ) {}
+            """),
+            Example("""
+            func foo(
+                bar: Bar,
+                baz: Baz
+            ) {}
+            """, configuration: ["leading_paren_on_newline": true, "trailing_paren_on_newline": true]),
+            Example("""
+            func foo(bar: Bar,
+                bar: Bar
+            ) {}
+            """),
+            Example("init(bar: Bar) {}"),
+        ],
+        triggeringExamples: [
+            Example("func foo(bar: Bar, ↓baz: Baz) {}"),
+            Example("func foo(↓bar: Bar, ↓baz: Baz) {}", configuration: ["leading_paren_on_newline": true]),
+            Example("func foo(bar: Bar, ↓baz: Baz↓) {}", configuration: ["trailing_paren_on_newline": true]),
+            Example("init(bar: Bar, ↓baz: Baz, ↓foo: Foo) {}"),
+            Example("""
+            func foo(bar: Bar,
+                bar: Bar, ↓foo: Foo
+            ) {}
+            """),
+        ]
+    )
+}
+
+private extension FunctionParametersNewlineRule {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
+        override func visitPost(_ node: FunctionParameterClauseSyntax) {
+            if configuration.leadingParenOnNewline, let parameter = node.parameters.first, parameter.isMissingLeadingNewline {
+                violations.append(parameter.positionAfterSkippingLeadingTrivia)
+            }
+
+            guard node.parameters.count > 1 else {
+                return
+            }
+
+            let parameters = node.parameters.dropFirst()
+
+            for parameter in parameters where parameter.isMissingLeadingNewline {
+                violations.append(parameter.positionAfterSkippingLeadingTrivia)
+            }
+
+            if configuration.trailingParenOnNewline, node.rightParen.isMissingLeadingNewline {
+                violations.append(node.rightParen.positionAfterSkippingLeadingTrivia)
+            }
+        }
+    }
+}
+
+fileprivate extension FunctionParameterSyntax {
+    var isMissingLeadingNewline: Bool {
+        return leadingTrivia.isEmpty || leadingTrivia.first?.isNewline == false
+    }
+}
+
+fileprivate extension TokenSyntax {
+    var isMissingLeadingNewline: Bool {
+        return leadingTrivia.isEmpty || leadingTrivia.first?.isNewline == false
+    }
+}

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FunctionParametersNewlineConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FunctionParametersNewlineConfiguration.swift
@@ -1,0 +1,13 @@
+import SwiftLintCore
+
+@AutoApply
+struct FunctionParametersNewlineConfiguration: SeverityBasedRuleConfiguration {
+    typealias Parent = FunctionParametersNewlineRule
+
+    @ConfigurationElement(key: "severity")
+    private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement(key: "leading_paren_on_newline")
+    private(set) var leadingParenOnNewline = false
+    @ConfigurationElement(key: "trailing_paren_on_newline")
+    private(set) var trailingParenOnNewline = false
+}

--- a/Tests/GeneratedTests/GeneratedTests.swift
+++ b/Tests/GeneratedTests/GeneratedTests.swift
@@ -475,6 +475,12 @@ final class FunctionParameterCountRuleGeneratedTests: SwiftLintTestCase {
     }
 }
 
+final class FunctionParametersNewlineRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(FunctionParametersNewlineRule.description)
+    }
+}
+
 final class GenericTypeNameRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(GenericTypeNameRule.description)


### PR DESCRIPTION
Fixes: https://github.com/realm/SwiftLint/issues/5564

This rule will ensure that all parameters are on a newline. 
This will enhance the diff when doing reviews. 

Not sure if we also should expand this rule for arrays and dictionaries. But I think it would be best to split those rules into multiple. 