### PR TITLE
Add `ignore_codingkeys` parameter to nesting

### DIFF
--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/NestingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/NestingRule.swift
@@ -64,7 +64,9 @@ private extension NestingRule {
         }
 
         override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
-            validate(forFunction: false, triggeringToken: node.enumKeyword)
+            if !(configuration.ignoreCodingKeys && node.isCodingKey) {
+                validate(forFunction: false, triggeringToken: node.enumKeyword)
+            }
             return .visitChildren
         }
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NestingConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NestingConfiguration.swift
@@ -15,6 +15,8 @@ struct NestingConfiguration: RuleConfiguration {
     private(set) var alwaysAllowOneTypeInFunctions = false
     @ConfigurationElement(key: "ignore_typealiases_and_associatedtypes")
     private(set) var ignoreTypealiasesAndAssociatedtypes = false
+    @ConfigurationElement(key: "ignore_codingkeys")
+    private(set) var ignoreCodingKeys = false
 
     func severity(with config: Severity, for level: Int) -> ViolationSeverity? {
         if let error = config.error, level > error {

--- a/Source/SwiftLintCore/Extensions/SwiftSyntax+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/SwiftSyntax+SwiftLint.swift
@@ -184,6 +184,25 @@ public extension EnumDeclSyntax {
             return rawValueTypes.contains(identifier)
         }
     }
+
+    /// True if this enum is a `CodingKey`
+    var isCodingKey: Bool {
+        guard let inheritedTypeCollection = inheritanceClause?.inheritedTypes else {
+            return false
+        }
+        
+        guard self.name.text == "CodingKeys" else {
+            return false
+        }
+
+        return inheritedTypeCollection.contains { element in
+            guard let identifier = element.type.as(IdentifierTypeSyntax.self)?.name.text else {
+                return false
+            }
+
+            return identifier == "CodingKey"
+        }
+    }
 }
 
 public extension FunctionDeclSyntax {

--- a/Tests/SwiftLintFrameworkTests/NestingRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/NestingRuleTests.swift
@@ -551,4 +551,38 @@ final class NestingRuleTests: SwiftLintTestCase {
 
         verifyRule(description, ruleConfiguration: ["ignore_typealiases_and_associatedtypes": true])
     }
+    
+    func testNestingWithoutCodingKeys() {
+        var nonTriggeringExamples = NestingRule.description.nonTriggeringExamples
+        nonTriggeringExamples.append(contentsOf: [
+            .init("""
+                struct Outer {
+                    struct Inner {
+                        enum CodingKeys: String, CodingKey {
+                            case id
+                        }
+                    }
+                }
+                """
+             )
+        ])
+        
+        var triggeringExamples = NestingRule.description.triggeringExamples
+        triggeringExamples.append(contentsOf: [
+            .init("""
+                struct Outer {
+                    struct Inner {
+                        enum Example: String, CodingKey {
+                            case id
+                        }
+                    }
+                }
+                """)
+        ])
+        
+        let description = NestingRule.description.with(nonTriggeringExamples: nonTriggeringExamples, triggeringExamples: triggeringExamples)
+        
+        verifyRule(description, ruleConfiguration: ["ignore_codingkeys": true ])
+    }
+
 }


### PR DESCRIPTION
Resolves #5641 

This very explicitly targets `enum`'s named `CodingKeys` which conform to `CodingKey`. To provide an exception for `Codable` users who have to provide custom keys. 


OK ✅ 
```swift
struct Outer {
    struct Inner: Codable {
        let identifier: Int
        enum CodingKeys: String, CodingKey {
            case identifier = "id"
        }
    }
}
```
---

Not OK ❌ 
```swift
struct Outer {
    struct Inner {
        let identifier: Int
        enum SomeKeys: String, CodingKey {
            case identifier = "id"
        }
    }
}
```