### PR TITLE
Remove deprecated path argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 #### Breaking
 
-* None.
+* The deprecated `--path` argument has now been removed completely.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#5614](https://github.com/realm/SwiftLint/issues/5614)
 
 #### Experimental
 

--- a/README.md
+++ b/README.md
@@ -680,7 +680,9 @@ opt_in_rules: # some rules are turned off by default, so you need to opt-in
 analyzer_rules: # rules run by `swiftlint analyze`
   - explicit_self
 
-included: # case-sensitive paths to include during linting.
+# case-sensitive paths to include during linting. Directory paths supplied on the
+# command line will be ignored.
+included: 
   - Sources
 excluded: # case-sensitive paths to ignore during linting. Takes precedence over `included`
   - Carthage

--- a/README.md
+++ b/README.md
@@ -680,7 +680,7 @@ opt_in_rules: # some rules are turned off by default, so you need to opt-in
 analyzer_rules: # rules run by `swiftlint analyze`
   - explicit_self
 
-# case-sensitive paths to include during linting. Directory paths supplied on the
+# Case-sensitive paths to include during linting. Directory paths supplied on the
 # command line will be ignored.
 included: 
   - Sources

--- a/README.md
+++ b/README.md
@@ -680,7 +680,7 @@ opt_in_rules: # some rules are turned off by default, so you need to opt-in
 analyzer_rules: # rules run by `swiftlint analyze`
   - explicit_self
 
-included: # case-sensitive paths to include during linting. `--path` is ignored if present
+included: # case-sensitive paths to include during linting.
   - Sources
 excluded: # case-sensitive paths to ignore during linting. Takes precedence over `included`
   - Carthage

--- a/Source/swiftlint/Commands/Analyze.swift
+++ b/Source/swiftlint/Commands/Analyze.swift
@@ -17,12 +17,8 @@ extension SwiftLint {
         var paths = [String]()
 
         func run() async throws {
-            let allPaths: [String]
-            if !paths.isEmpty {
-                allPaths = paths
-            } else {
-                allPaths = [""] // Analyze files in current working directory if no paths were specified.
-            }
+            // Analyze files in current working directory if no paths were specified.
+            let allPaths = paths.isNotEmpty ? paths : [""]
             let options = LintOrAnalyzeOptions(
                 mode: .analyze,
                 paths: allPaths,

--- a/Source/swiftlint/Commands/Analyze.swift
+++ b/Source/swiftlint/Commands/Analyze.swift
@@ -7,8 +7,6 @@ extension SwiftLint {
 
         @OptionGroup
         var common: LintOrAnalyzeArguments
-        @Option(help: pathOptionDescription(for: .analyze))
-        var path: String?
         @Flag(help: quietOptionDescription(for: .analyze))
         var quiet = false
         @Option(help: "The path of the full xcodebuild log to use when running AnalyzerRules.")
@@ -20,13 +18,7 @@ extension SwiftLint {
 
         func run() async throws {
             let allPaths: [String]
-            if let path {
-                // TODO: [06/14/2024] Remove deprecation warning after ~2 years.
-                Issue.genericWarning(
-                    "The --path option is deprecated. Pass the path(s) to analyze last to the swiftlint command."
-                ).print()
-                allPaths = [path] + paths
-            } else if !paths.isEmpty {
+            if !paths.isEmpty {
                 allPaths = paths
             } else {
                 allPaths = [""] // Analyze files in current working directory if no paths were specified.

--- a/Source/swiftlint/Commands/Lint.swift
+++ b/Source/swiftlint/Commands/Lint.swift
@@ -7,8 +7,6 @@ extension SwiftLint {
 
         @OptionGroup
         var common: LintOrAnalyzeArguments
-        @Option(help: pathOptionDescription(for: .lint))
-        var path: String?
         @Flag(help: "Lint standard input.")
         var useSTDIN = false
         @Flag(help: quietOptionDescription(for: .lint))
@@ -27,21 +25,12 @@ extension SwiftLint {
         func run() async throws {
             Issue.printDeprecationWarnings = !silenceDeprecationWarnings
 
-            if path != nil {
-                // TODO: [06/14/2024] Remove deprecation warning after ~2 years.
-                Issue.genericWarning(
-                    "The --path option is deprecated. Pass the path(s) to lint last to the swiftlint command."
-                ).print()
-            }
-
             if common.fix, let leniency = common.leniency {
                 Issue.genericWarning("The option --\(leniency) has no effect together with --fix.").print()
             }
 
             let allPaths =
-                if let path {
-                    [path] + paths
-                } else if !paths.isEmpty {
+                if !paths.isEmpty {
                     paths
                 } else {
                     [""] // Lint files in current working directory if no paths were specified.

--- a/Source/swiftlint/Commands/Lint.swift
+++ b/Source/swiftlint/Commands/Lint.swift
@@ -29,13 +29,8 @@ extension SwiftLint {
                 Issue.genericWarning("The option --\(leniency) has no effect together with --fix.").print()
             }
 
-            let allPaths =
-                if !paths.isEmpty {
-                    paths
-                } else {
-                    [""] // Lint files in current working directory if no paths were specified.
-                }
-
+            // Lint files in current working directory if no paths were specified.
+            let allPaths = paths.isNotEmpty ? paths : [""]
             let options = LintOrAnalyzeOptions(
                 mode: .lint,
                 paths: allPaths,

--- a/Source/swiftlint/Helpers/LintOrAnalyzeArguments.swift
+++ b/Source/swiftlint/Helpers/LintOrAnalyzeArguments.swift
@@ -55,10 +55,6 @@ struct LintOrAnalyzeArguments: ParsableArguments {
 // It'd be great to be able to parameterize an `@OptionGroup` so we could move these options into
 // `LintOrAnalyzeArguments`.
 
-func pathOptionDescription(for mode: LintOrAnalyzeMode) -> ArgumentHelp {
-    ArgumentHelp(visibility: .hidden)
-}
-
 func pathsArgumentDescription(for mode: LintOrAnalyzeMode) -> ArgumentHelp {
     "List of paths to the files or directories to \(mode.imperative)."
 }


### PR DESCRIPTION
Removes the deprecated path argument.

Added this as a breaking change to the changelog, as I think it may be in some cases. For example

https://github.com/fastlane/fastlane/blob/806c80c39754034c3dfcdade6beb51bb55c7f3b1/fastlane/spec/actions_specs/swiftlint_spec.rb#L126
