### PR TITLE
Print only file path when reporting a correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@
   [Martin Redington](https://github.com/mildm8nnered)
   [#5614](https://github.com/realm/SwiftLint/issues/5614)
 
+* When SwiftLint corrects violations automatically (`swiftlint lint --fix`)
+  it doesn't report the exact location of the fix any longer. The new format
+  is `<file-path>: Correcting <rule-name>` without line and column numbers.
+  Reason: Correction positions are likely just incorrect, especially when
+  multiple rules apply their rewrites. Fixing that is not trivial and likely
+  not worth the effort also considering that there haven't been any bug
+  reports about wrong correction positions so far.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+
 #### Experimental
 
 * None.

--- a/Source/SwiftLintCore/Models/Correction.swift
+++ b/Source/SwiftLintCore/Models/Correction.swift
@@ -7,7 +7,7 @@ public struct Correction: Equatable, Sendable {
 
     /// The console-printable description for this correction.
     public var consoleDescription: String {
-        return "\(location) Corrected \(ruleDescription.name)"
+        return "\(location.file ?? "<nopath>"): Corrected \(ruleDescription.name)"
     }
 
     /// Memberwise initializer.


### PR DESCRIPTION
Omit exact line and column information. Keep the internal logic available for a while in case people complain for good reasons. Then the change can be reverted easily.

Reasons behind this change:

* What is the position of a correction actually? The position where the rule triggered? The position of the transformed node?
* If there's more than a single fix, it's highly likely that all positions (except for the first) are wrong no matter what the answer to the first question is.
* Getting the positions right in a rewriter is hard. And there is always the feeling that something is wrong with them - probably because it is.
* Even if you get the positions right in a single rule: One run collects positions for all rules that apply to a file and so rewrites in other rules might draw existing positions wrong.
* We already have checks for more than one correction position disabled in tests due to these issues.