### PR TITLE
Enable upcoming features

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -32,6 +32,8 @@ copts = [
     "ConciseMagicFile",
     "-enable-upcoming-feature",
     "ImportObjcForwardDeclarations",
+    "-enable-upcoming-feature",
+    "ForwardTrailingClosures",
 ]
 
 strict_concurrency_copts = [

--- a/BUILD
+++ b/BUILD
@@ -34,6 +34,8 @@ copts = [
     "ImportObjcForwardDeclarations",
     "-enable-upcoming-feature",
     "ForwardTrailingClosures",
+    "-enable-upcoming-feature",
+    "InternalImportsByDefault",
 ]
 
 strict_concurrency_copts = [

--- a/BUILD
+++ b/BUILD
@@ -30,6 +30,8 @@ copts = [
     "ExistentialAny",
     "-enable-upcoming-feature",
     "ConciseMagicFile",
+    "-enable-upcoming-feature",
+    "ImportObjcForwardDeclarations",
 ]
 
 strict_concurrency_copts = [

--- a/BUILD
+++ b/BUILD
@@ -36,6 +36,8 @@ copts = [
     "ForwardTrailingClosures",
     "-enable-upcoming-feature",
     "InternalImportsByDefault",
+    "-enable-upcoming-feature",
+    "ImplicitOpenExistentials",
 ]
 
 strict_concurrency_copts = [

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,8 @@ let swiftFeatures: [SwiftSetting] = [
     .enableUpcomingFeature("ConciseMagicFile"),
     .enableUpcomingFeature("ImportObjcForwardDeclarations"),
     .enableUpcomingFeature("ForwardTrailingClosures"),
-    .enableUpcomingFeature("InternalImportsByDefault")
+    .enableUpcomingFeature("InternalImportsByDefault"),
+    .enableUpcomingFeature("ImplicitOpenExistentials")
 ]
 
 let swiftLintPluginDependencies: [Target.Dependency]

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,8 @@ import PackageDescription
 
 let swiftFeatures: [SwiftSetting] = [
     .enableUpcomingFeature("ExistentialAny"),
-    .enableUpcomingFeature("ConciseMagicFile")
+    .enableUpcomingFeature("ConciseMagicFile"),
+    .enableUpcomingFeature("ImportObjcForwardDeclarations")
 ]
 
 let swiftLintPluginDependencies: [Target.Dependency]

--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,8 @@ let swiftFeatures: [SwiftSetting] = [
     .enableUpcomingFeature("ExistentialAny"),
     .enableUpcomingFeature("ConciseMagicFile"),
     .enableUpcomingFeature("ImportObjcForwardDeclarations"),
-    .enableUpcomingFeature("ForwardTrailingClosures")
+    .enableUpcomingFeature("ForwardTrailingClosures"),
+    .enableUpcomingFeature("InternalImportsByDefault")
 ]
 
 let swiftLintPluginDependencies: [Target.Dependency]

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,8 @@ import PackageDescription
 let swiftFeatures: [SwiftSetting] = [
     .enableUpcomingFeature("ExistentialAny"),
     .enableUpcomingFeature("ConciseMagicFile"),
-    .enableUpcomingFeature("ImportObjcForwardDeclarations")
+    .enableUpcomingFeature("ImportObjcForwardDeclarations"),
+    .enableUpcomingFeature("ForwardTrailingClosures")
 ]
 
 let swiftLintPluginDependencies: [Target.Dependency]


### PR DESCRIPTION
All of them are going to be enabled by default in Swift 6. Let's already adopt them to be prepared. They all seem to have no influence on SwiftLint itself.