### PR TITLE
Unused import rule transitive dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@
   [SimplyDanny](https://github.com/SimplyDanny)
   [#5835](https://github.com/realm/SwiftLint/issues/5835)
 
+* Allow to specify transitive modules to be taken into account by
+  `unused_import` rule. This avoids that required imports are removed.  
+  [Paul Taykalo](https://github.com/PaulTaykalo)
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#5167](https://github.com/realm/SwiftLint/issues/5167)
+
 * Do not throw deprecation warning if deprecated property is not
   presented in configuration.  
   [chipp](https://github.com/chipp)

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedImportRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedImportRuleExamples.swift
@@ -25,6 +25,19 @@ struct UnusedImportRuleExamples {
         let 👨‍👩‍👧‍👦 = #selector(NSArray.contains(_:))
         👨‍👩‍👧‍👦 == 👨‍👩‍👧‍👦
         """),
+        Example("""
+        import Foundation
+        enum E {
+            static let min: CGFloat = 44
+        }
+        """, configuration: [
+            "allowed_transitive_imports": [
+                [
+                    "module": "Foundation",
+                    "allowed_transitive_imports": ["CoreFoundation"],
+                ] as [String: any Sendable],
+            ],
+        ]),
     ]
 
     static let triggeringExamples = [
@@ -152,30 +165,35 @@ struct UnusedImportRuleExamples {
             class A {}
             """),
         Example("""
-        ↓↓import Foundation
+        import Foundation
         typealias Foo = CFArray
+        dispatchMain()
         """, configuration: [
             "require_explicit_imports": true,
             "allowed_transitive_imports": [
                 [
                     "module": "Foundation",
-                    "allowed_transitive_imports": ["CoreFoundation"],
+                    "allowed_transitive_imports": ["CoreFoundation", "Dispatch"],
                 ] as [String: any Sendable],
             ],
         ] as [String: any Sendable], testMultiByteOffsets: false, testOnLinux: false):
             Example("""
-            import CoreFoundation
+            import Foundation
             typealias Foo = CFArray
+            dispatchMain()
             """),
         Example("""
-        ↓↓import Foundation
+        ↓↓↓import Foundation
         typealias Foo = CFData
+        dispatchMain()
         """, configuration: [
             "require_explicit_imports": true
         ], testMultiByteOffsets: false, testOnLinux: false):
             Example("""
             import CoreFoundation
+            import Dispatch
             typealias Foo = CFData
+            dispatchMain()
             """),
         Example("""
         import Foundation

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedImportRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedImportRuleExamples.swift
@@ -38,6 +38,20 @@ struct UnusedImportRuleExamples {
                 ] as [String: any Sendable],
             ],
         ]),
+        Example("""
+        import SwiftUI
+
+        final class EditMode: ObservableObject {
+            @Published var isEditing = false
+        }
+        """, configuration: [
+            "allowed_transitive_imports": [
+                [
+                    "module": "SwiftUI",
+                    "allowed_transitive_imports": ["Foundation"],
+                ] as [String: any Sendable],
+            ],
+        ], excludeFromDocumentation: true),
     ]
 
     static let triggeringExamples = [


### PR DESCRIPTION
This PR tries to resolve an issue, when unused import resolved incorrectly, since `swiflint` doesn't check transitive imports

For example, if we have 
```
import Cocoa

let viewController = NSViewController()
```

Cocoa module is actually 
```
import AppKit
import Foundation
import CoreData
```


So this PR actually tries to account `transitive_modules` configuration to prevent incorrect import removals


## Alternative

As an alternative we can try to generate interfaces of all imported modules (once per module)
And parse their imports on the top level

So , for example, if we found some missing modules, we'll check if those can be found in the generated interface.

For example, 

```
import SwiftUI
```

Will allow to use any of the underlying modules

```
/// Generated SwifTUI interface
import Accessibility
import AppKit
import Combine
import CoreData
import CoreFoundation
import CoreGraphics
import CoreTransferable
import Darwin
import DeveloperToolsSupport
import Foundation
import OSLog
import Observation
import Spatial
import SwiftUICore
import Symbols
import TargetConditionals
import UniformTypeIdentifiers
import _Concurrency
import _StringProcessing
import _SwiftConcurrencyShims
import os
import os.log
import simd
```

Related Issues:
https://github.com/realm/SwiftLint/issues/5167