### PR TITLE
Silence `unused_enumerated` rule when `$0` in a closure is explicitly unpacked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@
 
 #### Bug Fixes
 
-* None.
+* Silence `unused_enumerated` rule when `$0` in a closure is explicitly unpacked.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#5573](https://github.com/realm/SwiftLint/issues/5573)
 
 ## 0.55.0: Universal Washing Powder
 


### PR DESCRIPTION
The fix is quite specific for this single case. What are other cases where an "unpack" can happen? We could further check if `i` and `e` are actually used. But that's out of scope for this fix.

Fixes #5573.