### PR TITLE
Fix type inside shell script in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ validations can be disabled with either of the following:
 * Setting Xcode defaults:
 
   ```bash
-  defaults write com.apple.dt.Xcode IDESkipPackagePluginFingerprintValidation -bool YES
+  defaults write com.apple.dt.Xcode IDESkipPackagePluginFingerprintValidatation -bool YES
   defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
   ```
 


### PR DESCRIPTION
I notice wrong typo which doesn't works properly.