### PR TITLE
Keep initializers with attributed parameters in `unneeded_synthesized_initializer` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@
   [SimplyDanny](https://github.com/SimplyDanny)
   [#5592](https://github.com/realm/SwiftLint/issues/5592)
 
+* Keep initializers with attributed parameters in
+  `unneeded_synthesized_initializer` rule.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#5153](https://github.com/realm/SwiftLint/issues/5153)
+
 ## 0.55.1: Universal Washing Powder
 
 #### Breaking

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededSynthesizedInitializerRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededSynthesizedInitializerRule.swift
@@ -132,7 +132,7 @@ private extension StructDeclSyntax {
         }
 
         for (idx, parameter) in initializerParameters.enumerated() {
-            guard parameter.secondName == nil else {
+            guard parameter.secondName == nil, parameter.attributes.isEmpty else {
                 return false
             }
             let property = storedProperties[idx]

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededSynthesizedInitializerRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededSynthesizedInitializerRuleExamples.swift
@@ -200,6 +200,15 @@ enum UnneededSynthesizedInitializerRuleExamples {
                 """),
         Example("""
                 struct Foo {
+                    var bar: Int
+
+                    init(@Clamped bar: Int) {
+                        self.bar = bar
+                    }
+                }
+                """),
+        Example("""
+                struct Foo {
                     let bar: Int
 
                     init(bar: Int) {


### PR DESCRIPTION
Partially addresses #5153.