### PR TITLE
Enable the `closure_body_length` and `multiline_literal_brackets` rules

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -16,7 +16,6 @@ opt_in_rules:
 disabled_rules:
   - anonymous_argument_in_multiline_closure
   - anyobject_protocol
-  - closure_body_length
   - conditional_returns_on_newline
   - convenience_type
   - discouraged_optional_collection
@@ -34,7 +33,6 @@ disabled_rules:
   - multiline_arguments
   - multiline_arguments_brackets
   - multiline_function_chains
-  - multiline_literal_brackets
   - multiline_parameters
   - multiline_parameters_brackets
   - no_extension_access_modifier
@@ -64,6 +62,9 @@ balanced_xctest_lifecycle: &unit_test_configuration
   test_parent_classes:
     - SwiftLintTestCase
     - XCTestCase
+closure_body_length:
+    warning: 50
+    error: 100    
 empty_xctest_method: *unit_test_configuration
 file_name:
   excluded:

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DuplicateImportsRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DuplicateImportsRuleExamples.swift
@@ -37,6 +37,7 @@ internal struct DuplicateImportsRuleExamples {
 
     static let triggeringExamples = Array(corrections.keys.sorted())
 
+    // swiftlint:disable:next closure_body_length
     static let corrections: [Example: Example] = {
         var corrections = [
             Example("""

--- a/Tests/SwiftLintFrameworkTests/MissingDocsRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/MissingDocsRuleTests.swift
@@ -193,7 +193,8 @@ final class MissingDocsRuleTests: SwiftLintTestCase {
         XCTAssertFalse(configuration.excludesInheritedTypes)
         XCTAssertEqual(
             configuration.parameters.sorted { $0.value.rawValue > $1.value.rawValue },
-            [   RuleParameter<AccessControlLevel>(severity: .warning, value: .public),
+            [
+                RuleParameter<AccessControlLevel>(severity: .warning, value: .public),
                 RuleParameter<AccessControlLevel>(severity: .warning, value: .open),
             ]
         )

--- a/Tests/SwiftLintFrameworkTests/NestingRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/NestingRuleTests.swift
@@ -138,6 +138,7 @@ final class NestingRuleTests: SwiftLintTestCase {
             ]
         }
 
+        // swiftlint:disable:next closure_body_length
         triggeringExamples.append(contentsOf: detectingTypes.flatMap { type -> [Example] in
             [
                 .init("""
@@ -213,6 +214,7 @@ final class NestingRuleTests: SwiftLintTestCase {
     // swiftlint:disable:next function_body_length
     func testNestingWithoutCheckNestingInClosuresAndStatements() {
         var nonTriggeringExamples = NestingRule.description.nonTriggeringExamples
+        // swiftlint:disable:next closure_body_length
         nonTriggeringExamples.append(contentsOf: detectingTypes.flatMap { type -> [Example] in
             [
                 .init("""
@@ -386,6 +388,7 @@ final class NestingRuleTests: SwiftLintTestCase {
             ]
         })
 
+        // swiftlint:disable:next closure_body_length
         var triggeringExamples = detectingTypes.flatMap { type -> [Example] in
             [
                 .init("""


### PR DESCRIPTION

I upped the warning for `closure_body_length` to 50, which eliminated most of the cases
