### PR TITLE
Add update checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,14 @@
   have at most the same access level.  
   [SimplyDanny](https://github.com/SimplyDanny)
 
+* Add new `--check-for-updates` command line option to check for new versions
+  of SwiftLint, and an equivalent `check_for_updates` configuration file
+  setting.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [Ian Leitch](https://github.com/ileitch)
+  [#5613](https://github.com/realm/SwiftLint/issues/5613)
+
 #### Bug Fixes
 
 * Fix a few false positives and negatives by updating the parser to support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,9 +47,9 @@
   have at most the same access level.  
   [SimplyDanny](https://github.com/SimplyDanny)
 
-* Add new `--check-for-updates` command line option to check for new versions
-  of SwiftLint, and an equivalent `check_for_updates` configuration file
-  setting.  
+* Add new `--check-for-updates` command line option for the `lint`, `analyze`,
+  and `version` subcommands to check for new versions  of SwiftLint, and an
+  equivalent `check_for_updates` configuration file setting.  
   [Martin Redington](https://github.com/mildm8nnered)
   [SimplyDanny](https://github.com/SimplyDanny)
   [Ian Leitch](https://github.com/ileitch)

--- a/README.md
+++ b/README.md
@@ -703,6 +703,9 @@ baseline: Baseline.json
 # The path to save detected violations to as a new baseline.
 write_baseline: Baseline.json
 
+# If true, SwiftLint will check for updates after linting or analyzing.
+check_for_updates: true
+
 # configurable rules can be customized from this configuration file
 # binary rules can set their severity level
 force_cast: warning # implicitly

--- a/Source/SwiftLintCore/Extensions/Configuration+Merging.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Merging.swift
@@ -27,7 +27,8 @@ extension Configuration {
             allowZeroLintableFiles: childConfiguration.allowZeroLintableFiles,
             strict: childConfiguration.strict,
             baseline: childConfiguration.baseline,
-            writeBaseline: childConfiguration.writeBaseline
+            writeBaseline: childConfiguration.writeBaseline,
+            checkForUpdates: childConfiguration.checkForUpdates
         )
     }
 

--- a/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
@@ -99,12 +99,9 @@ extension Configuration {
             pinnedVersion: dict[Key.swiftlintVersion.rawValue].map { ($0 as? String) ?? String(describing: $0) },
             allowZeroLintableFiles: dict[Key.allowZeroLintableFiles.rawValue] as? Bool ?? false,
             strict: dict[Key.strict.rawValue] as? Bool ?? false,
-<<<<<<< HEAD
             baseline: dict[Key.baseline.rawValue] as? String,
-            writeBaseline: dict[Key.writeBaseline.rawValue] as? String
-=======
+            writeBaseline: dict[Key.writeBaseline.rawValue] as? String,
             checkForUpdates: dict[Key.checkForUpdates.rawValue] as? Bool ?? false
->>>>>>> 9093d9cc9 (Also support check for updates in configuration files)
         )
     }
 

--- a/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
@@ -17,6 +17,7 @@ extension Configuration {
         case strict = "strict"
         case baseline = "baseline"
         case writeBaseline = "write_baseline"
+        case checkForUpdates = "check_for_updates"
         case childConfig = "child_config"
         case parentConfig = "parent_config"
         case remoteConfigTimeout = "remote_timeout"
@@ -98,8 +99,12 @@ extension Configuration {
             pinnedVersion: dict[Key.swiftlintVersion.rawValue].map { ($0 as? String) ?? String(describing: $0) },
             allowZeroLintableFiles: dict[Key.allowZeroLintableFiles.rawValue] as? Bool ?? false,
             strict: dict[Key.strict.rawValue] as? Bool ?? false,
+<<<<<<< HEAD
             baseline: dict[Key.baseline.rawValue] as? String,
             writeBaseline: dict[Key.writeBaseline.rawValue] as? String
+=======
+            checkForUpdates: dict[Key.checkForUpdates.rawValue] as? Bool ?? false
+>>>>>>> 9093d9cc9 (Also support check for updates in configuration files)
         )
     }
 

--- a/Source/SwiftLintCore/Models/Configuration.swift
+++ b/Source/SwiftLintCore/Models/Configuration.swift
@@ -44,6 +44,9 @@ public struct Configuration {
     /// The path to write a baseline to.
     public let writeBaseline: String?
 
+    /// Check for updates
+    public let checkForUpdates: Bool
+
     /// This value is `true` iff the `--config` parameter was used to specify (a) configuration file(s)
     /// In particular, this means that the value is also `true` if the `--config` parameter
     /// was used to explicitly specify the default `.swiftlint.yml` as the configuration file
@@ -82,6 +85,7 @@ public struct Configuration {
         strict: Bool,
         baseline: String?,
         writeBaseline: String?
+        checkForUpdates: Bool
     ) {
         self.rulesWrapper = rulesWrapper
         self.fileGraph = fileGraph
@@ -95,6 +99,7 @@ public struct Configuration {
         self.strict = strict
         self.baseline = baseline
         self.writeBaseline = writeBaseline
+        self.checkForUpdates = checkForUpdates
     }
 
     /// Creates a Configuration by copying an existing configuration.
@@ -114,6 +119,7 @@ public struct Configuration {
         strict = configuration.strict
         baseline = configuration.baseline
         writeBaseline = configuration.writeBaseline
+        checkForUpdates = configuration.checkForUpdates
     }
 
     /// Creates a `Configuration` by specifying its properties directly,
@@ -125,7 +131,7 @@ public struct Configuration {
     /// - parameter ruleList:               The list of all rules. Used for alias resolving and as a fallback
     ///                                     if `allRulesWrapped` is nil.
     /// - parameter filePath                The underlaying file graph. If `nil` is specified, a empty file graph
-    ///                                     with the current working directory as the `rootDirectory` will be used
+    ///                                     with the current working directory as the `rootDirectory` will be used.
     /// - parameter includedPaths:          Included paths to lint.
     /// - parameter excludedPaths:          Excluded paths to not lint.
     /// - parameter indentation:            The style to use when indenting Swift source code.
@@ -139,6 +145,7 @@ public struct Configuration {
     /// - parameter strict:                 Treat warnings as errors.
     /// - parameter baseline:               The path to read a baseline from.
     /// - parameter writeBaseline:          The path to write a baseline to.
+    /// - parameter checkForUpdates:        Check for updates to SwiftLint.
     package init(
         rulesMode: RulesMode = .default(disabled: [], optIn: []),
         allRulesWrapped: [ConfigurationRuleWrapper]? = nil,
@@ -154,7 +161,8 @@ public struct Configuration {
         allowZeroLintableFiles: Bool = false,
         strict: Bool = false,
         baseline: String? = nil,
-        writeBaseline: String? = nil
+        writeBaseline: String? = nil,
+        checkForUpdates: Bool = false
     ) {
         if let pinnedVersion, pinnedVersion != Version.current.value {
             queuedPrintError(
@@ -183,6 +191,7 @@ public struct Configuration {
             strict: strict,
             baseline: baseline,
             writeBaseline: writeBaseline
+            checkForUpdates: checkForUpdates
         )
     }
 
@@ -289,6 +298,7 @@ extension Configuration: Hashable {
         hasher.combine(strict)
         hasher.combine(baseline)
         hasher.combine(writeBaseline)
+        hasher.combine(checkForUpdates)
         hasher.combine(basedOnCustomConfigurationFiles)
         hasher.combine(cachePath)
         hasher.combine(rules.map { type(of: $0).description.identifier })
@@ -309,6 +319,7 @@ extension Configuration: Hashable {
             lhs.strict == rhs.strict &&
             lhs.baseline == rhs.baseline &&
             lhs.writeBaseline == rhs.writeBaseline &&
+            lhs.checkForUpdates == rhs.checkForUpdates &&
             lhs.rulesMode == rhs.rulesMode
     }
 }

--- a/Source/SwiftLintCore/Models/Configuration.swift
+++ b/Source/SwiftLintCore/Models/Configuration.swift
@@ -84,7 +84,7 @@ public struct Configuration {
         allowZeroLintableFiles: Bool,
         strict: Bool,
         baseline: String?,
-        writeBaseline: String?
+        writeBaseline: String?,
         checkForUpdates: Bool
     ) {
         self.rulesWrapper = rulesWrapper
@@ -190,7 +190,7 @@ public struct Configuration {
             allowZeroLintableFiles: allowZeroLintableFiles,
             strict: strict,
             baseline: baseline,
-            writeBaseline: writeBaseline
+            writeBaseline: writeBaseline,
             checkForUpdates: checkForUpdates
         )
     }

--- a/Source/SwiftLintCore/Models/Configuration.swift
+++ b/Source/SwiftLintCore/Models/Configuration.swift
@@ -44,7 +44,7 @@ public struct Configuration {
     /// The path to write a baseline to.
     public let writeBaseline: String?
 
-    /// Check for updates
+    /// Check for updates.
     public let checkForUpdates: Bool
 
     /// This value is `true` iff the `--config` parameter was used to specify (a) configuration file(s)

--- a/Source/SwiftLintCore/Models/SwiftVersion.swift
+++ b/Source/SwiftLintCore/Models/SwiftVersion.swift
@@ -14,6 +14,7 @@ public struct SwiftVersion: RawRepresentable, Codable, VersionComparable, Sendab
 
 /// A comparable `major.minor.patch` version number.
 public protocol VersionComparable: Comparable {
+    /// The version string.
     var rawValue: String { get }
 }
 

--- a/Source/SwiftLintCore/Models/SwiftVersion.swift
+++ b/Source/SwiftLintCore/Models/SwiftVersion.swift
@@ -12,6 +12,7 @@ public struct SwiftVersion: RawRepresentable, Codable, VersionComparable, Sendab
     }
 }
 
+/// A comparable `major.minor.patch` version number.
 public protocol VersionComparable: Comparable {
     var rawValue: String { get }
 }

--- a/Source/SwiftLintCore/Models/SwiftVersion.swift
+++ b/Source/SwiftLintCore/Models/SwiftVersion.swift
@@ -12,7 +12,7 @@ public struct SwiftVersion: RawRepresentable, Codable, VersionComparable, Sendab
     }
 }
 
-protocol VersionComparable: Comparable {
+public protocol VersionComparable: Comparable {
     var rawValue: String { get }
 }
 

--- a/Source/SwiftLintCore/Models/SwiftVersion.swift
+++ b/Source/SwiftLintCore/Models/SwiftVersion.swift
@@ -2,7 +2,7 @@ import Foundation
 import SourceKittenFramework
 
 /// A value describing the version of the Swift compiler.
-public struct SwiftVersion: RawRepresentable, Codable, Comparable, Sendable {
+public struct SwiftVersion: RawRepresentable, Codable, VersionComparable, Sendable {
     public typealias RawValue = String
 
     public let rawValue: String
@@ -10,15 +10,21 @@ public struct SwiftVersion: RawRepresentable, Codable, Comparable, Sendable {
     public init(rawValue: String) {
         self.rawValue = rawValue
     }
+}
 
-    public static func == (lhs: SwiftVersion, rhs: SwiftVersion) -> Bool {
+protocol VersionComparable: Comparable {
+    var rawValue: String { get }
+}
+
+extension VersionComparable {
+    public static func == (lhs: Self, rhs: Self) -> Bool {
         if let lhsComparators = lhs.comparators, let rhsComparators = rhs.comparators {
             return lhsComparators == rhsComparators
         }
         return lhs.rawValue == rhs.rawValue
     }
 
-    public static func < (lhs: SwiftVersion, rhs: SwiftVersion) -> Bool {
+    public static func < (lhs: Self, rhs: Self) -> Bool {
         if let lhsComparators = lhs.comparators, let rhsComparators = rhs.comparators {
             return lhsComparators.lexicographicallyPrecedes(rhsComparators)
         }

--- a/Source/SwiftLintCore/Models/Version.swift
+++ b/Source/SwiftLintCore/Models/Version.swift
@@ -17,4 +17,3 @@ public struct Version: VersionComparable {
         self.value = value
     }
 }
-

--- a/Source/SwiftLintCore/Models/Version.swift
+++ b/Source/SwiftLintCore/Models/Version.swift
@@ -5,4 +5,34 @@ public struct Version {
 
     /// The current SwiftLint version.
     public static let current = Version(value: "0.55.1")
+
+    /// Public initializer.
+    ///
+    /// - parameter value: the string value for this version.
+    public init(value: String) {
+        self.value = value
+    }
+}
+
+extension Version: Comparable {
+    public static func == (lhs: Version, rhs: Version) -> Bool {
+        lhs.value == rhs.value
+    }
+
+    public static func < (lhs: Version, rhs: Version) -> Bool {
+        if let lhsComparators = lhs.comparators, let rhsComparators = rhs.comparators {
+            return lhsComparators.lexicographicallyPrecedes(rhsComparators)
+        }
+        return lhs.value < rhs.value
+    }
+
+    private var comparators: [Int]? {
+        let components = value.split(separator: ".").compactMap { Int($0) }
+        guard let major = components.first else {
+            return nil
+        }
+        let minor = components.dropFirst(1).first ?? 0
+        let patch = components.dropFirst(2).first ?? 0
+        return [major, minor, patch]
+    }
 }

--- a/Source/SwiftLintCore/Models/Version.swift
+++ b/Source/SwiftLintCore/Models/Version.swift
@@ -1,7 +1,11 @@
 /// A type describing the SwiftLint version.
-public struct Version {
+public struct Version: VersionComparable {
     /// The string value for this version.
     public let value: String
+
+    public var rawValue: String {
+        value
+    }
 
     /// The current SwiftLint version.
     public static let current = Version(value: "0.55.1")
@@ -14,25 +18,3 @@ public struct Version {
     }
 }
 
-extension Version: Comparable {
-    public static func == (lhs: Version, rhs: Version) -> Bool {
-        lhs.value == rhs.value
-    }
-
-    public static func < (lhs: Version, rhs: Version) -> Bool {
-        if let lhsComparators = lhs.comparators, let rhsComparators = rhs.comparators {
-            return lhsComparators.lexicographicallyPrecedes(rhsComparators)
-        }
-        return lhs.value < rhs.value
-    }
-
-    private var comparators: [Int]? {
-        let components = value.split(separator: ".").compactMap { Int($0) }
-        guard let major = components.first else {
-            return nil
-        }
-        let minor = components.dropFirst(1).first ?? 0
-        let patch = components.dropFirst(2).first ?? 0
-        return [major, minor, patch]
-    }
-}

--- a/Source/SwiftLintCore/Models/Version.swift
+++ b/Source/SwiftLintCore/Models/Version.swift
@@ -8,7 +8,7 @@ public struct Version {
 
     /// Public initializer.
     ///
-    /// - parameter value: the string value for this version.
+    /// - parameter value: The string value for this version.
     public init(value: String) {
         self.value = value
     }

--- a/Source/SwiftLintCore/Models/Version.swift
+++ b/Source/SwiftLintCore/Models/Version.swift
@@ -3,6 +3,7 @@ public struct Version: VersionComparable {
     /// The string value for this version.
     public let value: String
 
+    /// An alias for `value` required for protocol conformance.
     public var rawValue: String {
         value
     }

--- a/Source/swiftlint/Commands/Analyze.swift
+++ b/Source/swiftlint/Commands/Analyze.swift
@@ -44,7 +44,8 @@ extension SwiftLint {
                 format: common.format,
                 compilerLogPath: compilerLogPath,
                 compileCommands: compileCommands,
-                inProcessSourcekit: common.inProcessSourcekit
+                inProcessSourcekit: common.inProcessSourcekit,
+                checkForUpdates: common.checkForUpdates
             )
 
             try await LintOrAnalyzeCommand.run(options)

--- a/Source/swiftlint/Commands/Lint.swift
+++ b/Source/swiftlint/Commands/Lint.swift
@@ -56,7 +56,8 @@ extension SwiftLint {
                 format: common.format,
                 compilerLogPath: nil,
                 compileCommands: nil,
-                inProcessSourcekit: common.inProcessSourcekit
+                inProcessSourcekit: common.inProcessSourcekit,
+                checkForUpdates: common.checkForUpdates
             )
             try await LintOrAnalyzeCommand.run(options)
         }

--- a/Source/swiftlint/Commands/Version.swift
+++ b/Source/swiftlint/Commands/Version.swift
@@ -5,6 +5,8 @@ extension SwiftLint {
     struct Version: ParsableCommand {
         @Flag(help: "Display full version info")
         var verbose = false
+        @Flag(help: "Check whether a later version of SwiftLint is available")
+        var checkForUpdates = false
 
         static let configuration = CommandConfiguration(abstract: "Display the current version of SwiftLint")
 
@@ -16,6 +18,9 @@ extension SwiftLint {
                 print("Build ID:", buildID)
             } else {
                 print(Self.value)
+            }
+            if checkForUpdates {
+                UpdateChecker.checkForUpdates()
             }
             ExitHelper.successfullyExit()
         }

--- a/Source/swiftlint/Commands/Version.swift
+++ b/Source/swiftlint/Commands/Version.swift
@@ -2,7 +2,7 @@ import ArgumentParser
 import SwiftLintFramework
 
 extension SwiftLint {
-    struct Version: ParsableCommand {
+    struct Version: AsyncParsableCommand {
         @Flag(help: "Display full version info.")
         var verbose = false
         @Flag(help: "Check whether a later version of SwiftLint is available after processing all files.")
@@ -12,7 +12,7 @@ extension SwiftLint {
 
         static var value: String { SwiftLintFramework.Version.current.value }
 
-        func run() throws {
+        func run() async {
             if verbose, let buildID = ExecutableInfo.buildID {
                 print("Version:", Self.value)
                 print("Build ID:", buildID)
@@ -20,7 +20,7 @@ extension SwiftLint {
                 print(Self.value)
             }
             if checkForUpdates {
-                UpdateChecker.checkForUpdates()
+                await UpdateChecker.checkForUpdates()
             }
             ExitHelper.successfullyExit()
         }

--- a/Source/swiftlint/Commands/Version.swift
+++ b/Source/swiftlint/Commands/Version.swift
@@ -3,9 +3,9 @@ import SwiftLintFramework
 
 extension SwiftLint {
     struct Version: ParsableCommand {
-        @Flag(help: "Display full version info")
+        @Flag(help: "Display full version info.")
         var verbose = false
-        @Flag(help: "Check whether a later version of SwiftLint is available")
+        @Flag(help: "Check whether a later version of SwiftLint is available.")
         var checkForUpdates = false
 
         static let configuration = CommandConfiguration(abstract: "Display the current version of SwiftLint")

--- a/Source/swiftlint/Commands/Version.swift
+++ b/Source/swiftlint/Commands/Version.swift
@@ -20,7 +20,7 @@ extension SwiftLint {
                 print(Self.value)
             }
             if checkForUpdates {
-                await UpdateChecker.checkForUpdates()
+                UpdateChecker.checkForUpdates()
             }
             ExitHelper.successfullyExit()
         }

--- a/Source/swiftlint/Commands/Version.swift
+++ b/Source/swiftlint/Commands/Version.swift
@@ -5,7 +5,7 @@ extension SwiftLint {
     struct Version: ParsableCommand {
         @Flag(help: "Display full version info.")
         var verbose = false
-        @Flag(help: "Check whether a later version of SwiftLint is available.")
+        @Flag(help: "Check whether a later version of SwiftLint is available after processing all files.")
         var checkForUpdates = false
 
         static let configuration = CommandConfiguration(abstract: "Display the current version of SwiftLint")

--- a/Source/swiftlint/Helpers/LintOrAnalyzeArguments.swift
+++ b/Source/swiftlint/Helpers/LintOrAnalyzeArguments.swift
@@ -50,7 +50,7 @@ struct LintOrAnalyzeArguments: ParsableArguments {
     var output: String?
     @Flag(help: "Show a live-updating progress bar instead of each file being processed.")
     var progress = false
-    @Flag(help: "Check whether a later version of SwiftLint is available.")
+    @Flag(help: "Check whether a later version of SwiftLint is available after processing all files.")
     var checkForUpdates = false
 }
 

--- a/Source/swiftlint/Helpers/LintOrAnalyzeArguments.swift
+++ b/Source/swiftlint/Helpers/LintOrAnalyzeArguments.swift
@@ -50,6 +50,8 @@ struct LintOrAnalyzeArguments: ParsableArguments {
     var output: String?
     @Flag(help: "Show a live-updating progress bar instead of each file being processed.")
     var progress = false
+    @Flag(help: "Check whether a later version of SwiftLint is available")
+    var checkForUpdates = false
 }
 
 // MARK: - Common Argument Help

--- a/Source/swiftlint/Helpers/LintOrAnalyzeArguments.swift
+++ b/Source/swiftlint/Helpers/LintOrAnalyzeArguments.swift
@@ -50,7 +50,7 @@ struct LintOrAnalyzeArguments: ParsableArguments {
     var output: String?
     @Flag(help: "Show a live-updating progress bar instead of each file being processed.")
     var progress = false
-    @Flag(help: "Check whether a later version of SwiftLint is available")
+    @Flag(help: "Check whether a later version of SwiftLint is available.")
     var checkForUpdates = false
 }
 

--- a/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
+++ b/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
@@ -48,9 +48,6 @@ struct LintOrAnalyzeCommand {
         try await Signposts.record(name: "LintOrAnalyzeCommand.run") {
             try await options.autocorrect ? autocorrect(options) : lintOrAnalyze(options)
         }
-        if options.checkForUpdates {
-            UpdateChecker.checkForUpdates()
-        }
         ExitHelper.successfullyExit()
     }
 
@@ -62,6 +59,9 @@ struct LintOrAnalyzeCommand {
         }
         try Signposts.record(name: "LintOrAnalyzeCommand.PostProcessViolations") {
             try postProcessViolations(files: files, builder: builder)
+        }
+        if options.checkForUpdates || builder.configuration.checkForUpdates {
+            UpdateChecker.checkForUpdates()
         }
     }
 

--- a/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
+++ b/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
@@ -61,7 +61,7 @@ struct LintOrAnalyzeCommand {
             try postProcessViolations(files: files, builder: builder)
         }
         if options.checkForUpdates || builder.configuration.checkForUpdates {
-            UpdateChecker.checkForUpdates()
+            await UpdateChecker.checkForUpdates()
         }
     }
 

--- a/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
+++ b/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
@@ -48,6 +48,9 @@ struct LintOrAnalyzeCommand {
         try await Signposts.record(name: "LintOrAnalyzeCommand.run") {
             try await options.autocorrect ? autocorrect(options) : lintOrAnalyze(options)
         }
+        if options.checkForUpdates {
+            UpdateChecker.checkForUpdates()
+        }
         ExitHelper.successfullyExit()
     }
 
@@ -283,6 +286,7 @@ struct LintOrAnalyzeOptions {
     let compilerLogPath: String?
     let compileCommands: String?
     let inProcessSourcekit: Bool
+    let checkForUpdates: Bool
 
     var verb: String {
         if autocorrect {

--- a/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
+++ b/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
@@ -61,7 +61,7 @@ struct LintOrAnalyzeCommand {
             try postProcessViolations(files: files, builder: builder)
         }
         if options.checkForUpdates || builder.configuration.checkForUpdates {
-            await UpdateChecker.checkForUpdates()
+            UpdateChecker.checkForUpdates()
         }
     }
 

--- a/Source/swiftlint/Helpers/UpdateChecker.swift
+++ b/Source/swiftlint/Helpers/UpdateChecker.swift
@@ -1,17 +1,28 @@
+// swiftlint:disable file_header
+//
+// Adapted from periphery's UpdateChecker.swift
+//
+// https://github.com/peripheryapp/periphery
+//
+// Copyright (c) 2019 Ian Leitch
+// Licensed under the MIT License
+//
+// See https://github.com/peripheryapp/periphery/blob/master/LICENSE.md for license information
+//
+
 import Foundation
 import SwiftLintFramework
 
 enum UpdateChecker {
     static func checkForUpdates() {
-        guard let url = URL(string: "https://api.github.com/repos/realm/SwiftLint/releases/latest") else {
+        guard let url = URL(string: "https://api.github.com/repos/realm/SwiftLint/releases/latest"),
+              let data = sendSynchronousRequest(to: url),
+              let latestVersionNumber = parseVersionNumber(data)
+        else {
+            print("Could not check latest SwiftLint version")
             return
         }
-        guard let data = sendSynchronousRequest(to: url) else {
-            return
-        }
-        guard let latestVersionNumber = parseVersionNumber(data) else {
-            return
-        }
+
         let latestVersion = SwiftLintFramework.Version(value: latestVersionNumber)
         if latestVersion > SwiftLintFramework.Version.current {
             print("A new version of SwiftLint is available: \(latestVersionNumber)")
@@ -30,6 +41,7 @@ enum UpdateChecker {
 
     private static func sendSynchronousRequest(to url: URL) -> Data? {
         var request = URLRequest(url: url)
+        request.setValue("SwiftLint", forHTTPHeaderField: "User-Agent")
         request.setValue("application/vnd.github.v3+json", forHTTPHeaderField: "Accept")
         let semaphore = DispatchSemaphore(value: 0)
         var result: Data?

--- a/Source/swiftlint/Helpers/UpdateChecker.swift
+++ b/Source/swiftlint/Helpers/UpdateChecker.swift
@@ -17,11 +17,10 @@ import FoundationNetworking
 import SwiftLintFramework
 
 enum UpdateChecker {
-    static func checkForUpdates() {
+    static func checkForUpdates() async {
         guard let url = URL(string: "https://api.github.com/repos/realm/SwiftLint/releases/latest"),
-              let data = sendSynchronousRequest(to: url),
-              let latestVersionNumber = parseVersionNumber(data)
-        else {
+              let data = try? await sendRequest(to: url),
+              let latestVersionNumber = parseVersionNumber(data) else {
             print("Could not check latest SwiftLint version")
             return
         }
@@ -30,32 +29,21 @@ enum UpdateChecker {
         if latestVersion > SwiftLintFramework.Version.current {
             print("A new version of SwiftLint is available: \(latestVersionNumber)")
         } else {
-            print("Your version of SwiftLint is up to date")
+            print("Your version of SwiftLint is up to date.")
         }
     }
 
     private static func parseVersionNumber(_ data: Data) -> String? {
-        guard let jsonObject = try? JSONSerialization.jsonObject(with: data, options: []) as? [AnyHashable: Any],
-              let tagName = jsonObject["tag_name"] as? String else {
+        guard let jsonObject = try? JSONSerialization.jsonObject(with: data, options: []) as? [AnyHashable: Any] else {
             return nil
         }
-        return tagName
+        return jsonObject["tag_name"] as? String
     }
 
-    private static func sendSynchronousRequest(to url: URL) -> Data? {
+    private static func sendRequest(to url: URL) async throws -> Data {
         var request = URLRequest(url: url)
         request.setValue("SwiftLint", forHTTPHeaderField: "User-Agent")
         request.setValue("application/vnd.github.v3+json", forHTTPHeaderField: "Accept")
-        let semaphore = DispatchSemaphore(value: 0)
-        var result: Data?
-
-        let task = URLSession.shared.dataTask(with: request) { data, _, _ in
-            result = data
-            semaphore.signal()
-        }
-        task.resume()
-
-        semaphore.wait()
-        return result
+        return try await URLSession.shared.data(for: request).0
     }
 }

--- a/Source/swiftlint/Helpers/UpdateChecker.swift
+++ b/Source/swiftlint/Helpers/UpdateChecker.swift
@@ -1,0 +1,46 @@
+import Foundation
+import SwiftLintFramework
+
+enum UpdateChecker {
+    static func checkForUpdates() {
+        guard let url = URL(string: "https://api.github.com/repos/realm/SwiftLint/releases/latest") else {
+            return
+        }
+        guard let data = sendSynchronousRequest(to: url) else {
+            return
+        }
+        guard let latestVersionNumber = parseVersionNumber(data) else {
+            return
+        }
+        let latestVersion = SwiftLintFramework.Version(value: latestVersionNumber)
+        if latestVersion > SwiftLintFramework.Version.current {
+            print("A new version of SwiftLint is available: \(latestVersionNumber)")
+        } else {
+            print("Your version of SwiftLint is up to date")
+        }
+    }
+
+    private static func parseVersionNumber(_ data: Data) -> String? {
+        guard let jsonObject = try? JSONSerialization.jsonObject(with: data, options: []) as? [AnyHashable: Any],
+              let tagName = jsonObject["tag_name"] as? String else {
+            return nil
+        }
+        return tagName
+    }
+
+    private static func sendSynchronousRequest(to url: URL) -> Data? {
+        var request = URLRequest(url: url)
+        request.setValue("application/vnd.github.v3+json", forHTTPHeaderField: "Accept")
+        let semaphore = DispatchSemaphore(value: 0)
+        var result: Data?
+
+        let task = URLSession.shared.dataTask(with: request) { data, _, _ in
+            result = data
+            semaphore.signal()
+        }
+        task.resume()
+
+        semaphore.wait()
+        return result
+    }
+}

--- a/Source/swiftlint/Helpers/UpdateChecker.swift
+++ b/Source/swiftlint/Helpers/UpdateChecker.swift
@@ -11,6 +11,9 @@
 //
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import SwiftLintFramework
 
 enum UpdateChecker {

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -58,6 +58,7 @@ final class ConfigurationTests: SwiftLintTestCase {
         XCTAssertFalse(config.strict)
         XCTAssertNil(config.baseline)
         XCTAssertNil(config.writeBaseline)
+        XCTAssertFalse(config.checkForUpdates)
     }
 
     func testInitWithRelativePathAndRootPath() {
@@ -446,6 +447,11 @@ final class ConfigurationTests: SwiftLintTestCase {
         let baselinePath = "Baseline.json"
         let configuration = try Configuration(dict: ["write_baseline": baselinePath])
         XCTAssertEqual(configuration.writeBaseline, baselinePath)
+    }
+
+    func testCheckForUpdates() throws {
+        let configuration = try Configuration(dict: ["check_for_updates": true])
+        XCTAssertTrue(configuration.checkForUpdates)
     }
 }
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,8 +8,8 @@ jobs:
   strategy:
     maxParallel: 10
     matrix:
-      swift59:
-        containerImage: swift:5.9
+      swift5101:
+        containerImage: swift:5.10.1
   container: $[ variables['containerImage'] ]
   steps:
     - script: swift test --parallel -Xswiftc -DDISABLE_FOCUSED_EXAMPLES

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,8 +8,8 @@ jobs:
   strategy:
     maxParallel: 10
     matrix:
-      swift5101:
-        containerImage: swift:5.10.1
+      swift59:
+        containerImage: swift:5.9
   container: $[ variables['containerImage'] ]
   steps:
     - script: swift test --parallel -Xswiftc -DDISABLE_FOCUSED_EXAMPLES


### PR DESCRIPTION
Adds an update check facility to SwiftLint - addresses #5551 

This has been added as a `--check-for-updates` command line option to the `version`, `lint`, and `analyze` commands.

It can also be enabled via the configuration file, as `check_for_updates`.

Although the usefulness of an opt-in option is limited, at least this provides a good story for how users _can_ keep their installs up to date. And it could easily be changed to opt-out either here or at some later date.

The update checker code is pretty closely based on Periphery's implementation, and should probably be credited in the source file.

The update check is performed after all other processing, so linting will never be delayed, and the code is completely synchronous, as we do not have to worry about blocking the main thread.

The messaging for a new version is: `A new version of SwiftLint is available: 0.51.1`

We currently do not print any messaging if the update check fails, which is probably wrong.

```
% swiftlint help version
OVERVIEW: Display the current version of SwiftLint

USAGE: swiftlint version [--verbose] [--check-for-updates]

OPTIONS:
  --check-for-updates     Check whether a later version of SwiftLint is available.

%
% ./swiftlint version --check-for-updates
0.55.1
Your version of SwiftLint is up to date
%
%
% swiftlint help lint
OVERVIEW: Print lint warnings and errors

USAGE: swiftlint lint [<options>] [<paths> ...]

ARGUMENTS:
  <paths>                 List of paths to the files or directories to lint.

OPTIONS:
  --check-for-updates     Check whether a later version of SwiftLint is available.
```