### PR TITLE
Stop triggering `mark` rule in the middle of another comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@
 
 #### Bug Fixes
 
-* None.
+* Stop triggering `mark` rule on "mark" comments in the middle of another
+  comment.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#5592](https://github.com/realm/SwiftLint/issues/5592)
 
 ## 0.55.1: Universal Washing Powder
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/MarkRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/MarkRule.swift
@@ -47,9 +47,8 @@ private struct ViolationResult {
 private extension TokenSyntax {
     private enum Mark {
         static func lint(in text: String) -> [() -> String] {
-            let range = NSRange(text.startIndex..<text.endIndex, in: text)
-            return regex(badPattern).matches(in: text, options: [], range: range).compactMap { match in
-                isIgnoredCases(text, range: range) ? nil : {
+            regex(badPattern).matches(in: text, options: [], range: text.fullNSRange).compactMap { match in
+                isIgnoredCases(text, range: match.range) ? nil : {
                     var corrected = replace(text, range: match.range(at: 2), to: "- ")
                     corrected = replace(corrected, range: match.range(at: 1), to: "// MARK: ")
                     if !text.hasSuffix(" "), corrected.hasSuffix(" ") {
@@ -61,7 +60,7 @@ private extension TokenSyntax {
         }
 
         private static func isIgnoredCases(_ text: String, range: NSRange) -> Bool {
-            regex(goodPattern).firstMatch(in: text, range: range) != nil
+            range.lowerBound != 0 || regex(goodPattern).firstMatch(in: text, range: text.fullNSRange) != nil
         }
 
         private static let goodPattern = [

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/MarkRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/MarkRuleExamples.swift
@@ -20,6 +20,14 @@ internal struct MarkRuleExamples {
               // MARK: good
         }
         """),
+        Example("""
+        /// Comment
+        /// `xxx://marketingOptIn`
+        struct S {}
+
+          ///  //marketingOptIn
+        struct T {}
+        """, excludeFromDocumentation: true),
         issue1749Example
     ]
 


### PR DESCRIPTION
Fixes #5592.