### PR TITLE
Mark rule registry as sendable

### DIFF
--- a/Source/SwiftLintCore/Models/RuleRegistry.swift
+++ b/Source/SwiftLintCore/Models/RuleRegistry.swift
@@ -1,5 +1,5 @@
 /// Container to register and look up SwiftLint rules.
-public final class RuleRegistry {
+public final class RuleRegistry: @unchecked Sendable {
     private var registeredRules = [any Rule.Type]()
 
     /// Shared rule registry instance.


### PR DESCRIPTION
The `@unchecked` should be fine here given that the registry is initialized once at startup.

This silences a warning in Bazel which blocks release builds.