### PR TITLE
Reverse Data -> String conversion rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@
   [Martin Redington](https://github.com/mildm8nnered)
   [#5769](https://github.com/realm/SwiftLint/issues/5769)
 
+* Revert the part of the `non_optional_string_data_conversion`
+  rule that enforces non-failable conversions of `Data` to UTF-8
+  `String`. This is due to the fact that the data to be converted
+  can be arbitrary and especially doesn't need to represent a valid
+  UTF-8-encoded string.  
+  [Sam Rayner](https://github.com/samrayner)
+  [#5263](https://github.com/realm/SwiftLint/issues/5263)
+
 #### Experimental
 
 * None.
@@ -18,8 +26,9 @@
   `ignore_multiline_function_signatures`.  
   [leonardosrodrigues0](https://github.com/leonardosrodrigues0)
   [#3720](https://github.com/realm/SwiftLint/issues/3720)
+
 * Add new `optional_data_string_conversion` rule to enforce
-  failable conversions of `Data` -> UTF-8 `String`.
+  failable conversions of `Data` to UTF-8 `String`.  
   [Sam Rayner](https://github.com/samrayner)
   [#5263](https://github.com/realm/SwiftLint/issues/5263)
 
@@ -237,11 +246,6 @@
   rule.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#5709](https://github.com/realm/SwiftLint/issues/5709)
-
-* Revert `optional_data_string_conversion` enforcing
-  non-failable conversions of `Data` -> UTF-8 `String`.
-  [Sam Rayner](https://github.com/samrayner)
-  [#5263](https://github.com/realm/SwiftLint/issues/5263)
 
 ## 0.55.1: Universal Washing Powder
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
   `ignore_multiline_function_signatures`.  
   [leonardosrodrigues0](https://github.com/leonardosrodrigues0)
   [#3720](https://github.com/realm/SwiftLint/issues/3720)
+* Add new `optional_data_string_conversion` rule to enforce
+  failable conversions of `Data` -> UTF-8 `String`.
+  [Sam Rayner](https://github.com/samrayner)
+  [#5263](https://github.com/realm/SwiftLint/issues/5263)
 
 #### Bug Fixes
 
@@ -233,6 +237,11 @@
   rule.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#5709](https://github.com/realm/SwiftLint/issues/5709)
+
+* Revert `optional_data_string_conversion` enforcing
+  non-failable conversions of `Data` -> UTF-8 `String`.
+  [Sam Rayner](https://github.com/samrayner)
+  [#5263](https://github.com/realm/SwiftLint/issues/5263)
 
 ## 0.55.1: Universal Washing Powder
 

--- a/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
+++ b/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
@@ -141,6 +141,7 @@ public let builtInRules: [any Rule.Type] = [
     OpeningBraceRule.self,
     OperatorFunctionWhitespaceRule.self,
     OperatorUsageWhitespaceRule.self,
+    OptionalDataStringConversionRule.self,
     OptionalEnumCaseMatchingRule.self,
     OrphanedDocCommentRule.self,
     OverriddenSuperCallRule.self,

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/NonOptionalStringDataConversionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/NonOptionalStringDataConversionRule.swift
@@ -5,16 +5,14 @@ struct NonOptionalStringDataConversionRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
     static let description = RuleDescription(
         identifier: "non_optional_string_data_conversion",
-        name: "Non-Optional String <-> Data Conversion",
-        description: "Prefer using UTF-8 encoded strings when converting between `String` and `Data`",
+        name: "Non-Optional String -> Data Conversion",
+        description: "Prefer using non-optional Data(_:) when converting a UTF-8 String to Data",
         kind: .lint,
         nonTriggeringExamples: [
-            Example("Data(\"foo\".utf8)"),
-            Example("String(decoding: data, as: UTF8.self)"),
+            Example("Data(\"foo\".utf8)")
         ],
         triggeringExamples: [
-            Example("\"foo\".data(using: .utf8)"),
-            Example("String(data: data, encoding: .utf8)"),
+            Example("\"foo\".data(using: .utf8)")
         ]
     )
 }
@@ -28,15 +26,6 @@ private extension NonOptionalStringDataConversionRule {
                let argument = parent.arguments.onlyElement,
                argument.label?.text == "using",
                argument.expression.as(MemberAccessExprSyntax.self)?.isUTF8 == true {
-                violations.append(node.positionAfterSkippingLeadingTrivia)
-            }
-        }
-
-        override func visitPost(_ node: DeclReferenceExprSyntax) {
-            if node.baseName.text == "String",
-               let parent = node.parent?.as(FunctionCallExprSyntax.self),
-               parent.arguments.map({ $0.label?.text }) == ["data", "encoding"],
-               parent.arguments.last?.expression.as(MemberAccessExprSyntax.self)?.isUTF8 == true {
                 violations.append(node.positionAfterSkippingLeadingTrivia)
             }
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/NonOptionalStringDataConversionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/NonOptionalStringDataConversionRule.swift
@@ -5,8 +5,8 @@ struct NonOptionalStringDataConversionRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
     static let description = RuleDescription(
         identifier: "non_optional_string_data_conversion",
-        name: "Non-Optional String -> Data Conversion",
-        description: "Prefer using non-optional Data(_:) when converting a UTF-8 String to Data",
+        name: "Non-optional String -> Data Conversion",
+        description: "Prefer non-optional `Data(_:)` initializer when converting `String` to `Data`",
         kind: .lint,
         nonTriggeringExamples: [
             Example("Data(\"foo\".utf8)")

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/OptionalDataStringConversionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/OptionalDataStringConversionRule.swift
@@ -22,8 +22,9 @@ private extension OptionalDataStringConversionRule {
         override func visitPost(_ node: DeclReferenceExprSyntax) {
             if node.baseName.text == "String",
                let parent = node.parent?.as(FunctionCallExprSyntax.self),
-               parent.arguments.map({ $0.label?.text }) == ["decoding", "as"],
-               parent.arguments.last?.expression.as(IdentifierTypeSyntax.self)?.name == "UTF8.self" {
+               let expr = parent.arguments.last?.expression.as(MemberAccessExprSyntax.self),
+               expr.base?.description == "UTF8",
+               expr.declName.baseName.description == "self" {
                 violations.append(node.positionAfterSkippingLeadingTrivia)
             }
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/OptionalDataStringConversionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/OptionalDataStringConversionRule.swift
@@ -1,0 +1,31 @@
+import SwiftSyntax
+
+@SwiftSyntaxRule
+struct OptionalDataStringConversionRule: Rule {
+    var configuration = SeverityConfiguration<Self>(.warning)
+    static let description = RuleDescription(
+        identifier: "optional_data_string_conversion",
+        name: "Optional Data -> String Conversion",
+        description: "Prefer using failable String(data:encoding:) when converting from `Data` to a UTF-8 `String`",
+        kind: .lint,
+        nonTriggeringExamples: [
+            Example("String(data: data, encoding: .utf8)")
+        ],
+        triggeringExamples: [
+            Example("String(decoding: data, as: UTF8.self)")
+        ]
+    )
+}
+
+private extension OptionalDataStringConversionRule {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
+        override func visitPost(_ node: DeclReferenceExprSyntax) {
+            if node.baseName.text == "String",
+               let parent = node.parent?.as(FunctionCallExprSyntax.self),
+               parent.arguments.map({ $0.label?.text }) == ["decoding", "as"],
+               parent.arguments.last?.expression.as(IdentifierTypeSyntax.self)?.name == "UTF8.self" {
+                violations.append(node.positionAfterSkippingLeadingTrivia)
+            }
+        }
+    }
+}

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/OptionalDataStringConversionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/OptionalDataStringConversionRule.swift
@@ -6,7 +6,7 @@ struct OptionalDataStringConversionRule: Rule {
     static let description = RuleDescription(
         identifier: "optional_data_string_conversion",
         name: "Optional Data -> String Conversion",
-        description: "Prefer using failable String(data:encoding:) when converting from `Data` to a UTF-8 `String`",
+        description: "Prefer failable `String(data:encoding:)` initializer when converting `Data` to `String`",
         kind: .lint,
         nonTriggeringExamples: [
             Example("String(data: data, encoding: .utf8)")

--- a/Source/SwiftLintCore/Extensions/Configuration+Remote.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Remote.swift
@@ -94,7 +94,7 @@ internal extension Configuration.FileGraph.FilePath {
             guard
                 taskResult.2 == nil, // No error
                 (taskResult.1 as? HTTPURLResponse)?.statusCode == 200,
-                let configStr = (taskResult.0.flatMap { String(decoding: $0, as: UTF8.self) })
+                let configStr = (taskResult.0.flatMap { String(data: $0, encoding: .utf8) })
             else {
                 return try handleWrongData(
                     urlString: urlString,

--- a/Source/SwiftLintCore/RuleConfigurations/RegexConfiguration.swift
+++ b/Source/SwiftLintCore/RuleConfigurations/RegexConfiguration.swift
@@ -37,8 +37,9 @@ public struct RegexConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration, 
                 .map(\.rawValue).sorted(by: <).joined(separator: ","),
             severity.rawValue,
         ]
-        if let jsonData = try? JSONSerialization.data(withJSONObject: jsonObject) {
-            return String(decoding: jsonData, as: UTF8.self)
+        if let jsonData = try? JSONSerialization.data(withJSONObject: jsonObject),
+          let jsonString = String(data: jsonData, encoding: .utf8) {
+              return jsonString
         }
         queuedFatalError("Could not serialize regex configuration for cache")
     }

--- a/Source/swiftlint/Extensions/Configuration+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Configuration+CommandLine.swift
@@ -213,8 +213,10 @@ extension Configuration {
     fileprivate func getFiles(with visitor: LintableFilesVisitor) async throws -> [SwiftLintFile] {
         if visitor.useSTDIN {
             let stdinData = FileHandle.standardInput.readDataToEndOfFile()
-            let stdinString = String(decoding: stdinData, as: UTF8.self)
-            return [SwiftLintFile(contents: stdinString)]
+            if let stdinString = String(data: stdinData, encoding: .utf8) {
+                return [SwiftLintFile(contents: stdinString)]
+            }
+            throw SwiftLintError.usageError(description: "stdin isn't a UTF8-encoded string")
         }
         if visitor.useScriptInputFiles {
             let files = try scriptInputFiles()

--- a/Source/swiftlint/Helpers/LintableFilesVisitor.swift
+++ b/Source/swiftlint/Helpers/LintableFilesVisitor.swift
@@ -187,8 +187,8 @@ struct LintableFilesVisitor {
     }
 
     private static func loadLogCompilerInvocations(_ path: String) -> [[String]]? {
-        if let data = FileManager.default.contents(atPath: path) {
-            let logContents = String(decoding: data, as: UTF8.self)
+        if let data = FileManager.default.contents(atPath: path),
+            let logContents = String(data: data, encoding: .utf8) {
             if logContents.isEmpty {
                 return nil
             }

--- a/Source/swiftlint/Helpers/SwiftPMCompilationDB.swift
+++ b/Source/swiftlint/Helpers/SwiftPMCompilationDB.swift
@@ -37,7 +37,7 @@ struct SwiftPMCompilationDB: Codable {
             let pathToReplace = Array(nodes.nodes.keys.filter({ node in
                 node.hasSuffix(suffix)
             }))[0].dropLast(suffix.count - 1)
-            let stringFileContents = String(decoding: yaml, as: UTF8.self)
+            let stringFileContents = String(data: yaml, encoding: .utf8)!
                 .replacingOccurrences(of: pathToReplace, with: "")
             compilationDB = try decoder.decode(Self.self, from: stringFileContents)
         } else {

--- a/Tests/GeneratedTests/GeneratedTests.swift
+++ b/Tests/GeneratedTests/GeneratedTests.swift
@@ -835,6 +835,12 @@ final class OperatorUsageWhitespaceRuleGeneratedTests: SwiftLintTestCase {
     }
 }
 
+final class OptionalDataStringConversionRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(OptionalDataStringConversionRule.description)
+    }
+}
+
 final class OptionalEnumCaseMatchingRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(OptionalEnumCaseMatchingRule.description)

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -190,8 +190,8 @@ private func execute(_ args: [String],
     queue.async(group: group) { stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile() }
     process.waitUntilExit()
     group.wait()
-    let stdout = stdoutData.map { String(decoding: $0, as: UTF8.self) } ?? ""
-    let stderr = stderrData.map { String(decoding: $0, as: UTF8.self) } ?? ""
+    let stdout = stdoutData.flatMap { String(data: $0, encoding: .utf8) } ?? ""
+    let stderr = stderrData.flatMap { String(data: $0, encoding: .utf8) } ?? ""
     return (process.terminationStatus, stdout, stderr)
 }
 

--- a/Tests/IntegrationTests/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/default_rule_configurations.yml
@@ -386,6 +386,8 @@ operator_usage_whitespace:
   allowed_no_space_operators: ["...", "..<"]
 operator_whitespace:
   severity: warning
+optional_data_string_conversion:
+  severity: warning
 optional_enum_case_matching:
   severity: warning
 orphaned_doc_comment:


### PR DESCRIPTION
This reverses the Data -> String portion of [this PR](https://github.com/realm/SwiftLint/pull/5264) by introducing a new rule, following feedback on [the original issue](https://github.com/realm/SwiftLint/issues/5263). It leaves the String -> Data portion of the original rule unchanged.