### PR TITLE
Fixed baseline compare issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@
   [SimplyDanny](https://github.com/SimplyDanny)
   [#5623](https://github.com/realm/SwiftLint/issues/5623)
 
+* Fix `baseline compare` incorrectly reporting some violations
+  as new, and also now sorts the violations from `baseline compare`
+  deterministically.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#5606](https://github.com/realm/SwiftLint/issues/5606)
+
 ## 0.55.1: Universal Washing Powder
 
 #### Breaking

--- a/Source/SwiftLintCore/Models/Baseline.swift
+++ b/Source/SwiftLintCore/Models/Baseline.swift
@@ -140,7 +140,9 @@ public struct Baseline: Equatable {
                 return filter(relativePathViolations: otherBaselineViolations, baselineViolations: baselineViolations)
             }
             return Set(otherBaselineViolations.violationsWithAbsolutePaths)
-        }.sorted()
+        }.sorted {
+            $0.location == $1.location ? $0.ruleIdentifier < $1.ruleIdentifier : $0.location < $1.location
+        }
     }
 }
 

--- a/Source/SwiftLintCore/Models/Baseline.swift
+++ b/Source/SwiftLintCore/Models/Baseline.swift
@@ -27,8 +27,8 @@ private struct BaselineViolation: Codable, Hashable, Comparable {
 
     static func < (lhs: Self, rhs: Self) -> Bool {
         lhs.violation.location == rhs.violation.location
-        ? lhs.violation.ruleIdentifier < rhs.violation.ruleIdentifier
-        : lhs.violation.location < rhs.violation.location
+            ? lhs.violation.ruleIdentifier < rhs.violation.ruleIdentifier
+            : lhs.violation.location < rhs.violation.location
     }
 }
 

--- a/Tests/SwiftLintFrameworkTests/BaselineTests.swift
+++ b/Tests/SwiftLintFrameworkTests/BaselineTests.swift
@@ -140,11 +140,10 @@ final class BaselineTests: XCTestCase {
     func testCompare() throws {
         try withExampleFileCreated { sourceFilePath in
             let violations = Self.violations(for: sourceFilePath)
-            let oldViolations = Array(violations.dropFirst())
-            let newViolations = Array(violations.dropLast())
-            let oldBaseline = Baseline(violations: oldViolations)
+            let oldBaseline = Baseline(violations: Array(violations.dropFirst()))
+            let newViolations = Array(try violations.lineShifted(by: 2, path: sourceFilePath).dropLast())
             let newBaseline = Baseline(violations: newViolations)
-            XCTAssertEqual(oldBaseline.compare(newBaseline), [violations.first])
+            XCTAssertEqual(oldBaseline.compare(newBaseline), [newViolations.first])
             XCTAssertEqual(newBaseline.compare(oldBaseline), [violations.last])
         }
     }

--- a/Tests/SwiftLintFrameworkTests/BaselineTests.swift
+++ b/Tests/SwiftLintFrameworkTests/BaselineTests.swift
@@ -139,12 +139,16 @@ final class BaselineTests: XCTestCase {
 
     func testCompare() throws {
         try withExampleFileCreated { sourceFilePath in
-            let violations = Self.violations(for: sourceFilePath)
-            let oldBaseline = Baseline(violations: Array(violations.dropFirst()))
-            let newViolations = Array(try violations.lineShifted(by: 2, path: sourceFilePath).dropLast())
-            let newBaseline = Baseline(violations: newViolations)
-            XCTAssertEqual(oldBaseline.compare(newBaseline), [newViolations.first])
-            XCTAssertEqual(newBaseline.compare(oldBaseline), [violations.last])
+            let ruleDescriptions = Self.ruleDescriptions + Self.ruleDescriptions
+            let violations = ruleDescriptions.violations(for: sourceFilePath)
+            let numberofViolationsToDrop = 3
+            let oldBaseline = Baseline(violations: Array(violations.dropFirst(numberofViolationsToDrop)).reversed())
+            let newViolations = Array(
+                try violations.lineShifted(by: 2, path: sourceFilePath).dropLast(numberofViolationsToDrop)
+            )
+            let newBaseline = Baseline(violations: newViolations.reversed())
+            XCTAssertEqual(oldBaseline.compare(newBaseline), Array(newViolations.prefix(numberofViolationsToDrop)))
+            XCTAssertEqual(newBaseline.compare(oldBaseline), Array(violations.suffix(numberofViolationsToDrop)))
         }
     }
 


### PR DESCRIPTION
Fixes #5606 where `baseline compare` can produce some false alarms, because we throw away the `text` information from one of the baselines, but the files on disk may be absent or have changed, so the new `text` values read during `filter`ing may (likely) not be appropriate.

In this PR, the logic and public API for `filter` is completely unchanged, but the public function converts the `StyleViolations` to `BaselineViolations`, and retrieves any existing `BaselineViolations` for the file.

These `BaselineViolations` are then passed to a private `filter` function, which implements the core `filter`ing logic.

The `compare` function now passes the `BaselineViolations` from each Baseline to this private function.

We now also sort the violations reported by `baseline compare`, by location and rule, so the output should now be wholly deterministic which is was not quite before.
