### PR TITLE
Enable `implicit_return` and fix all violations

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -26,7 +26,6 @@ disabled_rules:
   - file_types_order
   - force_unwrapping
   - function_default_parameter_at_end
-  - implicit_return
   - indentation_width
   - inert_defer
   - missing_docs

--- a/Source/SwiftLintBuiltInRules/Extensions/SourceKittenDictionary+SwiftUI.swift
+++ b/Source/SwiftLintBuiltInRules/Extensions/SourceKittenDictionary+SwiftUI.swift
@@ -135,7 +135,7 @@ extension SourceKittenDictionary {
     /// Whether or not the dictionary represents a SwiftUI View with an `accesibilityHidden(true)`
     /// or `accessibility(hidden: true)` modifier.
     func hasAccessibilityHiddenModifier(in file: SwiftLintFile) -> Bool {
-        return hasModifier(
+        hasModifier(
             anyOf: [
                 SwiftUIModifier(
                     name: "accessibilityHidden",
@@ -153,7 +153,7 @@ extension SourceKittenDictionary {
     /// Whether or not the dictionary represents a SwiftUI View with an `accessibilityElement()` or
     /// `accessibilityElement(children: .ignore)` modifier (`.ignore` is the default parameter value).
     func hasAccessibilityElementChildrenIgnoreModifier(in file: SwiftLintFile) -> Bool {
-        return hasModifier(
+        hasModifier(
             anyOf: [
                 SwiftUIModifier(
                     name: "accessibilityElement",

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedOptionalBooleanRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedOptionalBooleanRuleExamples.swift
@@ -167,5 +167,5 @@ private func wrapExample(_ type: String,
                          _ test: String,
                          file: StaticString = #filePath,
                          line: UInt = #line) -> Example {
-    return Example("\(type) Foo {\n\t\(test)\n}", file: file, line: line)
+    Example("\(type) Foo {\n\t\(test)\n}", file: file, line: line)
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedOptionalCollectionExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedOptionalCollectionExamples.swift
@@ -214,7 +214,7 @@ private func wrapExample(_ type: String,
                          _ test: String,
                          file: StaticString = #filePath,
                          line: UInt = #line) -> Example {
-    return Example("""
+    Example("""
         \(type) Foo {
             \(test)
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/GenericTypeNameRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/GenericTypeNameRule.swift
@@ -39,7 +39,7 @@ struct GenericTypeNameRule: Rule {
             Example("typealias BackwardTriple<T1, ↓T2_Bar, T3> = (T3, T2_Bar, T1)"),
             Example("typealias DictionaryOfStrings<↓T_Foo: Hashable> = Dictionary<T_Foo, String>"),
         ] + ["class", "struct", "enum"].flatMap { type -> [Example] in
-            return [
+            [
                 Example("\(type) Foo<↓T_Foo> {}"),
                 Example("\(type) Foo<T, ↓U_Foo> {}"),
                 Example("\(type) Foo<↓T_Foo, ↓U_Foo> {}"),

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoGroupingExtensionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoGroupingExtensionRule.swift
@@ -23,9 +23,9 @@ struct NoGroupingExtensionRule: OptInRule {
     )
 
     func validate(file: SwiftLintFile) -> [StyleViolation] {
-        return Visitor(configuration: configuration, file: file)
+        Visitor(configuration: configuration, file: file)
             .walk(tree: file.syntaxTree) { visitor in
-                return visitor.extensionDeclarations.compactMap { decl in
+                visitor.extensionDeclarations.compactMap { decl in
                     guard visitor.typeDeclarations.contains(decl.name) else {
                         return nil
                     }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ObjectLiteralRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ObjectLiteralRule.swift
@@ -72,7 +72,7 @@ private extension ObjectLiteralRule {
         }
 
         private func inits(forClasses names: [String]) -> [String] {
-            return names.flatMap { name in
+            names.flatMap { name in
                 [
                     name,
                     name + ".init",

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferZeroOverExplicitInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferZeroOverExplicitInitRule.swift
@@ -74,31 +74,31 @@ private extension FunctionCallExprSyntax {
     }
 
     var isCGPointZeroCall: Bool {
-        return name == "CGPoint" &&
+        name == "CGPoint" &&
             argumentNames == ["x", "y"] &&
             argumentsAreAllZero
     }
 
     var isCGSizeCall: Bool {
-        return name == "CGSize" &&
+        name == "CGSize" &&
             argumentNames == ["width", "height"] &&
             argumentsAreAllZero
     }
 
     var isCGRectCall: Bool {
-        return name == "CGRect" &&
+        name == "CGRect" &&
             argumentNames == ["x", "y", "width", "height"] &&
             argumentsAreAllZero
     }
 
     var isCGVectorCall: Bool {
-        return name == "CGVector" &&
+        name == "CGVector" &&
             argumentNames == ["dx", "dy"] &&
             argumentsAreAllZero
     }
 
     var isUIEdgeInsetsCall: Bool {
-        return name == "UIEdgeInsets" &&
+        name == "UIEdgeInsets" &&
             argumentNames == ["top", "left", "bottom", "right"] &&
             argumentsAreAllZero
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/SyntacticSugarRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/SyntacticSugarRule.swift
@@ -20,15 +20,15 @@ struct SyntacticSugarRule: CorrectableRule, SourceKitFreeRule {
         return visitor.walk(file: file) { visitor in
             flattenViolations(visitor.violations)
         }.map { violation in
-            return StyleViolation(ruleDescription: Self.description,
-                                  severity: configuration.severity,
-                                  location: Location(file: file, byteOffset: ByteCount(violation.position)),
-                                  reason: violation.type.violationReason)
+            StyleViolation(ruleDescription: Self.description,
+                           severity: configuration.severity,
+                           location: Location(file: file, byteOffset: ByteCount(violation.position)),
+                           reason: violation.type.violationReason)
         }
     }
 
     private func flattenViolations(_ violations: [SyntacticSugarRuleViolation]) -> [SyntacticSugarRuleViolation] {
-        return violations.flatMap { [$0] + flattenViolations($0.children) }
+        violations.flatMap { [$0] + flattenViolations($0.children) }
     }
 
     func correct(file: SwiftLintFile) -> [Correction] {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
@@ -4,7 +4,7 @@ private func embedInSwitch(
     _ text: String,
     case: String = "case .bar",
     file: StaticString = #filePath, line: UInt = #line) -> Example {
-    return Example("""
+    Example("""
         switch foo {
         \(`case`):
             \(text)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/VoidFunctionInTernaryConditionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/VoidFunctionInTernaryConditionRule.swift
@@ -144,7 +144,7 @@ private extension VoidFunctionInTernaryConditionRule {
 
 private extension ExprListSyntax {
     var containsAssignment: Bool {
-        return children(viewMode: .sourceAccurate).contains(where: { $0.is(AssignmentExprSyntax.self) })
+        children(viewMode: .sourceAccurate).contains(where: { $0.is(AssignmentExprSyntax.self) })
     }
 }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/XCTSpecificMatcherRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/XCTSpecificMatcherRule.swift
@@ -124,7 +124,7 @@ private enum TwoArgsXCTAssert: String {
             .prefix(2)
             .map { $0.expression.trimmedDescription }
             .sorted { arg1, _ -> Bool in
-                return protectedArguments.contains(arg1)
+                protectedArguments.contains(arg1)
             }
 
         //

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityLabelForImageRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityLabelForImageRule.swift
@@ -124,7 +124,7 @@ private extension SourceKittenDictionary {
     /// Whether or not the dictionary represents a SwiftUI View with an `accesibilityLabel(_:)`
     /// or `accessibility(label:)` modifier.
     func hasAccessibilityLabelModifier(in file: SwiftLintFile) -> Bool {
-        return hasModifier(
+        hasModifier(
             anyOf: [
                 SwiftUIModifier(
                     name: "accessibilityLabel",

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityTraitForButtonRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityTraitForButtonRule.swift
@@ -88,7 +88,7 @@ private extension SourceKittenDictionary {
     /// or by a `gesture`, `simultaneousGesture`, or `highPriorityGesture` modifier with an argument
     /// starting with a `TapGesture` object with a count of 1 (default value is 1).
     func hasOnSingleTapModifier(in file: SwiftLintFile) -> Bool {
-        return hasModifier(
+        hasModifier(
             anyOf: [
                 SwiftUIModifier(
                     name: "onTapGesture",
@@ -120,7 +120,7 @@ private extension SourceKittenDictionary {
     /// Whether or not the dictionary represents a SwiftUI View with an `accessibilityAddTraits()` or
     /// `accessibility(addTraits:)` modifier with the specified trait (specify trait as a String).
     func hasAccessibilityTrait(_ trait: String, in file: SwiftLintFile) -> Bool {
-        return hasModifier(
+        hasModifier(
             anyOf: [
                 SwiftUIModifier(
                     name: "accessibilityAddTraits",

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/CommentSpacingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/CommentSpacingRule.swift
@@ -123,7 +123,7 @@ struct CommentSpacingRule: SourceKitFreeRule, SubstitutionCorrectableRule {
             .filter(\.kind.isComment)
             .map { $0.range.toSourceKittenByteRange() }
             .compactMap { (range: ByteRange) -> [NSRange]? in
-                return file.stringView
+                file.stringView
                     .substringWithByteRange(range)
                     .map(StringView.init)
                     .map { commentBody in
@@ -134,7 +134,7 @@ struct CommentSpacingRule: SourceKitFreeRule, SubstitutionCorrectableRule {
                             .compactMap { result in
                                 // Set the location to be directly before the first non-slash,
                                 // non-whitespace character which was matched
-                                return file.stringView.byteRangeToNSRange(
+                                file.stringView.byteRangeToNSRange(
                                     ByteRange(
                                         // Safe to mix NSRange offsets with byte offsets here because the regex can't
                                         // contain multi-byte characters
@@ -149,7 +149,7 @@ struct CommentSpacingRule: SourceKitFreeRule, SubstitutionCorrectableRule {
     }
 
     func validate(file: SwiftLintFile) -> [StyleViolation] {
-        return violationRanges(in: file).map { range in
+        violationRanges(in: file).map { range in
             StyleViolation(
                 ruleDescription: Self.description,
                 severity: configuration.severity,
@@ -159,6 +159,6 @@ struct CommentSpacingRule: SourceKitFreeRule, SubstitutionCorrectableRule {
     }
 
     func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
-        return (violationRange, " ")
+        (violationRange, " ")
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/CompilerProtocolInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/CompilerProtocolInitRule.swift
@@ -105,7 +105,7 @@ private struct ExpressibleByCompiler {
     }()
 
     func match(arguments: [String]) -> Bool {
-        return self.arguments.contains(arguments)
+        self.arguments.contains(arguments)
     }
 
     private static let byArrayLiteral: ExpressibleByCompiler = {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ExpiringTodoRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ExpiringTodoRule.swift
@@ -117,13 +117,13 @@ struct ExpiringTodoRule: OptInRule {
 
 private extension Date {
     var isAfterToday: Bool {
-        return Calendar.current.compare(.init(), to: self, toGranularity: .day) == .orderedAscending
+        Calendar.current.compare(.init(), to: self, toGranularity: .day) == .orderedAscending
     }
 }
 
 private extension SyntaxKind {
    /// Returns if the syntax kind is comment-like.
    var isCommentLike: Bool {
-       return Self.commentKinds.contains(self)
+       Self.commentKinds.contains(self)
    }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/PeriodSpacingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/PeriodSpacingRule.swift
@@ -53,16 +53,16 @@ struct PeriodSpacingRule: SourceKitFreeRule, OptInRule, SubstitutionCorrectableR
             .filter(\.kind.isComment)
             .map { $0.range.toSourceKittenByteRange() }
             .compactMap { (range: ByteRange) -> [NSRange]? in
-                return file.stringView
+                file.stringView
                     .substringWithByteRange(range)
                     .map(StringView.init)
                     .map { commentBody in
                         // Look for a period followed by two or more whitespaces but not new line or carriage returns
-                        return regex(#"\.[^\S\r\n]{2,}"#)
+                        regex(#"\.[^\S\r\n]{2,}"#)
                             .matches(in: commentBody)
                             .compactMap { result in
                                 // Set the location to start from the second whitespace till the last one.
-                                return file.stringView.byteRangeToNSRange(
+                                file.stringView.byteRangeToNSRange(
                                     ByteRange(
                                         // Safe to mix NSRange offsets with byte offsets here because the
                                         // regex can't contain multi-byte characters
@@ -77,7 +77,7 @@ struct PeriodSpacingRule: SourceKitFreeRule, OptInRule, SubstitutionCorrectableR
     }
 
     func validate(file: SwiftLintFile) -> [StyleViolation] {
-        return violationRanges(in: file).map { range in
+        violationRanges(in: file).map { range in
             StyleViolation(
                 ruleDescription: Self.description,
                 severity: configuration.severity,
@@ -87,6 +87,6 @@ struct PeriodSpacingRule: SourceKitFreeRule, OptInRule, SubstitutionCorrectableR
     }
 
     func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
-        return (violationRange, "")
+        (violationRange, "")
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ProhibitedInterfaceBuilderRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ProhibitedInterfaceBuilderRule.swift
@@ -37,7 +37,7 @@ private extension ProhibitedInterfaceBuilderRule {
 }
 
 private func wrapExample(_ text: String, file: StaticString = #filePath, line: UInt = #line) -> Example {
-    return Example("""
+    Example("""
     class ViewController: UIViewController {
         \(text)
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/QuickDiscouragedCallRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/QuickDiscouragedCallRule.swift
@@ -15,7 +15,7 @@ struct QuickDiscouragedCallRule: OptInRule {
     func validate(file: SwiftLintFile) -> [StyleViolation] {
         let dict = file.structureDictionary
         let testClasses = dict.substructure.filter {
-            return $0.inheritedTypes.isNotEmpty &&
+            $0.inheritedTypes.isNotEmpty &&
                 $0.declarationKind == .class
         }
 
@@ -34,7 +34,7 @@ struct QuickDiscouragedCallRule: OptInRule {
     }
 
     private func validate(file: SwiftLintFile, dictionary: SourceKittenDictionary) -> [StyleViolation] {
-        return dictionary.traverseDepthFirst { subDict in
+        dictionary.traverseDepthFirst { subDict in
             guard let kind = subDict.expressionKind else { return nil }
             return validate(file: file, kind: kind, dictionary: subDict)
         }
@@ -60,7 +60,7 @@ struct QuickDiscouragedCallRule: OptInRule {
     }
 
     private func violationOffsets(in substructure: [SourceKittenDictionary]) -> [ByteCount] {
-        return substructure.flatMap { dictionary -> [ByteCount] in
+        substructure.flatMap { dictionary -> [ByteCount] in
             let substructure = dictionary.substructure.flatMap { dict -> [SourceKittenDictionary] in
                 if dict.expressionKind == .closure {
                     return dict.substructure

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/QuickDiscouragedFocusedTestRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/QuickDiscouragedFocusedTestRule.swift
@@ -48,7 +48,7 @@ private extension ClassDeclSyntax {
 
 private extension FunctionDeclSyntax {
     var isSpecFunction: Bool {
-        return name.tokenKind == .identifier("spec") &&
+        name.tokenKind == .identifier("spec") &&
         signature.parameterClause.parameters.isEmpty &&
         modifiers.contains(keyword: .override)
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/QuickDiscouragedPendingTestRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/QuickDiscouragedPendingTestRule.swift
@@ -48,7 +48,7 @@ private extension ClassDeclSyntax {
 
 private extension FunctionDeclSyntax {
     var isSpecFunction: Bool {
-        return name.tokenKind == .identifier("spec") &&
+        name.tokenKind == .identifier("spec") &&
         signature.parameterClause.parameters.isEmpty &&
             modifiers.contains(keyword: .override)
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/RequiredEnumCaseRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/RequiredEnumCaseRule.swift
@@ -167,7 +167,7 @@ private extension RequiredEnumCaseRule {
 
 private extension EnumDeclSyntax {
     var enumCasesNames: [String] {
-        return memberBlock.members
+        memberBlock.members
             .flatMap { member -> [String] in
                 guard let enumCaseDecl = member.decl.as(EnumCaseDeclSyntax.self) else {
                     return []

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/StrongIBOutletRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/StrongIBOutletRule.swift
@@ -69,7 +69,7 @@ private extension VariableDeclSyntax {
 }
 
 private func wrapExample(_ text: String, file: StaticString = #filePath, line: UInt = #line) -> Example {
-    return Example("""
+    Example("""
     class ViewController: UIViewController {
         \(text)
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedDeclarationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedDeclarationRule.swift
@@ -70,7 +70,7 @@ struct UnusedDeclarationRule: AnalyzerRule, CollectingRule {
         // Unused declarations are:
         // 1. all declarations
         // 2. minus all references
-        return declaredUSRs
+        declaredUSRs
             .filter { !allReferencedUSRs.contains($0.usr) }
             .map { $0.nameOffset }
             .sorted()
@@ -81,7 +81,7 @@ struct UnusedDeclarationRule: AnalyzerRule, CollectingRule {
 
 private extension SwiftLintFile {
     func index(compilerArguments: [String]) -> SourceKittenDictionary? {
-        return path
+        path
             .flatMap { path in
                 try? Request.index(file: path, arguments: compilerArguments)
                             .send()
@@ -90,7 +90,7 @@ private extension SwiftLintFile {
     }
 
     func referencedUSRs(index: SourceKittenDictionary, editorOpen: SourceKittenDictionary) -> Set<String> {
-        return Set(index.traverseEntitiesDepthFirst { parent, entity -> String? in
+        Set(index.traverseEntitiesDepthFirst { parent, entity -> String? in
             if let usr = entity.usr,
                let kind = entity.kind,
                kind.starts(with: "source.lang.swift.ref"),
@@ -109,7 +109,7 @@ private extension SwiftLintFile {
     func declaredUSRs(index: SourceKittenDictionary, editorOpen: SourceKittenDictionary,
                       compilerArguments: [String], configuration: UnusedDeclarationConfiguration)
     -> Set<UnusedDeclarationRule.DeclaredUSR> {
-        return Set(index.traverseEntitiesDepthFirst { _, indexEntity in
+        Set(index.traverseEntitiesDepthFirst { _, indexEntity in
             self.declaredUSR(indexEntity: indexEntity, editorOpen: editorOpen, compilerArguments: compilerArguments,
                              configuration: configuration)
         })
@@ -225,15 +225,15 @@ private extension SwiftLintFile {
 
 private extension SourceKittenDictionary {
     var usr: String? {
-        return value["key.usr"] as? String
+        value["key.usr"] as? String
     }
 
     var annotatedDeclaration: String? {
-        return value["key.annotated_decl"] as? String
+        value["key.annotated_decl"] as? String
     }
 
     var isImplicit: Bool {
-        return value["key.is_implicit"] as? Bool == true
+        value["key.is_implicit"] as? Bool == true
     }
 
     func propertyAtOffset<T>(_ offset: ByteCount, property: KeyPath<Self, T?>) -> T? {
@@ -251,7 +251,7 @@ private extension SourceKittenDictionary {
     }
 
     func shouldSkipRelated(relatedUSRsToSkip: Set<String>) -> Bool {
-        return (value["key.related"] as? [[String: any SourceKitRepresentable]])?
+        (value["key.related"] as? [[String: any SourceKitRepresentable]])?
             .compactMap { SourceKittenDictionary($0).usr }
             .contains(where: relatedUSRsToSkip.contains) == true
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedImportRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedImportRule.swift
@@ -18,7 +18,7 @@ struct UnusedImportRule: CorrectableRule, AnalyzerRule {
     )
 
     func validate(file: SwiftLintFile, compilerArguments: [String]) -> [StyleViolation] {
-        return importUsage(in: file, compilerArguments: compilerArguments).map { importUsage in
+        importUsage(in: file, compilerArguments: compilerArguments).map { importUsage in
             StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: importUsage.violationRange?.location ?? 1),
@@ -186,7 +186,7 @@ private extension SwiftLintFile {
     }
 
     func rangedAndSortedUnusedImports(of unusedImports: [String]) -> [(String, NSRange)] {
-        return unusedImports
+        unusedImports
             .compactMap { module in
                 match(pattern: "^(@(?!_exported)\\w+ +)?import +\(module)\\b.*?\n").first.map { (module, $0.0) }
             }
@@ -240,7 +240,7 @@ private extension SwiftLintFile {
     }
 
     func offsetPerLine() -> [Int: Int64] {
-        return Dictionary(
+        Dictionary(
             uniqueKeysWithValues: contents.bridge()
                 .components(separatedBy: "\n")
                 .map { Int64($0.bridge().lengthOfBytes(using: .utf8)) }

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/ClosureBodyLengthRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/ClosureBodyLengthRuleExamples.swift
@@ -30,7 +30,7 @@ internal struct ClosureBodyLengthRuleExamples {
 // MARK: - Private
 
 private func singleLineClosure(file: StaticString = #filePath, line: UInt = #line) -> Example {
-    return Example("foo.bar { $0 }", file: file, line: line)
+    Example("foo.bar { $0 }", file: file, line: line)
 }
 
 private func trailingClosure(_ violationSymbol: String = "",
@@ -39,7 +39,7 @@ private func trailingClosure(_ violationSymbol: String = "",
                              emptyLinesCount: Int,
                              file: StaticString = #filePath,
                              line: UInt = #line) -> Example {
-    return Example("""
+    Example("""
         foo.bar \(violationSymbol){ toto in
         \((0..<codeLinesCount).map { "\tlet a\($0) = 0\n" }.joined())\
         \(repeatElement("\t// toto\n", count: commentLinesCount).joined())\
@@ -52,7 +52,7 @@ private func argumentClosure(_ violationSymbol: String = "",
                              codeLinesCount: Int,
                              file: StaticString = #filePath,
                              line: UInt = #line) -> Example {
-    return Example("""
+    Example("""
         foo.bar(\(violationSymbol){ toto in
         \((0..<codeLinesCount).map { "\tlet a\($0) = 0\n" }.joined())\
         })
@@ -63,7 +63,7 @@ private func labeledArgumentClosure(_ violationSymbol: String = "",
                                     codeLinesCount: Int,
                                     file: StaticString = #filePath,
                                     line: UInt = #line) -> Example {
-    return Example("""
+    Example("""
         foo.bar(label: \(violationSymbol){ toto in
         \((0..<codeLinesCount).map { "\tlet a\($0) = 0\n" }.joined())\
         })
@@ -74,7 +74,7 @@ private func multiLabeledArgumentClosures(_ violationSymbol: String = "",
                                           codeLinesCount: Int,
                                           file: StaticString = #filePath,
                                           line: UInt = #line) -> Example {
-    return Example("""
+    Example("""
         foo.bar(label: \(violationSymbol){ toto in
         \((0..<codeLinesCount).map { "\tlet a\($0) = 0\n" }.joined())\
         }, anotherLabel: \(violationSymbol){ toto in
@@ -87,7 +87,7 @@ private func labeledAndTrailingClosures(_ violationSymbol: String = "",
                                         codeLinesCount: Int,
                                         file: StaticString = #filePath,
                                         line: UInt = #line) -> Example {
-    return Example("""
+    Example("""
         foo.bar(label: \(violationSymbol){ toto in
         \((0..<codeLinesCount).map { "\tlet a\($0) = 0\n" }.joined())\
         }) \(violationSymbol){ toto in
@@ -100,7 +100,7 @@ private func lazyInitialization(_ violationSymbol: String = "",
                                 codeLinesCount: Int,
                                 file: StaticString = #filePath,
                                 line: UInt = #line) -> Example {
-    return Example("""
+    Example("""
         let foo: Bar = \(violationSymbol){ toto in
         \tlet bar = Bar()
         \((0..<codeLinesCount).map { "\tlet a\($0) = 0\n" }.joined())\

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/FileLengthRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/FileLengthRule.swift
@@ -22,7 +22,7 @@ struct FileLengthRule: Rule {
         func lineCountWithoutComments() -> Int {
             let commentKinds = SyntaxKind.commentKinds
             return file.syntaxKindsByLines.filter { kinds in
-                return !Set(kinds).isSubset(of: commentKinds)
+                !Set(kinds).isSubset(of: commentKinds)
             }.count
         }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/TypeBodyLengthRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/TypeBodyLengthRule.swift
@@ -6,7 +6,7 @@ private func wrapExample(
     _ add: String = "",
     file: StaticString = #filePath,
     line: UInt = #line) -> Example {
-    return Example("\(prefix)\(type) Abc {\n" +
+    Example("\(prefix)\(type) Abc {\n" +
                    repeatElement(template, count: count).joined() + "\(add)}\n", file: file, line: line)
 }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverFilterCountRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverFilterCountRule.swift
@@ -10,7 +10,7 @@ struct ContainsOverFilterCountRule: OptInRule {
         description: "Prefer `contains` over comparing `filter(where:).count` to 0",
         kind: .performance,
         nonTriggeringExamples: [">", "==", "!="].flatMap { operation in
-            return [
+            [
                 Example("let result = myList.filter(where: { $0 % 2 == 0 }).count \(operation) 1"),
                 Example("let result = myList.filter { $0 % 2 == 0 }.count \(operation) 1"),
                 Example("let result = myList.filter(where: { $0 % 2 == 0 }).count \(operation) 01"),
@@ -21,7 +21,7 @@ struct ContainsOverFilterCountRule: OptInRule {
             Example("let result = myList.contains(10)"),
         ],
         triggeringExamples: [">", "==", "!="].flatMap { operation in
-            return [
+            [
                 Example("let result = ↓myList.filter(where: { $0 % 2 == 0 }).count \(operation) 0"),
                 Example("let result = ↓myList.filter { $0 % 2 == 0 }.count \(operation) 0"),
                 Example("let result = ↓myList.filter(where: someFunction).count \(operation) 0"),

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverFilterIsEmptyRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverFilterIsEmptyRule.swift
@@ -10,7 +10,7 @@ struct ContainsOverFilterIsEmptyRule: OptInRule {
         description: "Prefer `contains` over using `filter(where:).isEmpty`",
         kind: .performance,
         nonTriggeringExamples: [">", "==", "!="].flatMap { operation in
-            return [
+            [
                 Example("let result = myList.filter(where: { $0 % 2 == 0 }).count \(operation) 1"),
                 Example("let result = myList.filter { $0 % 2 == 0 }.count \(operation) 1"),
             ]

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverFirstNotNilRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverFirstNotNilRule.swift
@@ -10,14 +10,14 @@ struct ContainsOverFirstNotNilRule: OptInRule {
         description: "Prefer `contains` over `first(where:) != nil` and `firstIndex(where:) != nil`.",
         kind: .performance,
         nonTriggeringExamples: ["first", "firstIndex"].flatMap { method in
-            return [
+            [
                 Example("let \(method) = myList.\(method)(where: { $0 % 2 == 0 })"),
                 Example("let \(method) = myList.\(method) { $0 % 2 == 0 }"),
             ]
         },
         triggeringExamples: ["first", "firstIndex"].flatMap { method in
-            return ["!=", "=="].flatMap { comparison in
-                return [
+            ["!=", "=="].flatMap { comparison in
+                [
                     Example("↓myList.\(method) { $0 % 2 == 0 } \(comparison) nil"),
                     Example("↓myList.\(method)(where: { $0 % 2 == 0 }) \(comparison) nil"),
                     Example("↓myList.map { $0 + 1 }.\(method)(where: { $0 % 2 == 0 }) \(comparison) nil"),

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverRangeNilComparisonRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverRangeNilComparisonRule.swift
@@ -16,7 +16,7 @@ struct ContainsOverRangeNilComparisonRule: OptInRule {
             Example("resourceString.range(of: rule.regex, options: .regularExpression) != nil"),
         ],
         triggeringExamples: ["!=", "=="].flatMap { comparison in
-            return [
+            [
                 Example("↓myString.range(of: \"Test\") \(comparison) nil")
             ]
         }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/CyclomaticComplexityConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/CyclomaticComplexityConfiguration.swift
@@ -11,6 +11,6 @@ struct CyclomaticComplexityConfiguration: RuleConfiguration {
     private(set) var ignoresCaseStatements = false
 
     var params: [RuleParameter<Int>] {
-        return length.params
+        length.params
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileHeaderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileHeaderConfiguration.swift
@@ -85,13 +85,11 @@ struct FileHeaderConfiguration: SeverityBasedRuleConfiguration {
     }
 
     private func regexFromString(for file: SwiftLintFile, using pattern: String) -> NSRegularExpression? {
-        return makeRegex(for: file, using: pattern, options: Self.stringRegexOptions,
-                         escapeFileName: false)
+        makeRegex(for: file, using: pattern, options: Self.stringRegexOptions, escapeFileName: false)
     }
 
     private func regexFromPattern(for file: SwiftLintFile, using pattern: String) -> NSRegularExpression? {
-        return makeRegex(for: file, using: pattern, options: Self.patternRegexOptions,
-                         escapeFileName: true)
+        makeRegex(for: file, using: pattern, options: Self.patternRegexOptions, escapeFileName: true)
     }
 
     func forbiddenRegex(for file: SwiftLintFile) -> NSRegularExpression? {

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ImplicitReturnConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ImplicitReturnConfiguration.swift
@@ -29,6 +29,6 @@ struct ImplicitReturnConfiguration: SeverityBasedRuleConfiguration {
     }
 
     func isKindIncluded(_ kind: ReturnKind) -> Bool {
-        return self.includedKinds.contains(kind)
+        includedKinds.contains(kind)
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/LineLengthConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/LineLengthConfiguration.swift
@@ -18,6 +18,6 @@ struct LineLengthConfiguration: RuleConfiguration {
     private(set) var excludedLinesPatterns: Set<String> = []
 
     var params: [RuleParameter<Int>] {
-        return length.params
+        length.params
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NameConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NameConfiguration.swift
@@ -20,11 +20,11 @@ struct NameConfiguration<Parent: Rule>: RuleConfiguration, InlinableOptionType {
     private(set) var validatesStartWithLowercase = StartWithLowercaseConfiguration.error
 
     var minLengthThreshold: Int {
-        return max(minLength.warning, minLength.error ?? minLength.warning)
+        max(minLength.warning, minLength.error ?? minLength.warning)
     }
 
     var maxLengthThreshold: Int {
-        return min(maxLength.warning, maxLength.error ?? maxLength.warning)
+        min(maxLength.warning, maxLength.error ?? maxLength.warning)
     }
 
     var allowedSymbolsAndAlphanumerics: CharacterSet {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ClosureEndIndentationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ClosureEndIndentationRule.swift
@@ -17,8 +17,8 @@ struct ClosureEndIndentationRule: Rule, OptInRule {
     fileprivate static let notWhitespace = regex("[^\\s]")
 
     func validate(file: SwiftLintFile) -> [StyleViolation] {
-        return violations(in: file).map { violation in
-            return styleViolation(for: violation, in: file)
+        violations(in: file).map { violation in
+            styleViolation(for: violation, in: file)
         }
     }
 
@@ -62,8 +62,7 @@ extension ClosureEndIndentationRule: CorrectableRule {
         }
 
         var corrections = correctedLocations.map {
-            return Correction(ruleDescription: Self.description,
-                              location: Location(file: file, characterOffset: $0))
+            Correction(ruleDescription: Self.description, location: Location(file: file, characterOffset: $0))
         }
 
         file.write(correctedContents)
@@ -114,7 +113,7 @@ extension ClosureEndIndentationRule {
     }
 
     fileprivate func violations(in file: SwiftLintFile) -> [Violation] {
-        return file.structureDictionary.traverseDepthFirst { subDict in
+        file.structureDictionary.traverseDepthFirst { subDict in
             guard let kind = subDict.expressionKind else { return nil }
             return violations(in: file, of: kind, dictionary: subDict)
         }
@@ -204,7 +203,7 @@ extension ClosureEndIndentationRule {
         }
 
         return closureArguments.compactMap { dictionary in
-            return validateClosureArgument(in: file, dictionary: dictionary)
+            validateClosureArgument(in: file, dictionary: dictionary)
         }
     }
 
@@ -311,7 +310,7 @@ extension ClosureEndIndentationRule {
 
     private func filterClosureArguments(_ arguments: [SourceKittenDictionary],
                                         file: SwiftLintFile) -> [SourceKittenDictionary] {
-        return arguments.filter { argument in
+        arguments.filter { argument in
             guard let bodyByteRange = argument.bodyByteRange,
                 let range = file.stringView.byteRangeToNSRange(bodyByteRange),
                 let match = regex("\\s*\\{").firstMatch(in: file.contents, options: [], range: range)?.range,

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ClosureParameterPositionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ClosureParameterPositionRule.swift
@@ -119,7 +119,7 @@ private extension ClosureParameterPositionRule {
                 return
             }
             let localViolations = positionsToCheck.dropLast().filter { position in
-                return locationConverter.location(for: position).line != startLine
+                locationConverter.location(for: position).line != startLine
             }
 
             violations.append(contentsOf: localViolations)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/CollectionAlignmentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/CollectionAlignmentRule.swift
@@ -93,7 +93,7 @@ extension CollectionAlignmentRule {
         }
 
         private var alignColonsTriggeringExamples: [Example] {
-            return [
+            [
                 Example("""
                 doThings(arg: [
                     "foo": 1,
@@ -122,7 +122,7 @@ extension CollectionAlignmentRule {
         }
 
         private var alignColonsNonTriggeringExamples: [Example] {
-            return [
+            [
                 Example("""
                 doThings(arg: [
                     "foo": 1,
@@ -155,7 +155,7 @@ extension CollectionAlignmentRule {
         }
 
         private var alignLeftTriggeringExamples: [Example] {
-            return [
+            [
                 Example("""
                 doThings(arg: [
                     "foo": 1,
@@ -184,7 +184,7 @@ extension CollectionAlignmentRule {
         }
 
         private var alignLeftNonTriggeringExamples: [Example] {
-            return [
+            [
                 Example("""
                 doThings(arg: [
                     "foo": 1,
@@ -217,7 +217,7 @@ extension CollectionAlignmentRule {
         }
 
         private var sharedTriggeringExamples: [Example] {
-            return [
+            [
                 Example("""
                 let coordinates = [
                     CLLocationCoordinate2D(latitude: 0, longitude: 33),
@@ -236,7 +236,7 @@ extension CollectionAlignmentRule {
         }
 
         private var sharedNonTriggeringExamples: [Example] {
-            return [
+            [
                 Example("""
                 let coordinates = [
                     CLLocationCoordinate2D(latitude: 0, longitude: 33),

--- a/Source/SwiftLintBuiltInRules/Rules/Style/CommaInheritanceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/CommaInheritanceRule.swift
@@ -61,7 +61,7 @@ struct CommaInheritanceRule: OptInRule, SubstitutionCorrectableRule,
     // MARK: - Rule
 
     func validate(file: SwiftLintFile) -> [StyleViolation] {
-        return violationRanges(in: file).map {
+        violationRanges(in: file).map {
             StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
@@ -71,7 +71,7 @@ struct CommaInheritanceRule: OptInRule, SubstitutionCorrectableRule,
     // MARK: - SubstitutionCorrectableRule
 
     func substitution(for violationRange: NSRange, in file: SwiftLintFile) -> (NSRange, String)? {
-        return (violationRange, ", ")
+        (violationRange, ", ")
     }
 
     func violationRanges(in file: SwiftLintFile) -> [NSRange] {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/CommaRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/CommaRule.swift
@@ -89,7 +89,7 @@ struct CommaRule: CorrectableRule, SourceKitFreeRule {
     )
 
     func validate(file: SwiftLintFile) -> [StyleViolation] {
-        return violationRanges(in: file).map {
+        violationRanges(in: file).map {
             StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, byteOffset: $0.0.location))

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ComputedAccessorsOrderRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ComputedAccessorsOrderRuleExamples.swift
@@ -1,6 +1,6 @@
 struct ComputedAccessorsOrderRuleExamples {
     static var nonTriggeringExamples: [Example] {
-        return [
+        [
             Example("""
             class Foo {
                 var foo: Int {
@@ -168,7 +168,7 @@ struct ComputedAccessorsOrderRuleExamples {
     }
 
     static var triggeringExamples: [Example] {
-        return [
+        [
             Example("""
             class Foo {
                 var foo: Int {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/EmptyEnumArgumentsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/EmptyEnumArgumentsRule.swift
@@ -4,7 +4,7 @@ private func wrapInSwitch(
     variable: String = "foo",
     _ str: String,
     file: StaticString = #filePath, line: UInt = #line) -> Example {
-    return Example(
+    Example(
         """
         switch \(variable) {
         \(str): break
@@ -13,7 +13,7 @@ private func wrapInSwitch(
 }
 
 private func wrapInFunc(_ str: String, file: StaticString = #filePath, line: UInt = #line) -> Example {
-    return Example("""
+    Example("""
     func example(foo: Foo) {
         switch foo {
         case \(str):

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ExplicitSelfRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ExplicitSelfRule.swift
@@ -16,7 +16,7 @@ struct ExplicitSelfRule: CorrectableRule, AnalyzerRule {
     )
 
     func validate(file: SwiftLintFile, compilerArguments: [String]) -> [StyleViolation] {
-        return violationRanges(in: file, compilerArguments: compilerArguments).map {
+        violationRanges(in: file, compilerArguments: compilerArguments).map {
             StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: $0.location))
@@ -86,7 +86,7 @@ private let kindsToFind: Set = [
 private extension SwiftLintFile {
     func allCursorInfo(compilerArguments: [String], atByteOffsets byteOffsets: [ByteCount]) throws
         -> [[String: any SourceKitRepresentable]] {
-        return try byteOffsets.compactMap { offset in
+        try byteOffsets.compactMap { offset in
             if isExplicitAccess(at: offset) { return nil }
             let cursorInfoRequest = Request.cursorInfoWithoutSymbolGraph(
                 file: self.path!, offset: offset, arguments: compilerArguments

--- a/Source/SwiftLintBuiltInRules/Rules/Style/FileHeaderRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/FileHeaderRule.swift
@@ -95,15 +95,15 @@ struct FileHeaderRule: OptInRule {
     }
 
     private func makeViolation(at location: Location) -> StyleViolation {
-        return StyleViolation(ruleDescription: Self.description,
-                              severity: configuration.severityConfiguration.severity,
-                              location: location,
-                              reason: "Header comments should be consistent with project patterns")
+        StyleViolation(ruleDescription: Self.description,
+                       severity: configuration.severityConfiguration.severity,
+                       location: location,
+                       reason: "Header comments should be consistent with project patterns")
     }
 }
 
 private extension SyntaxKind {
     var isFileHeaderKind: Bool {
-        return self == .comment || self == .commentURL
+        self == .comment || self == .commentURL
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/LiteralExpressionEndIndentationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/LiteralExpressionEndIndentationRule.swift
@@ -122,8 +122,8 @@ struct LiteralExpressionEndIndentationRule: Rule, OptInRule {
     )
 
     func validate(file: SwiftLintFile) -> [StyleViolation] {
-        return violations(in: file).map { violation in
-            return styleViolation(for: violation, in: file)
+        violations(in: file).map { violation in
+            styleViolation(for: violation, in: file)
         }
     }
 
@@ -169,8 +169,7 @@ extension LiteralExpressionEndIndentationRule: CorrectableRule {
         }
 
         var corrections = correctedLocations.map {
-            return Correction(ruleDescription: Self.description,
-                              location: Location(file: file, characterOffset: $0))
+            Correction(ruleDescription: Self.description, location: Location(file: file, characterOffset: $0))
         }
 
         file.write(correctedContents)
@@ -214,7 +213,7 @@ extension LiteralExpressionEndIndentationRule {
     }
 
     fileprivate func violations(in file: SwiftLintFile) -> [Violation] {
-        return file.structureDictionary.traverseDepthFirst { subDict in
+        file.structureDictionary.traverseDepthFirst { subDict in
             guard let kind = subDict.expressionKind else { return nil }
             guard let violation = violation(in: file, of: kind, dictionary: subDict) else { return nil }
             return [violation]

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ModifierOrderRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ModifierOrderRule.swift
@@ -39,7 +39,7 @@ struct ModifierOrderRule: ASTRule, OptInRule, CorrectableRule {
     }
 
     func correct(file: SwiftLintFile) -> [Correction] {
-        return file.structureDictionary.traverseDepthFirst { subDict in
+        file.structureDictionary.traverseDepthFirst { subDict in
             guard subDict.declarationKind != nil else { return nil }
             return correct(file: file, dictionary: subDict)
         }
@@ -171,7 +171,7 @@ private extension SourceKittenDictionary {
 
 private extension String {
     func lastComponentAfter(_ character: String) -> String {
-        return components(separatedBy: character).last ?? ""
+        components(separatedBy: character).last ?? ""
     }
 }
 
@@ -180,5 +180,5 @@ private struct ModifierDescription: Equatable {
     let group: SwiftDeclarationAttributeKind.ModifierGroup
     let offset: ByteCount
     let length: ByteCount
-    var range: ByteRange { return ByteRange(location: offset, length: length) }
+    var range: ByteRange { ByteRange(location: offset, length: length) }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/MultilineFunctionChainsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/MultilineFunctionChainsRule.swift
@@ -95,10 +95,10 @@ struct MultilineFunctionChainsRule: ASTRule, OptInRule {
     func validate(file: SwiftLintFile,
                   kind: SwiftExpressionKind,
                   dictionary: SourceKittenDictionary) -> [StyleViolation] {
-        return violatingOffsets(file: file, kind: kind, dictionary: dictionary).map { offset in
-            return StyleViolation(ruleDescription: Self.description,
-                                  severity: configuration.severity,
-                                  location: Location(file: file, characterOffset: offset))
+        violatingOffsets(file: file, kind: kind, dictionary: dictionary).map { offset in
+            StyleViolation(ruleDescription: Self.description,
+                           severity: configuration.severity,
+                           location: Location(file: file, characterOffset: offset))
         }
     }
 
@@ -214,7 +214,7 @@ struct MultilineFunctionChainsRule: ASTRule, OptInRule {
 
 private extension SourceKittenDictionary {
     var subcalls: [SourceKittenDictionary] {
-        return substructure.compactMap { dictionary -> SourceKittenDictionary? in
+        substructure.compactMap { dictionary -> SourceKittenDictionary? in
             guard dictionary.expressionKind == .call else {
                 return nil
             }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/MultilineParametersBracketsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/MultilineParametersBracketsRule.swift
@@ -91,7 +91,7 @@ struct MultilineParametersBracketsRule: OptInRule {
     )
 
     func validate(file: SwiftLintFile) -> [StyleViolation] {
-        return violations(in: file.structureDictionary, file: file)
+        violations(in: file.structureDictionary, file: file)
     }
 
     private func violations(in substructure: SourceKittenDictionary, file: SwiftLintFile) -> [StyleViolation] {
@@ -112,7 +112,7 @@ struct MultilineParametersBracketsRule: OptInRule {
             let parameters = substructure.substructure.filter { $0.declarationKind == .varParameter }
             let parameterBodies = parameters.compactMap { $0.content(in: file) }
             let parametersNewlineCount = parameterBodies.map { body in
-                return body.countOccurrences(of: "\n")
+                body.countOccurrences(of: "\n")
             }.reduce(0, +)
             let declarationNewlineCount = functionName.countOccurrences(of: "\n")
             let isMultiline = declarationNewlineCount > parametersNewlineCount

--- a/Source/SwiftLintBuiltInRules/Rules/Style/NumberSeparatorRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/NumberSeparatorRuleExamples.swift
@@ -1,6 +1,6 @@
 internal struct NumberSeparatorRuleExamples {
     static let nonTriggeringExamples: [Example] = {
-        return ["-", "+", ""].flatMap { (sign: String) -> [Example] in
+        ["-", "+", ""].flatMap { (sign: String) -> [Example] in
             [
                 Example("let foo = \(sign)100"),
                 Example("let foo = \(sign)1_000"),
@@ -33,7 +33,7 @@ internal struct NumberSeparatorRuleExamples {
     static let corrections = makeCorrections(signs: [("-↓", "-"), ("+↓", "+"), ("↓", "")])
 
     private static func makeTriggeringExamples(signs: [String]) -> [Example] {
-        return signs.flatMap { (sign: String) -> [Example] in
+        signs.flatMap { (sign: String) -> [Example] in
             [
                 Example("let foo = \(sign)10_0"),
                 Example("let foo = \(sign)1000"),

--- a/Source/SwiftLintBuiltInRules/Rules/Style/OperatorUsageWhitespaceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/OperatorUsageWhitespaceRule.swift
@@ -16,7 +16,7 @@ struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, SourceKitFreeRul
     )
 
     func validate(file: SwiftLintFile) -> [StyleViolation] {
-        return violationRanges(file: file).map { range, _ in
+        violationRanges(file: file).map { range, _ in
             StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severityConfiguration.severity,
                            location: Location(file: file, byteOffset: range.location))
@@ -45,7 +45,7 @@ struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, SourceKitFreeRul
                 return (range, correction)
             }
             .filter { range, _ in
-                return file.ruleEnabled(violatingRanges: [range], for: self).isNotEmpty
+                file.ruleEnabled(violatingRanges: [range], for: self).isNotEmpty
             }
 
         var correctedContents = file.contents
@@ -100,7 +100,7 @@ struct OperatorUsageWhitespaceRule: OptInRule, CorrectableRule, SourceKitFreeRul
             .flatMap { [lineIndex + $0, lineIndex - $0] }
 
         func isValidIndex(_ idx: Int) -> Bool {
-            return idx != lineIndex && idx >= 0 && idx < file.stringView.lines.count
+            idx != lineIndex && idx >= 0 && idx < file.stringView.lines.count
         }
 
         for lineIndex in lineIndexesAround where isValidIndex(lineIndex) {
@@ -214,7 +214,7 @@ private class OperatorUsageWhitespaceVisitor: SyntaxVisitor {
 
 private extension Trivia {
     var containsTooMuchWhitespacing: Bool {
-        return contains { element in
+        contains { element in
             guard case let .spaces(spaces) = element, spaces > 1 else {
                 return false
             }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfTypeOverTypeOfSelfRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfTypeOverTypeOfSelfRule.swift
@@ -135,7 +135,7 @@ private extension PreferSelfTypeOverTypeOfSelfRule {
 
 private extension FunctionCallExprSyntax {
     var hasViolation: Bool {
-        return isTypeOfSelfCall &&
+        isTypeOfSelfCall &&
         arguments.map(\.label?.text) == ["of"] &&
         arguments.first?.expression.as(DeclReferenceExprSyntax.self)?.baseName.tokenKind == .keyword(.self)
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SingleTestClassRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SingleTestClassRule.swift
@@ -56,10 +56,10 @@ struct SingleTestClassRule: SourceKitFreeRule, OptInRule {
         guard classes.count > 1 else { return [] }
 
         return classes.map { position in
-            return StyleViolation(ruleDescription: Self.description,
-                                  severity: configuration.severity,
-                                  location: Location(file: file, position: position.position),
-                                  reason: "\(classes.count) test classes found in this file")
+            StyleViolation(ruleDescription: Self.description,
+                           severity: configuration.severity,
+                           location: Location(file: file, position: position.position),
+                           reason: "\(classes.count) test classes found in this file")
         }
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SortedImportsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SortedImportsRule.swift
@@ -3,19 +3,19 @@ import SourceKittenFramework
 
 fileprivate extension Line {
     var contentRange: NSRange {
-        return NSRange(location: range.location, length: content.bridge().length)
+        NSRange(location: range.location, length: content.bridge().length)
     }
 
     // `Line` in this rule always contains word import
     // This method returns contents of line that are before import
     func importAttributes() -> String {
-        return content[importAttributesRange()].trimmingCharacters(in: .whitespaces)
+        content[importAttributesRange()].trimmingCharacters(in: .whitespaces)
     }
 
     // `Line` in this rule always contains word import
     // This method returns contents of line that are after import
     func importModule() -> Substring {
-        return content[importModuleRange()]
+        content[importModuleRange()]
     }
 
     func importAttributesRange() -> Range<String.Index> {
@@ -37,7 +37,7 @@ private extension Sequence where Element == Line {
     // Groups lines, so that lines that are one after the other
     // will end up in same group.
     func grouped() -> [[Line]] {
-        return reduce(into: [[]]) { result, line in
+        reduce(into: [[]]) { result, line in
             guard let last = result.last?.last else {
                 result = [[line]]
                 return
@@ -93,8 +93,8 @@ struct SortedImportsRule: CorrectableRule, OptInRule {
     }
 
     private func violatingOffsets(inGroups groups: [[Line]]) -> [Int] {
-        return groups.flatMap { group in
-            return zip(group, group.dropFirst()).reduce(into: []) { violatingOffsets, groupPair in
+        groups.flatMap { group in
+            zip(group, group.dropFirst()).reduce(into: []) { violatingOffsets, groupPair in
                 let (previous, current) = groupPair
                 let isOrderedCorrectly = should(previous, comeBefore: current)
                 if isOrderedCorrectly {
@@ -144,7 +144,7 @@ struct SortedImportsRule: CorrectableRule, OptInRule {
             }
             let result = group.map { $0.content }.joined(separator: "\n")
             let union = group.dropFirst().reduce(first) { result, line in
-                return NSUnionRange(result, line.contentRange)
+                NSUnionRange(result, line.contentRange)
             }
             correctedContents.replaceCharacters(in: union, with: result)
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/StatementPositionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/StatementPositionRule.swift
@@ -87,7 +87,7 @@ private extension StatementPositionRule {
     static let defaultPattern = "\\}(?:[\\s\\n\\r]{2,}|[\\n\\t\\r]+)?\\b(else|catch)\\b"
 
     func defaultValidate(file: SwiftLintFile) -> [StyleViolation] {
-        return defaultViolationRanges(in: file, matching: Self.defaultPattern).compactMap { range in
+        defaultViolationRanges(in: file, matching: Self.defaultPattern).compactMap { range in
             StyleViolation(ruleDescription: Self.description,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: range.location))
@@ -95,8 +95,8 @@ private extension StatementPositionRule {
     }
 
     func defaultViolationRanges(in file: SwiftLintFile, matching pattern: String) -> [NSRange] {
-        return file.match(pattern: pattern).filter { _, syntaxKinds in
-            return syntaxKinds.starts(with: [.keyword])
+        file.match(pattern: pattern).filter { _, syntaxKinds in
+            syntaxKinds.starts(with: [.keyword])
         }.compactMap { $0.0 }
     }
 
@@ -122,7 +122,7 @@ private extension StatementPositionRule {
 // Uncuddled Behaviors
 private extension StatementPositionRule {
     func uncuddledValidate(file: SwiftLintFile) -> [StyleViolation] {
-        return uncuddledViolationRanges(in: file).compactMap { range in
+        uncuddledViolationRanges(in: file).compactMap { range in
             StyleViolation(ruleDescription: Self.uncuddledDescription,
                            severity: configuration.severity,
                            location: Location(file: file, characterOffset: range.location))
@@ -139,7 +139,7 @@ private extension StatementPositionRule {
 
     static func uncuddledMatchValidator(contents: StringView) -> ((NSTextCheckingResult)
         -> NSTextCheckingResult?) {
-            return { match in
+            { match in
                 if match.numberOfRanges != 5 {
                     return match
                 }
@@ -159,7 +159,7 @@ private extension StatementPositionRule {
 
     static func uncuddledMatchFilter(contents: StringView,
                                      syntaxMap: SwiftLintSyntaxMap) -> ((NSTextCheckingResult) -> Bool) {
-        return { match in
+        { match in
             let range = match.range
             guard let matchRange = contents.NSRangeToByteRange(start: range.location,
                                                                length: range.length) else {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SwitchCaseAlignmentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SwitchCaseAlignmentRule.swift
@@ -93,14 +93,13 @@ extension SwitchCaseAlignmentRule {
         }
 
         var triggeringExamples: [Example] {
-            return (indentedCasesOption ? nonIndentedCases : indentedCases)
+            (indentedCasesOption ? nonIndentedCases : indentedCases)
                 + invalidCases
                 + invalidOneLiners
         }
 
         var nonTriggeringExamples: [Example] {
-            return indentedCasesOption ? indentedCases : nonIndentedCases
-                + validOneLiners
+            indentedCasesOption ? indentedCases : nonIndentedCases + validOneLiners
         }
 
         private var indentedCases: [Example] {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SwitchCaseOnNewlineRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SwitchCaseOnNewlineRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
 private func wrapInSwitch(_ str: String, file: StaticString = #filePath, line: UInt = #line) -> Example {
-    return Example("""
+    Example("""
     switch foo {
         \(str)
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/TrailingNewlineRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/TrailingNewlineRule.swift
@@ -14,7 +14,7 @@ extension String {
     }
 
     fileprivate func trailingNewlineCount() -> Int? {
-        return countOfTrailingCharacters(in: .newlines)
+        countOfTrailingCharacters(in: .newlines)
     }
 }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/TypeContentsOrderRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/TypeContentsOrderRule.swift
@@ -68,7 +68,7 @@ struct TypeContentsOrderRule: OptInRule {
     }
 
     private func typeContentOffsets(in typeStructure: SourceKittenDictionary) -> [TypeContentOffset] {
-        return typeStructure.substructure.compactMap { typeContentStructure in
+        typeStructure.substructure.compactMap { typeContentStructure in
             guard let typeContent = typeContent(for: typeContentStructure) else { return nil }
             return (typeContent, typeContentStructure.offset!)
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/VerticalWhitespaceBetweenCasesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/VerticalWhitespaceBetweenCasesRule.swift
@@ -3,7 +3,7 @@ import SourceKittenFramework
 
 private extension SwiftLintFile {
     func violatingRanges(for pattern: String) -> [NSRange] {
-        return match(pattern: pattern, excludingSyntaxKinds: SyntaxKind.commentKinds)
+        match(pattern: pattern, excludingSyntaxKinds: SyntaxKind.commentKinds)
     }
 }
 
@@ -130,7 +130,7 @@ struct VerticalWhitespaceBetweenCasesRule: Rule {
     private let pattern = "([^\\n{][ \\t]*\\n)([ \\t]*(?:case[^\\n]+|default):[ \\t]*\\n)"
 
     private func violationRanges(in file: SwiftLintFile) -> [NSRange] {
-        return file.violatingRanges(for: pattern).filter {
+        file.violatingRanges(for: pattern).filter {
             !isFalsePositive(in: file, range: $0)
         }
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/VerticalWhitespaceClosingBracesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/VerticalWhitespaceClosingBracesRule.swift
@@ -70,6 +70,6 @@ struct VerticalWhitespaceClosingBracesRule: CorrectableRule, OptInRule {
 
 private extension SwiftLintFile {
     func violatingRanges(for pattern: String) -> [NSRange] {
-        return match(pattern: pattern, excludingSyntaxKinds: SyntaxKind.commentAndStringKinds)
+        match(pattern: pattern, excludingSyntaxKinds: SyntaxKind.commentAndStringKinds)
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/VerticalWhitespaceOpeningBracesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/VerticalWhitespaceOpeningBracesRule.swift
@@ -3,7 +3,7 @@ import SourceKittenFramework
 
 private extension SwiftLintFile {
     func violatingRanges(for pattern: String) -> [NSRange] {
-        return match(pattern: pattern, excludingSyntaxKinds: SyntaxKind.commentAndStringKinds)
+        match(pattern: pattern, excludingSyntaxKinds: SyntaxKind.commentAndStringKinds)
     }
 }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/VerticalWhitespaceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/VerticalWhitespaceRule.swift
@@ -43,7 +43,7 @@ struct VerticalWhitespaceRule: CorrectableRule {
         }
 
         return linesSections.map { eachLastLine, eachSectionCount in
-            return StyleViolation(
+            StyleViolation(
                 ruleDescription: Self.description,
                 severity: configuration.severityConfiguration.severity,
                 location: Location(file: file.path, line: eachLastLine.index),

--- a/Source/SwiftLintCore/Extensions/Array+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/Array+SwiftLint.swift
@@ -59,7 +59,7 @@ public extension Array {
     ///
     /// - returns: The elements grouped by applying the specified transformation.
     func group<U: Hashable>(by transform: (Element) -> U) -> [U: [Element]] {
-        return Dictionary(grouping: self, by: { transform($0) })
+        Dictionary(grouping: self, by: { transform($0) })
     }
 
     /// Returns the elements failing the `belongsInSecondPartition` test, followed by the elements passing the
@@ -83,7 +83,7 @@ public extension Array {
     ///
     /// - returns: The result of applying `transform` on every element and flattening the results.
     func parallelFlatMap<T>(transform: (Element) -> [T]) -> [T] {
-        return parallelMap(transform: transform).flatMap { $0 }
+        parallelMap(transform: transform).flatMap { $0 }
     }
 
     /// Same as `compactMap` but spreads the work in the `transform` block in parallel using GCD's `concurrentPerform`.
@@ -92,7 +92,7 @@ public extension Array {
     ///
     /// - returns: The result of applying `transform` on every element and discarding the `nil` ones.
     func parallelCompactMap<T>(transform: (Element) -> T?) -> [T] {
-        return parallelMap(transform: transform).compactMap { $0 }
+        parallelMap(transform: transform).compactMap { $0 }
     }
 
     /// Same as `map` but spreads the work in the `transform` block in parallel using GCD's `concurrentPerform`.
@@ -114,7 +114,7 @@ public extension Array {
 public extension Collection {
     /// Whether this collection has one or more element.
     var isNotEmpty: Bool {
-        return !isEmpty
+        !isEmpty
     }
 
     /// Get the only element in the collection.

--- a/Source/SwiftLintCore/Extensions/Configuration+FileGraph.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+FileGraph.swift
@@ -179,7 +179,7 @@ package extension Configuration {
         }
 
         private func findPossiblyExistingVertex(sameAs vertex: Vertex) -> Vertex? {
-            return vertices.first {
+            vertices.first {
                 $0.originalRemoteString != nil && $0.originalRemoteString == vertex.originalRemoteString
             } ?? vertices.first { $0.filePath == vertex.filePath }
         }
@@ -237,7 +237,7 @@ package extension Configuration {
             }
 
             return verticesToMerge.map {
-                return (
+                (
                     configurationDict: $0.configurationDict,
                     rootDirectory: $0.rootDirectory
                 )

--- a/Source/SwiftLintCore/Extensions/Configuration+FileGraphSubtypes.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+FileGraphSubtypes.swift
@@ -81,7 +81,7 @@ internal extension Configuration.FileGraph {
         }
 
         internal static func == (lhs: Vertex, rhs: Vertex) -> Bool {
-            return lhs.filePath == rhs.filePath
+            lhs.filePath == rhs.filePath
                 && lhs.originalRemoteString == rhs.originalRemoteString
                 && lhs.rootDirectory == rhs.rootDirectory
         }

--- a/Source/SwiftLintCore/Extensions/Configuration+LintableFiles.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+LintableFiles.swift
@@ -18,7 +18,7 @@ extension Configuration {
     /// - returns: Files to lint.
     public func lintableFiles(inPath path: String, forceExclude: Bool,
                               excludeBy: ExcludeBy) -> [SwiftLintFile] {
-        return lintablePaths(inPath: path, forceExclude: forceExclude, excludeBy: excludeBy)
+        lintablePaths(inPath: path, forceExclude: forceExclude, excludeBy: excludeBy)
             .compactMap(SwiftLintFile.init(pathDeferringReading:))
     }
 
@@ -109,7 +109,7 @@ extension Configuration {
     ///
     /// - returns: The expanded excluded file paths.
     public func excludedPaths(fileManager: some LintableFileManager = FileManager.default) -> [String] {
-        return excludedPaths
+        excludedPaths
             .flatMap(Glob.resolveGlob)
             .parallelFlatMap { fileManager.filesToLint(inPath: $0, rootDirectory: rootDirectory) }
     }

--- a/Source/SwiftLintCore/Extensions/Configuration+Merging.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Merging.swift
@@ -84,7 +84,7 @@ extension Configuration {
     ///
     /// - returns: A new configuration.
     public func configuration(for file: SwiftLintFile) -> Configuration {
-        return (file.path?.bridge().deletingLastPathComponent).map(configuration(forDirectory:)) ?? self
+        (file.path?.bridge().deletingLastPathComponent).map(configuration(forDirectory:)) ?? self
     }
 
     private func configuration(forDirectory directory: String) -> Configuration {

--- a/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
@@ -44,7 +44,7 @@ extension Configuration {
         enableAllRules: Bool = false,
         cachePath: String? = nil
     ) throws {
-        func defaultStringArray(_ object: Any?) -> [String] { return [String].array(of: object) ?? [] }
+        func defaultStringArray(_ object: Any?) -> [String] { [String].array(of: object) ?? [] }
 
         // Use either the new 'opt_in_rules' or fallback to the deprecated 'enabled_rules'
         let optInRules = defaultStringArray(dict[Key.optInRules.rawValue] ?? dict[Key.enabledRules.rawValue])
@@ -107,7 +107,7 @@ extension Configuration {
 
     // MARK: - Methods: Validations
     private static func validKeys(ruleList: RuleList) -> Set<String> {
-        return validGlobalKeys.union(ruleList.allValidIdentifiers())
+        validGlobalKeys.union(ruleList.allValidIdentifiers())
     }
 
     private static func getIndentationLogIfInvalid(from dict: [String: Any]) -> IndentationStyle {
@@ -136,12 +136,12 @@ extension Configuration {
 
         // Deprecation warning for rules
         let deprecatedRulesIdentifiers = ruleList.list.flatMap { identifier, rule -> [(String, String)] in
-            return rule.description.deprecatedAliases.map { ($0, identifier) }
+            rule.description.deprecatedAliases.map { ($0, identifier) }
         }
 
         let userProvidedRuleIDs = Set(disabledRules + optInRules + onlyRules)
         let deprecatedUsages = deprecatedRulesIdentifiers.filter { deprecatedIdentifier, _ in
-            return dict[deprecatedIdentifier] != nil || userProvidedRuleIDs.contains(deprecatedIdentifier)
+            dict[deprecatedIdentifier] != nil || userProvidedRuleIDs.contains(deprecatedIdentifier)
         }
 
         for (deprecatedIdentifier, identifier) in deprecatedUsages {

--- a/Source/SwiftLintCore/Extensions/Dictionary+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/Dictionary+SwiftLint.swift
@@ -38,12 +38,12 @@ public struct SourceKittenDictionary {
 
     /// Body length
     public var bodyLength: ByteCount? {
-        return (value["key.bodylength"] as? Int64).map(ByteCount.init)
+        (value["key.bodylength"] as? Int64).map(ByteCount.init)
     }
 
     /// Body offset.
     public var bodyOffset: ByteCount? {
-        return (value["key.bodyoffset"] as? Int64).map(ByteCount.init)
+        (value["key.bodyoffset"] as? Int64).map(ByteCount.init)
     }
 
     /// Body byte range.
@@ -54,26 +54,26 @@ public struct SourceKittenDictionary {
 
     /// Kind.
     public var kind: String? {
-        return value["key.kind"] as? String
+        value["key.kind"] as? String
     }
 
     /// Length.
     public var length: ByteCount? {
-        return (value["key.length"] as? Int64).map(ByteCount.init)
+        (value["key.length"] as? Int64).map(ByteCount.init)
     }
     /// Name.
     public var name: String? {
-        return value["key.name"] as? String
+        value["key.name"] as? String
     }
 
     /// Name length.
     public var nameLength: ByteCount? {
-        return (value["key.namelength"] as? Int64).map(ByteCount.init)
+        (value["key.namelength"] as? Int64).map(ByteCount.init)
     }
 
     /// Name offset.
     public var nameOffset: ByteCount? {
-        return (value["key.nameoffset"] as? Int64).map(ByteCount.init)
+        (value["key.nameoffset"] as? Int64).map(ByteCount.init)
     }
 
     /// Byte range of name.
@@ -84,7 +84,7 @@ public struct SourceKittenDictionary {
 
     /// Offset.
     public var offset: ByteCount? {
-        return (value["key.offset"] as? Int64).map(ByteCount.init)
+        (value["key.offset"] as? Int64).map(ByteCount.init)
     }
 
     /// Returns byte range starting from `offset` with `length` bytes
@@ -95,42 +95,42 @@ public struct SourceKittenDictionary {
 
     /// Setter accessibility.
     public var setterAccessibility: String? {
-        return value["key.setter_accessibility"] as? String
+        value["key.setter_accessibility"] as? String
     }
 
     /// Type name.
     public var typeName: String? {
-        return value["key.typename"] as? String
+        value["key.typename"] as? String
     }
 
     /// Documentation length.
     public var docLength: ByteCount? {
-        return (value["key.doclength"] as? Int64).flatMap(ByteCount.init)
+        (value["key.doclength"] as? Int64).flatMap(ByteCount.init)
     }
 
     /// The attribute for this dictionary, as returned by SourceKit.
     public var attribute: String? {
-        return value["key.attribute"] as? String
+        value["key.attribute"] as? String
     }
 
     /// Module name in `@import` expressions.
     public var moduleName: String? {
-        return value["key.modulename"] as? String
+        value["key.modulename"] as? String
     }
 
     /// The line number for this declaration.
     public var line: Int64? {
-        return value["key.line"] as? Int64
+        value["key.line"] as? Int64
     }
 
     /// The column number for this declaration.
     public var column: Int64? {
-        return value["key.column"] as? Int64
+        value["key.column"] as? Int64
     }
 
     /// The `SwiftDeclarationAttributeKind` values associated with this dictionary.
     public var enclosedSwiftAttributes: [SwiftDeclarationAttributeKind] {
-        return swiftAttributes.compactMap { $0.attribute }
+        swiftAttributes.compactMap { $0.attribute }
             .compactMap(SwiftDeclarationAttributeKind.init(rawValue:))
     }
 
@@ -154,7 +154,7 @@ public struct SourceKittenDictionary {
     }
 
     public var enclosedVarParameters: [SourceKittenDictionary] {
-        return substructure.flatMap { subDict -> [SourceKittenDictionary] in
+        substructure.flatMap { subDict -> [SourceKittenDictionary] in
             if subDict.declarationKind == .varParameter {
                 return [subDict]
             }
@@ -168,7 +168,7 @@ public struct SourceKittenDictionary {
     }
 
     public var enclosedArguments: [SourceKittenDictionary] {
-        return substructure.flatMap { subDict -> [SourceKittenDictionary] in
+        substructure.flatMap { subDict -> [SourceKittenDictionary] in
             guard subDict.expressionKind == .argument else {
                 return []
             }
@@ -244,8 +244,8 @@ public extension Dictionary where Key == Example {
     ///
     /// - returns: A new `Dictionary`.
     func removingViolationMarkers() -> [Key: Value] {
-        return Dictionary(uniqueKeysWithValues: map { key, value in
-            return (key.removingViolationMarkers(), value)
+        Dictionary(uniqueKeysWithValues: map { key, value in
+            (key.removingViolationMarkers(), value)
         })
     }
 }

--- a/Source/SwiftLintCore/Extensions/FileManager+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/FileManager+SwiftLint.swift
@@ -47,7 +47,7 @@ extension FileManager: LintableFileManager {
     }
 
     public func modificationDate(forFileAtPath path: String) -> Date? {
-        return (try? attributesOfItem(atPath: path))?[.modificationDate] as? Date
+        (try? attributesOfItem(atPath: path))?[.modificationDate] as? Date
     }
 
     public func isFile(atPath path: String) -> Bool {

--- a/Source/SwiftLintCore/Extensions/NSRange+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/NSRange+SwiftLint.swift
@@ -2,7 +2,7 @@ import Foundation
 
 extension NSRange {
     func intersects(_ range: NSRange) -> Bool {
-        return NSIntersectionRange(self, range).length > 0
+        NSIntersectionRange(self, range).length > 0
     }
 
     func intersects(_ ranges: [NSRange]) -> Bool {

--- a/Source/SwiftLintCore/Extensions/NSRegularExpression+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/NSRegularExpression+SwiftLint.swift
@@ -57,17 +57,17 @@ public extension NSRegularExpression {
 
     func matches(in stringView: StringView,
                  options: NSRegularExpression.MatchingOptions = []) -> [NSTextCheckingResult] {
-        return matches(in: stringView.string, options: options, range: stringView.range)
+        matches(in: stringView.string, options: options, range: stringView.range)
     }
 
     func matches(in stringView: StringView,
                  options: NSRegularExpression.MatchingOptions = [],
                  range: NSRange) -> [NSTextCheckingResult] {
-        return matches(in: stringView.string, options: options, range: range)
+        matches(in: stringView.string, options: options, range: range)
     }
 
     func matches(in file: SwiftLintFile,
                  options: NSRegularExpression.MatchingOptions = []) -> [NSTextCheckingResult] {
-        return matches(in: file.stringView.string, options: options, range: file.stringView.range)
+        matches(in: file.stringView.string, options: options, range: file.stringView.range)
     }
 }

--- a/Source/SwiftLintCore/Extensions/String+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/String+SwiftLint.swift
@@ -15,11 +15,11 @@ public extension String {
     }
 
     func isUppercase() -> Bool {
-        return self == uppercased()
+        self == uppercased()
     }
 
     func isLowercase() -> Bool {
-        return self == lowercased()
+        self == lowercased()
     }
 
     private subscript (range: Range<Int>) -> String {
@@ -63,14 +63,14 @@ public extension String {
     }
 
     var fullNSRange: NSRange {
-        return NSRange(location: 0, length: utf16.count)
+        NSRange(location: 0, length: utf16.count)
     }
 
     /// Returns a new string, converting the path to a canonical absolute path.
     ///
     /// - returns: A new `String`.
     func absolutePathStandardized() -> String {
-        return bridge().absolutePathRepresentation().bridge().standardizingPath
+        bridge().absolutePathRepresentation().bridge().standardizingPath
     }
 
     var isFile: Bool {
@@ -88,7 +88,7 @@ public extension String {
     /// - Parameter character: Character to count
     /// - Returns: Number of times `character` occurs in `self`
     func countOccurrences(of character: Character) -> Int {
-        return self.reduce(0, {
+        self.reduce(0, {
             $1 == character ? $0 + 1 : $0
         })
     }

--- a/Source/SwiftLintCore/Extensions/SwiftDeclarationAttributeKind+Swiftlint.swift
+++ b/Source/SwiftLintCore/Extensions/SwiftDeclarationAttributeKind+Swiftlint.swift
@@ -2,7 +2,7 @@ import SourceKittenFramework
 
 public extension SwiftDeclarationAttributeKind {
     static var attributesRequiringFoundation: Set<SwiftDeclarationAttributeKind> {
-        return [
+        [
             .objc,
             .objcName,
             .objcMembers,
@@ -95,7 +95,7 @@ public extension SwiftDeclarationAttributeKind {
         }
 
         public var debugDescription: String {
-            return self.rawValue
+            self.rawValue
         }
     }
 }

--- a/Source/SwiftLintCore/Extensions/SwiftLintFile+Cache.swift
+++ b/Source/SwiftLintCore/Extensions/SwiftLintFile+Cache.swift
@@ -22,18 +22,18 @@ private let responseCache = Cache { file -> [String: any SourceKitRepresentable]
     }
 }
 private let structureDictionaryCache = Cache { file in
-    return responseCache.get(file).map(Structure.init).map { SourceKittenDictionary($0.dictionary) }
+    responseCache.get(file).map(Structure.init).map { SourceKittenDictionary($0.dictionary) }
 }
 private let syntaxTreeCache = Cache { file -> SourceFileSyntax in
-    return Parser.parse(source: file.contents)
+    Parser.parse(source: file.contents)
 }
 private let foldedSyntaxTreeCache = Cache { file -> SourceFileSyntax? in
-    return OperatorTable.standardOperators
+    OperatorTable.standardOperators
         .foldAll(file.syntaxTree) { _ in }
         .as(SourceFileSyntax.self)
 }
 private let locationConverterCache = Cache { file -> SourceLocationConverter in
-    return SourceLocationConverter(fileName: file.path ?? "<nopath>", tree: file.syntaxTree)
+    SourceLocationConverter(fileName: file.path ?? "<nopath>", tree: file.syntaxTree)
 }
 private let commandsCache = Cache { file -> [Command] in
     guard file.contents.contains("swiftlint:") else {
@@ -98,12 +98,12 @@ private class Cache<T> {
 
 extension SwiftLintFile {
     fileprivate var cacheKey: FileCacheKey {
-        return id
+        id
     }
 
     public var sourcekitdFailed: Bool {
         get {
-            return responseCache.get(self) == nil
+            responseCache.get(self) == nil
         }
         set {
             if newValue {
@@ -116,7 +116,7 @@ extension SwiftLintFile {
 
     internal var assertHandler: AssertHandler? {
         get {
-            return assertHandlerCache.get(self)
+            assertHandlerCache.get(self)
         }
         set {
             assertHandlerCache.set(key: cacheKey, value: newValue)

--- a/Source/SwiftLintCore/Extensions/SwiftLintFile+Regex.swift
+++ b/Source/SwiftLintCore/Extensions/SwiftLintFile+Regex.swift
@@ -18,7 +18,7 @@ extension SwiftLintFile {
         let commands: [Command]
         if let restrictingRuleIdentifiers {
             commands = self.commands().filter { command in
-                return command.ruleIdentifiers.contains(where: restrictingRuleIdentifiers.contains)
+                command.ruleIdentifiers.contains(where: restrictingRuleIdentifiers.contains)
             }
         } else {
             commands = self.commands()
@@ -94,7 +94,7 @@ extension SwiftLintFile {
     }
 
     public func match(pattern: String, with syntaxKinds: [SyntaxKind], range: NSRange? = nil) -> [NSRange] {
-        return match(pattern: pattern, range: range)
+        match(pattern: pattern, range: range)
             .filter { $0.1 == syntaxKinds }
             .map { $0.0 }
     }
@@ -112,18 +112,18 @@ extension SwiftLintFile {
 
     public func matchesAndSyntaxKinds(matching pattern: String,
                                       range: NSRange? = nil) -> [(NSTextCheckingResult, [SyntaxKind])] {
-        return matchesAndTokens(matching: pattern, range: range).map { textCheckingResult, tokens in
+        matchesAndTokens(matching: pattern, range: range).map { textCheckingResult, tokens in
             (textCheckingResult, tokens.kinds)
         }
     }
 
     public func rangesAndTokens(matching pattern: String,
                                 range: NSRange? = nil) -> [(NSRange, [SwiftLintSyntaxToken])] {
-        return matchesAndTokens(matching: pattern, range: range).map { ($0.0.range, $0.1) }
+        matchesAndTokens(matching: pattern, range: range).map { ($0.0.range, $0.1) }
     }
 
     public func match(pattern: String, range: NSRange? = nil, captureGroup: Int = 0) -> [(NSRange, [SyntaxKind])] {
-        return matchesAndSyntaxKinds(matching: pattern, range: range).map { textCheckingResult, syntaxKinds in
+        matchesAndSyntaxKinds(matching: pattern, range: range).map { textCheckingResult, syntaxKinds in
             (textCheckingResult.range(at: captureGroup), syntaxKinds)
         }
     }
@@ -203,7 +203,7 @@ extension SwiftLintFile {
                       excludingSyntaxKinds syntaxKinds: Set<SyntaxKind>,
                       range: NSRange? = nil,
                       captureGroup: Int = 0) -> [NSRange] {
-        return match(pattern: pattern, range: range, captureGroup: captureGroup)
+        match(pattern: pattern, range: range, captureGroup: captureGroup)
             .filter { syntaxKinds.isDisjoint(with: $0.1) }
             .map { $0.0 }
     }
@@ -279,7 +279,7 @@ extension SwiftLintFile {
     }
 
     public func ruleEnabled(violatingRange: NSRange, for rule: some Rule) -> NSRange? {
-        return ruleEnabled(violatingRanges: [violatingRange], for: rule).first
+        ruleEnabled(violatingRanges: [violatingRange], for: rule).first
     }
 
     public func isACL(token: SwiftLintSyntaxToken) -> Bool {
@@ -292,6 +292,6 @@ extension SwiftLintFile {
     }
 
     public func contents(for token: SwiftLintSyntaxToken) -> String? {
-        return stringView.substringWithByteRange(token.range)
+        stringView.substringWithByteRange(token.range)
     }
 }

--- a/Source/SwiftLintCore/Extensions/SwiftSyntax+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/SwiftSyntax+SwiftLint.swift
@@ -12,7 +12,7 @@ public extension SwiftLintSyntaxVisitor {
     }
 
     func walk<T>(file: SwiftLintFile, handler: (Self) -> [T]) -> [T] {
-        return walk(tree: file.syntaxTree, handler: handler)
+        walk(tree: file.syntaxTree, handler: handler)
     }
 }
 

--- a/Source/SwiftLintCore/Extensions/SyntaxKind+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/SyntaxKind+SwiftLint.swift
@@ -25,7 +25,7 @@ public extension SyntaxKind {
 
     /// Syntax kinds that don't have associated module info when getting their cursor info.
     static var kindsWithoutModuleInfo: Set<SyntaxKind> {
-        return [
+        [
             .attributeBuiltin,
             .keyword,
             .number,

--- a/Source/SwiftLintCore/Models/AccessControlLevel.swift
+++ b/Source/SwiftLintCore/Models/AccessControlLevel.swift
@@ -50,7 +50,7 @@ public enum AccessControlLevel: String, CustomStringConvertible {
 
     /// Returns true if is `private` or `fileprivate`
     public var isPrivate: Bool {
-        return self == .private || self == .fileprivate
+        self == .private || self == .fileprivate
     }
 }
 
@@ -67,6 +67,6 @@ extension AccessControlLevel: Comparable {
     }
 
     public static func < (lhs: AccessControlLevel, rhs: AccessControlLevel) -> Bool {
-        return lhs.priority < rhs.priority
+        lhs.priority < rhs.priority
     }
 }

--- a/Source/SwiftLintCore/Models/Configuration.swift
+++ b/Source/SwiftLintCore/Models/Configuration.swift
@@ -306,7 +306,7 @@ extension Configuration: Hashable {
     }
 
     public static func == (lhs: Configuration, rhs: Configuration) -> Bool {
-        return lhs.includedPaths == rhs.includedPaths &&
+        lhs.includedPaths == rhs.includedPaths &&
             lhs.excludedPaths == rhs.excludedPaths &&
             lhs.indentation == rhs.indentation &&
             lhs.warningThreshold == rhs.warningThreshold &&
@@ -327,7 +327,7 @@ extension Configuration: Hashable {
 // MARK: - CustomStringConvertible
 extension Configuration: CustomStringConvertible {
     public var description: String {
-        return "Configuration: \n"
+        "Configuration: \n"
             + "- Indentation Style: \(indentation)\n"
             + "- Included Paths: \(includedPaths)\n"
             + "- Excluded Paths: \(excludedPaths)\n"

--- a/Source/SwiftLintCore/Models/Correction.swift
+++ b/Source/SwiftLintCore/Models/Correction.swift
@@ -7,7 +7,7 @@ public struct Correction: Equatable, Sendable {
 
     /// The console-printable description for this correction.
     public var consoleDescription: String {
-        return "\(location.file ?? "<nopath>"): Corrected \(ruleDescription.name)"
+        "\(location.file ?? "<nopath>"): Corrected \(ruleDescription.name)"
     }
 
     /// Memberwise initializer.

--- a/Source/SwiftLintCore/Models/Example.swift
+++ b/Source/SwiftLintCore/Models/Example.swift
@@ -86,7 +86,7 @@ public extension Example {
 
     /// Returns a copy of the Example with all instances of the "↓" character removed.
     func removingViolationMarkers() -> Example {
-        return with(code: code.replacingOccurrences(of: "↓", with: ""))
+        with(code: code.replacingOccurrences(of: "↓", with: ""))
     }
 }
 
@@ -127,7 +127,7 @@ extension Example: Hashable {
     public static func == (lhs: Example, rhs: Example) -> Bool {
         // Ignoring file/line metadata because two Examples could represent
         // the same idea, but captured at two different points in the code
-        return lhs.code == rhs.code
+        lhs.code == rhs.code
     }
 
     public func hash(into hasher: inout Hasher) {
@@ -139,7 +139,7 @@ extension Example: Hashable {
 
 extension Example: Comparable {
     public static func < (lhs: Example, rhs: Example) -> Bool {
-        return lhs.code < rhs.code
+        lhs.code < rhs.code
     }
 }
 

--- a/Source/SwiftLintCore/Models/HashableConfigurationRuleWrapperWrapper.swift
+++ b/Source/SwiftLintCore/Models/HashableConfigurationRuleWrapperWrapper.swift
@@ -5,7 +5,7 @@ internal struct HashableConfigurationRuleWrapperWrapper: Hashable {
         lhs: HashableConfigurationRuleWrapperWrapper, rhs: HashableConfigurationRuleWrapperWrapper
     ) -> Bool {
         // Only use identifier for equality check (not taking config into account)
-        return type(of: lhs.configurationRuleWrapper.rule).description.identifier
+        type(of: lhs.configurationRuleWrapper.rule).description.identifier
             == type(of: rhs.configurationRuleWrapper.rule).description.identifier
     }
 

--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -24,10 +24,10 @@ private extension Rule {
         }
 
         let regionsDisablingCurrentRule = regions.filter { region in
-            return region.isRuleDisabled(self.init())
+            region.isRuleDisabled(self.init())
         }
         let regionsDisablingSuperfluousDisableRule = regions.filter { region in
-            return region.isRuleDisabled(superfluousDisableCommandRule)
+            region.isRuleDisabled(superfluousDisableCommandRule)
         }
 
         return regionsDisablingCurrentRule.compactMap { region -> StyleViolation? in
@@ -40,7 +40,7 @@ private extension Rule {
             }
 
             let noViolationsInDisabledRegion = !allViolations.contains { violation in
-                return region.contains(violation.location)
+                region.contains(violation.location)
             }
             guard noViolationsInDisabledRegion else {
                 return nil
@@ -91,9 +91,9 @@ private extension Rule {
         }
 
         let (disabledViolationsAndRegions, enabledViolationsAndRegions) = violations.map { violation in
-            return (violation, regions.first { $0.contains(violation.location) })
+            (violation, regions.first { $0.contains(violation.location) })
         }.partitioned { _, region in
-            return region?.isRuleEnabled(self) ?? true
+            region?.isRuleEnabled(self) ?? true
         }
 
         let ruleIDs = Self.description.allIdentifiers +
@@ -204,7 +204,7 @@ public struct CollectedLinter {
     ///
     /// - returns: All style violations found by this linter.
     public func styleViolations(using storage: RuleStorage) -> [StyleViolation] {
-        return getStyleViolations(using: storage).0
+        getStyleViolations(using: storage).0
     }
 
     /// Computes or retrieves style violations and the time spent executing each rule.
@@ -214,7 +214,7 @@ public struct CollectedLinter {
     /// - returns: All style violations found by this linter, and the time spent executing each rule.
     public func styleViolationsAndRuleTimes(using storage: RuleStorage)
         -> ([StyleViolation], [(id: String, time: Double)]) {
-            return getStyleViolations(using: storage, benchmark: true)
+            getStyleViolations(using: storage, benchmark: true)
     }
 
     private func getStyleViolations(using storage: RuleStorage,
@@ -348,7 +348,7 @@ public struct CollectedLinter {
                 !region.disabledRuleIdentifiers.contains(.all) &&
                 !region.disabledRuleIdentifiers.contains(superfluousRuleIdentifier)
             }).map { id in
-                return StyleViolation(
+                StyleViolation(
                     ruleDescription: type(of: superfluousDisableCommandRule).description,
                     severity: superfluousDisableCommandRule.configuration.severity,
                     location: region.start,

--- a/Source/SwiftLintCore/Models/LinterCache.swift
+++ b/Source/SwiftLintCore/Models/LinterCache.swift
@@ -13,7 +13,7 @@ private struct FileCacheEntry: Codable {
 private struct FileCache: Codable {
     var entries: [String: FileCacheEntry]
 
-    static var empty: FileCache { return Self(entries: [:]) }
+    static var empty: FileCache { Self(entries: [:]) }
 }
 
 /// A persisted cache for storing and retrieving linter results.
@@ -115,7 +115,7 @@ public final class LinterCache {
     }
 
     internal func flushed() -> LinterCache {
-        return Self(cache: mergeCaches(), location: location, fileManager: fileManager, swiftVersion: swiftVersion)
+        Self(cache: mergeCaches(), location: location, fileManager: fileManager, swiftVersion: swiftVersion)
     }
 
     private func fileCache(cacheDescription: String) -> FileCache {

--- a/Source/SwiftLintCore/Models/Location.swift
+++ b/Source/SwiftLintCore/Models/Location.swift
@@ -23,7 +23,7 @@ public struct Location: CustomStringConvertible, Comparable, Codable, Sendable {
 
     /// The file path for this location relative to the current working directory.
     public var relativeFile: String? {
-        return file?.replacingOccurrences(of: FileManager.default.currentDirectoryPath + "/", with: "")
+        file?.replacingOccurrences(of: FileManager.default.currentDirectoryPath + "/", with: "")
     }
 
     /// Creates a `Location` by specifying its properties directly.

--- a/Source/SwiftLintCore/Models/Region.swift
+++ b/Source/SwiftLintCore/Models/Region.swift
@@ -28,7 +28,7 @@ public struct Region: Equatable {
     ///
     /// - returns: True if the specific location is contained in this region.
     public func contains(_ location: Location) -> Bool {
-        return start <= location && end >= location
+        start <= location && end >= location
     }
 
     /// Whether the specified rule is enabled in this region.
@@ -37,7 +37,7 @@ public struct Region: Equatable {
     ///
     /// - returns: True if the specified rule is enabled in this region.
     public func isRuleEnabled(_ rule: some Rule) -> Bool {
-        return !isRuleDisabled(rule)
+        !isRuleDisabled(rule)
     }
 
     /// Whether the specified rule is disabled in this region.
@@ -46,7 +46,7 @@ public struct Region: Equatable {
     ///
     /// - returns: True if the specified rule is disabled in this region.
     public func isRuleDisabled(_ rule: some Rule) -> Bool {
-        return areRulesDisabled(ruleIDs: type(of: rule).description.allIdentifiers)
+        areRulesDisabled(ruleIDs: type(of: rule).description.allIdentifiers)
     }
 
     /// Whether the given rules are disabled in this region.

--- a/Source/SwiftLintCore/Models/RuleDescription.swift
+++ b/Source/SwiftLintCore/Models/RuleDescription.swift
@@ -52,11 +52,11 @@ public struct RuleDescription: Equatable, Sendable {
     public let requiresFileOnDisk: Bool
 
     /// The console-printable string for this description.
-    public var consoleDescription: String { return "\(name) (\(identifier)): \(description)" }
+    public var consoleDescription: String { "\(name) (\(identifier)): \(description)" }
 
     /// All identifiers that have been used to uniquely identify this rule in past and current SwiftLint versions.
     public var allIdentifiers: [String] {
-        return Array(deprecatedAliases) + [identifier]
+        Array(deprecatedAliases) + [identifier]
     }
 
     /// Creates a `RuleDescription` by specifying all its properties directly.
@@ -92,6 +92,6 @@ public struct RuleDescription: Equatable, Sendable {
     // MARK: Equatable
 
     public static func == (lhs: RuleDescription, rhs: RuleDescription) -> Bool {
-        return lhs.identifier == rhs.identifier
+        lhs.identifier == rhs.identifier
     }
 }

--- a/Source/SwiftLintCore/Models/RuleList.swift
+++ b/Source/SwiftLintCore/Models/RuleList.swift
@@ -73,11 +73,11 @@ public struct RuleList {
     }
 
     internal func identifier(for alias: String) -> String? {
-        return aliases[alias]
+        aliases[alias]
     }
 
     internal func allValidIdentifiers() -> [String] {
-        return list.flatMap { _, rule -> [String] in
+        list.flatMap { _, rule -> [String] in
             rule.description.allIdentifiers
         }
     }
@@ -85,7 +85,7 @@ public struct RuleList {
 
 extension RuleList: Equatable {
     public static func == (lhs: RuleList, rhs: RuleList) -> Bool {
-        return lhs.list.map { $0.0 } == rhs.list.map { $0.0 }
+        lhs.list.map { $0.0 } == rhs.list.map { $0.0 }
             && lhs.list.map { $0.1.description } == rhs.list.map { $0.1.description }
             && lhs.aliases == rhs.aliases
     }

--- a/Source/SwiftLintCore/Models/RuleRegistry.swift
+++ b/Source/SwiftLintCore/Models/RuleRegistry.swift
@@ -27,6 +27,6 @@ public final class RuleRegistry: @unchecked Sendable {
     ///
     /// - returns: The rule matching the specified ID, if one was found.
     public func rule(forID id: String) -> (any Rule.Type)? {
-        return list.list[id]
+        list.list[id]
     }
 }

--- a/Source/SwiftLintCore/Models/RuleStorage.swift
+++ b/Source/SwiftLintCore/Models/RuleStorage.swift
@@ -32,7 +32,7 @@ public class RuleStorage: CustomStringConvertible {
     ///
     /// - returns: All file information for a given rule that was collected via `collect(...)`.
     func collectedInfo<R: CollectingRule>(for rule: R) -> [SwiftLintFile: R.FileInfo]? {
-        return access.sync {
+        access.sync {
             storage[ObjectIdentifier(R.self)] as? [SwiftLintFile: R.FileInfo]
         }
     }

--- a/Source/SwiftLintCore/Models/StyleViolation.swift
+++ b/Source/SwiftLintCore/Models/StyleViolation.swift
@@ -20,7 +20,7 @@ public struct StyleViolation: CustomStringConvertible, Codable, Hashable {
 
     /// A printable description for this violation.
     public var description: String {
-        return XcodeReporter.generateForSingleViolation(self)
+        XcodeReporter.generateForSingleViolation(self)
     }
 
     /// Creates a `StyleViolation` by specifying its properties directly.

--- a/Source/SwiftLintCore/Models/SwiftLintFile.swift
+++ b/Source/SwiftLintCore/Models/SwiftLintFile.swift
@@ -47,22 +47,22 @@ public final class SwiftLintFile {
 
     /// The path on disk for this file.
     public var path: String? {
-        return file.path
+        file.path
     }
 
     /// The file's contents.
     public var contents: String {
-        return file.contents
+        file.contents
     }
 
     /// A string view into the contents of this file optimized for string manipulation operations.
     public var stringView: StringView {
-        return file.stringView
+        file.stringView
     }
 
     /// The parsed lines for this file's contents.
     public var lines: [Line] {
-        return file.lines
+        file.lines
     }
 
     /// Mark this file as used for testing purposes.

--- a/Source/SwiftLintCore/Models/SwiftLintSyntaxMap.swift
+++ b/Source/SwiftLintCore/Models/SwiftLintSyntaxMap.swift
@@ -23,11 +23,11 @@ public struct SwiftLintSyntaxMap {
     /// - returns: The array of syntax tokens intersecting with byte range.
     public func tokens(inByteRange byteRange: ByteRange) -> [SwiftLintSyntaxToken] {
         func intersect(_ token: SwiftLintSyntaxToken) -> Bool {
-            return token.range.intersects(byteRange)
+            token.range.intersects(byteRange)
         }
 
         func intersectsOrAfter(_ token: SwiftLintSyntaxToken) -> Bool {
-            return token.offset + token.length > byteRange.location
+            token.offset + token.length > byteRange.location
         }
 
         guard let startIndex = tokens.firstIndexAssumingSorted(where: intersectsOrAfter) else {
@@ -49,6 +49,6 @@ public struct SwiftLintSyntaxMap {
     ///
     /// - returns: The syntax kinds in the specified byte range.
     public func kinds(inByteRange byteRange: ByteRange) -> [SyntaxKind] {
-        return tokens(inByteRange: byteRange).compactMap { $0.kind }
+        tokens(inByteRange: byteRange).compactMap { $0.kind }
     }
 }

--- a/Source/SwiftLintCore/Models/SwiftLintSyntaxToken.swift
+++ b/Source/SwiftLintCore/Models/SwiftLintSyntaxToken.swift
@@ -18,23 +18,23 @@ public struct SwiftLintSyntaxToken {
 
     /// The byte range in a source file for this token.
     public var range: ByteRange {
-        return value.range
+        value.range
     }
 
     /// The starting byte offset in a source file for this token.
     public var offset: ByteCount {
-        return value.offset
+        value.offset
     }
 
     /// The length in bytes for this token.
     public var length: ByteCount {
-        return value.length
+        value.length
     }
 }
 
 public extension Array where Element == SwiftLintSyntaxToken {
     /// The kinds for these tokens.
     var kinds: [SyntaxKind] {
-        return compactMap { $0.kind }
+        compactMap { $0.kind }
     }
 }

--- a/Source/SwiftLintCore/Models/SwiftVersion.swift
+++ b/Source/SwiftLintCore/Models/SwiftVersion.swift
@@ -95,14 +95,14 @@ public extension SwiftVersion {
 
 private extension Dictionary where Key == String {
     var versionMajor: Int? {
-        return (self["key.version_major"] as? Int64).flatMap({ Int($0) })
+        (self["key.version_major"] as? Int64).flatMap({ Int($0) })
     }
 
     var versionMinor: Int? {
-        return (self["key.version_minor"] as? Int64).flatMap({ Int($0) })
+        (self["key.version_minor"] as? Int64).flatMap({ Int($0) })
     }
 
     var versionPatch: Int? {
-        return (self["key.version_patch"] as? Int64).flatMap({ Int($0) })
+        (self["key.version_patch"] as? Int64).flatMap({ Int($0) })
     }
 }

--- a/Source/SwiftLintCore/Models/ViolationSeverity.swift
+++ b/Source/SwiftLintCore/Models/ViolationSeverity.swift
@@ -9,6 +9,6 @@ public enum ViolationSeverity: String, Comparable, Codable, InlinableOptionType 
     // MARK: Comparable
 
     public static func < (lhs: ViolationSeverity, rhs: ViolationSeverity) -> Bool {
-        return lhs == .warning && rhs == .error
+        lhs == .warning && rhs == .error
     }
 }

--- a/Source/SwiftLintCore/Models/YamlParser.swift
+++ b/Source/SwiftLintCore/Models/YamlParser.swift
@@ -26,7 +26,7 @@ public struct YamlParser {
 
 private extension Constructor {
     static func swiftlintConstructor(env: [String: String]) -> Constructor {
-        return Constructor(customScalarMap(env: env))
+        Constructor(customScalarMap(env: env))
     }
 
     static func customScalarMap(env: [String: String]) -> ScalarMap {
@@ -40,8 +40,8 @@ private extension Constructor {
 
 private extension String {
     static func constructExpandingEnvVars(env: [String: String]) -> (_ scalar: Node.Scalar) -> String? {
-        return { (scalar: Node.Scalar) -> String? in
-            return scalar.string.expandingEnvVars(env: env)
+        { (scalar: Node.Scalar) -> String? in
+            scalar.string.expandingEnvVars(env: env)
         }
     }
 

--- a/Source/SwiftLintCore/Protocols/ASTRule.swift
+++ b/Source/SwiftLintCore/Protocols/ASTRule.swift
@@ -27,7 +27,7 @@ public protocol ASTRule: Rule {
 
 public extension ASTRule {
     func validate(file: SwiftLintFile) -> [StyleViolation] {
-        return validate(file: file, dictionary: file.structureDictionary)
+        validate(file: file, dictionary: file.structureDictionary)
     }
 
     /// Executes the rule on a file and a subset of its AST structure, returning any violations to the rule's
@@ -38,7 +38,7 @@ public extension ASTRule {
     ///
     /// - returns: All style violations to the rule's expectations.
     func validate(file: SwiftLintFile, dictionary: SourceKittenDictionary) -> [StyleViolation] {
-        return dictionary.traverseDepthFirst { subDict in
+        dictionary.traverseDepthFirst { subDict in
             guard let kind = self.kind(from: subDict) else { return nil }
             return validate(file: file, kind: kind, dictionary: subDict)
         }
@@ -47,18 +47,18 @@ public extension ASTRule {
 
 public extension ASTRule where KindType == SwiftDeclarationKind {
     func kind(from dictionary: SourceKittenDictionary) -> KindType? {
-        return dictionary.declarationKind
+        dictionary.declarationKind
     }
 }
 
 public extension ASTRule where KindType == SwiftExpressionKind {
     func kind(from dictionary: SourceKittenDictionary) -> KindType? {
-        return dictionary.expressionKind
+        dictionary.expressionKind
     }
 }
 
 public extension ASTRule where KindType == StatementKind {
     func kind(from dictionary: SourceKittenDictionary) -> KindType? {
-        return dictionary.statementKind
+        dictionary.statementKind
     }
 }

--- a/Source/SwiftLintCore/Protocols/CollectingRule.swift
+++ b/Source/SwiftLintCore/Protocols/CollectingRule.swift
@@ -54,11 +54,11 @@ public extension CollectingRule {
         return validate(file: file, collectedInfo: info, compilerArguments: compilerArguments)
     }
     func collectInfo(for file: SwiftLintFile, compilerArguments: [String]) -> FileInfo {
-        return collectInfo(for: file)
+        collectInfo(for: file)
     }
     func validate(file: SwiftLintFile, collectedInfo: [SwiftLintFile: FileInfo],
                   compilerArguments: [String]) -> [StyleViolation] {
-        return validate(file: file, collectedInfo: collectedInfo)
+        validate(file: file, collectedInfo: collectedInfo)
     }
     func validate(file: SwiftLintFile) -> [StyleViolation] {
         queuedFatalError("Must call `validate(file:collectedInfo:)` for CollectingRule")
@@ -116,7 +116,7 @@ package protocol CollectingCorrectableRule: CollectingRule, CorrectableRule {
 package extension CollectingCorrectableRule {
     func correct(file: SwiftLintFile, collectedInfo: [SwiftLintFile: FileInfo],
                  compilerArguments: [String]) -> [Correction] {
-        return correct(file: file, collectedInfo: collectedInfo)
+        correct(file: file, collectedInfo: collectedInfo)
     }
 
     func correct(file: SwiftLintFile, using storage: RuleStorage, compilerArguments: [String]) -> [Correction] {

--- a/Source/SwiftLintCore/Protocols/Rule.swift
+++ b/Source/SwiftLintCore/Protocols/Rule.swift
@@ -84,11 +84,11 @@ public extension Rule {
 
     func validate(file: SwiftLintFile, using storage: RuleStorage,
                   compilerArguments: [String]) -> [StyleViolation] {
-        return validate(file: file, compilerArguments: compilerArguments)
+        validate(file: file, compilerArguments: compilerArguments)
     }
 
     func validate(file: SwiftLintFile, compilerArguments: [String]) -> [StyleViolation] {
-        return validate(file: file)
+        validate(file: file)
     }
 
     func isEqualTo(_ rule: any Rule) -> Bool {
@@ -153,10 +153,10 @@ public protocol CorrectableRule: Rule {
 
 public extension CorrectableRule {
     func correct(file: SwiftLintFile, compilerArguments: [String]) -> [Correction] {
-        return correct(file: file)
+        correct(file: file)
     }
     func correct(file: SwiftLintFile, using storage: RuleStorage, compilerArguments: [String]) -> [Correction] {
-        return correct(file: file, compilerArguments: compilerArguments)
+        correct(file: file, compilerArguments: compilerArguments)
     }
 }
 

--- a/Source/SwiftLintCore/Reporters/CSVReporter.swift
+++ b/Source/SwiftLintCore/Reporters/CSVReporter.swift
@@ -26,7 +26,7 @@ struct CSVReporter: Reporter {
     // MARK: - Private
 
     private static func csvRow(for violation: StyleViolation) -> String {
-        return [
+        [
             violation.location.file?.escapedForCSV() ?? "",
             violation.location.line?.description ?? "",
             violation.location.character?.description ?? "",

--- a/Source/SwiftLintCore/Reporters/CheckstyleReporter.swift
+++ b/Source/SwiftLintCore/Reporters/CheckstyleReporter.swift
@@ -8,7 +8,7 @@ struct CheckstyleReporter: Reporter {
     static let description = "Reports violations as Checkstyle XML."
 
     static func generateReport(_ violations: [StyleViolation]) -> String {
-        return [
+        [
             "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<checkstyle version=\"4.3\">",
             violations
                 .group(by: { ($0.location.file ?? "<nopath>").escapedForXML() })
@@ -21,7 +21,7 @@ struct CheckstyleReporter: Reporter {
     // MARK: - Private
 
     private static func generateForViolationFile(_ file: String, violations: [StyleViolation]) -> String {
-        return [
+        [
             "\n\t<file name=\"", file, "\">\n",
             violations.map(generateForSingleViolation).joined(),
             "\t</file>",

--- a/Source/SwiftLintCore/Reporters/CodeClimateReporter.swift
+++ b/Source/SwiftLintCore/Reporters/CodeClimateReporter.swift
@@ -13,14 +13,14 @@ struct CodeClimateReporter: Reporter {
     static let description = "Reports violations as a JSON array in Code Climate format."
 
     static func generateReport(_ violations: [StyleViolation]) -> String {
-        return toJSON(violations.map(dictionary(for:)))
+        toJSON(violations.map(dictionary(for:)))
             .replacingOccurrences(of: "\\/", with: "/")
     }
 
     // MARK: - Private
 
     private static func dictionary(for violation: StyleViolation) -> [String: Any] {
-        return [
+        [
             "check_name": violation.ruleName,
             "description": violation.reason,
             "engine_name": "SwiftLint",

--- a/Source/SwiftLintCore/Reporters/GitHubActionsLoggingReporter.swift
+++ b/Source/SwiftLintCore/Reporters/GitHubActionsLoggingReporter.swift
@@ -8,7 +8,7 @@ struct GitHubActionsLoggingReporter: Reporter {
                                     "machine for Actions can recognize as messages."
 
     static func generateReport(_ violations: [StyleViolation]) -> String {
-        return violations.map(generateForSingleViolation).joined(separator: "\n")
+        violations.map(generateForSingleViolation).joined(separator: "\n")
     }
 
     // MARK: - Private
@@ -17,7 +17,7 @@ struct GitHubActionsLoggingReporter: Reporter {
         // swiftlint:disable:next line_length
         // https://help.github.com/en/github/automating-your-workflow-with-github-actions/development-tools-for-github-actions#logging-commands
         // ::(warning|error) file={relative_path_to_file},line={:line},col={:character}::{content}
-        return [
+        [
             "::\(violation.severity.rawValue) ",
             "file=\(violation.location.relativeFile ?? ""),",
             "line=\(violation.location.line ?? 1),",

--- a/Source/SwiftLintCore/Reporters/GitLabJUnitReporter.swift
+++ b/Source/SwiftLintCore/Reporters/GitLabJUnitReporter.swift
@@ -7,7 +7,7 @@ struct GitLabJUnitReporter: Reporter {
     static let description = "Reports violations as JUnit XML supported by GitLab."
 
     static func generateReport(_ violations: [StyleViolation]) -> String {
-        return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<testsuites><testsuite>" +
+        "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<testsuites><testsuite>" +
             violations.map({ violation -> String in
                 let fileName = (violation.location.relativeFile ?? "<nopath>").escapedForXML()
                 let line = violation.location.line.map(String.init)

--- a/Source/SwiftLintCore/Reporters/HTMLReporter.swift
+++ b/Source/SwiftLintCore/Reporters/HTMLReporter.swift
@@ -15,8 +15,7 @@ struct HTMLReporter: Reporter {
     static let description = "Reports violations as HTML."
 
     static func generateReport(_ violations: [StyleViolation]) -> String {
-        return generateReport(violations, swiftlintVersion: Version.current.value,
-                              dateString: formatter.string(from: Date()))
+        generateReport(violations, swiftlintVersion: Version.current.value, dateString: formatter.string(from: Date()))
     }
 
     // MARK: - Internal

--- a/Source/SwiftLintCore/Reporters/JSONReporter.swift
+++ b/Source/SwiftLintCore/Reporters/JSONReporter.swift
@@ -10,13 +10,13 @@ struct JSONReporter: Reporter {
     static let description = "Reports violations as a JSON array."
 
     static func generateReport(_ violations: [StyleViolation]) -> String {
-        return toJSON(violations.map(dictionary(for:)))
+        toJSON(violations.map(dictionary(for:)))
     }
 
     // MARK: - Private
 
     private static func dictionary(for violation: StyleViolation) -> [String: Any] {
-        return [
+        [
             "file": violation.location.file ?? NSNull() as Any,
             "line": violation.location.line ?? NSNull() as Any,
             "character": violation.location.character ?? NSNull() as Any,

--- a/Source/SwiftLintCore/Reporters/MarkdownReporter.swift
+++ b/Source/SwiftLintCore/Reporters/MarkdownReporter.swift
@@ -24,7 +24,7 @@ struct MarkdownReporter: Reporter {
     // MARK: - Private
 
     private static func markdownRow(for violation: StyleViolation) -> String {
-        return [
+        [
             violation.location.file?.escapedForMarkdown() ?? "",
             violation.location.line?.description ?? "",
             severity(for: violation.severity),

--- a/Source/SwiftLintCore/Reporters/RelativePathReporter.swift
+++ b/Source/SwiftLintCore/Reporters/RelativePathReporter.swift
@@ -7,7 +7,7 @@ struct RelativePathReporter: Reporter {
     static let description = "Reports violations with relative paths."
 
     static func generateReport(_ violations: [StyleViolation]) -> String {
-        return violations.map(generateForSingleViolation).joined(separator: "\n")
+        violations.map(generateForSingleViolation).joined(separator: "\n")
     }
 
     /// Generates a report for a single violation.
@@ -18,7 +18,7 @@ struct RelativePathReporter: Reporter {
     internal static func generateForSingleViolation(_ violation: StyleViolation) -> String {
         // {relative_path_to_file}{:line}{:character}: {error,warning}: {content}
 
-        return [
+        [
             "\(violation.location.relativeFile ?? "<nopath>")",
             ":\(violation.location.line ?? 1)",
             ":\(violation.location.character ?? 1): ",

--- a/Source/SwiftLintCore/Reporters/SARIFReporter.swift
+++ b/Source/SwiftLintCore/Reporters/SARIFReporter.swift
@@ -36,7 +36,7 @@ struct SARIFReporter: Reporter {
     // MARK: - Private
 
     private static func dictionary(for violation: StyleViolation) -> [String: Any] {
-        return [
+        [
             "level": violation.severity.rawValue,
             "ruleId": violation.ruleIdentifier,
             "message": [

--- a/Source/SwiftLintCore/Reporters/SonarQubeReporter.swift
+++ b/Source/SwiftLintCore/Reporters/SonarQubeReporter.swift
@@ -9,14 +9,14 @@ struct SonarQubeReporter: Reporter {
     static let description = "Reports violations in SonarQube import format."
 
     static func generateReport(_ violations: [StyleViolation]) -> String {
-        return toJSON(["issues": violations.map(dictionary(for:))])
+        toJSON(["issues": violations.map(dictionary(for:))])
     }
 
     // MARK: - Private
 
     // refer to https://docs.sonarqube.org/display/SONAR/Generic+Issue+Data
     private static func dictionary(for violation: StyleViolation) -> [String: Any] {
-        return [
+        [
             "engineId": "SwiftLint",
             "ruleId": violation.ruleIdentifier,
             "primaryLocation": [

--- a/Source/SwiftLintCore/Reporters/XcodeReporter.swift
+++ b/Source/SwiftLintCore/Reporters/XcodeReporter.swift
@@ -7,7 +7,7 @@ struct XcodeReporter: Reporter {
     static let description = "Reports violations in the format Xcode uses to display in the IDE. (default)"
 
     static func generateReport(_ violations: [StyleViolation]) -> String {
-        return violations.map(generateForSingleViolation).joined(separator: "\n")
+        violations.map(generateForSingleViolation).joined(separator: "\n")
     }
 
     /// Generates a report for a single violation.
@@ -17,7 +17,7 @@ struct XcodeReporter: Reporter {
     /// - returns: The report for a single violation.
     internal static func generateForSingleViolation(_ violation: StyleViolation) -> String {
         // {full_path_to_file}{:line}{:character}: {error,warning}: {content}
-        return [
+        [
             "\(violation.location): ",
             "\(violation.severity.rawValue): ",
             "\(violation.ruleName) Violation: ",

--- a/Source/SwiftLintCore/RuleConfigurations/RegexConfiguration.swift
+++ b/Source/SwiftLintCore/RuleConfigurations/RegexConfiguration.swift
@@ -45,8 +45,8 @@ public struct RegexConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration, 
 
     /// The `RuleDescription` for the custom rule defined here.
     public var description: RuleDescription {
-        return RuleDescription(identifier: identifier, name: name ?? identifier,
-                               description: "", kind: .style)
+        RuleDescription(identifier: identifier, name: name ?? identifier,
+                        description: "", kind: .style)
     }
 
     /// Create a `RegexConfiguration` with the specified identifier, with other properties to be set later.

--- a/Source/SwiftLintCore/Rules/CustomRules.swift
+++ b/Source/SwiftLintCore/Rules/CustomRules.swift
@@ -38,7 +38,7 @@ struct CustomRulesConfiguration: RuleConfiguration, CacheDescriptionProvider {
 
 struct CustomRules: Rule, CacheDescriptionProvider {
     var cacheDescription: String {
-        return configuration.cacheDescription
+        configuration.cacheDescription
     }
 
     static let description = RuleDescription(
@@ -92,6 +92,6 @@ struct CustomRules: Rule, CacheDescriptionProvider {
 
 private extension Region {
     func isRuleDisabled(customRuleIdentifier: String) -> Bool {
-        return disabledRuleIdentifiers.contains(RuleIdentifier(customRuleIdentifier))
+        disabledRuleIdentifiers.contains(RuleIdentifier(customRuleIdentifier))
     }
 }

--- a/Source/SwiftLintCore/Rules/SuperfluousDisableCommandRule.swift
+++ b/Source/SwiftLintCore/Rules/SuperfluousDisableCommandRule.swift
@@ -31,7 +31,7 @@ package struct SuperfluousDisableCommandRule: SourceKitFreeRule {
 
     package func validate(file: SwiftLintFile) -> [StyleViolation] {
         // This rule is implemented in Linter.swift
-        return []
+        []
     }
 
     func reason(for rule: (some Rule).Type) -> String {
@@ -42,6 +42,6 @@ package struct SuperfluousDisableCommandRule: SourceKitFreeRule {
     }
 
     func reason(forNonExistentRule rule: String) -> String {
-        return "'\(rule)' is not a valid SwiftLint rule; remove it from the disable command"
+        "'\(rule)' is not a valid SwiftLint rule; remove it from the disable command"
     }
 }

--- a/Source/swiftlint/Commands/Common/RulesFilterOptions.swift
+++ b/Source/swiftlint/Commands/Common/RulesFilterOptions.swift
@@ -4,11 +4,11 @@ enum RuleEnablementOptions: String, EnumerableFlag {
     case enabled, disabled
 
     static func name(for value: RuleEnablementOptions) -> NameSpecification {
-        return .shortAndLong
+        .shortAndLong
     }
 
     static func help(for value: RuleEnablementOptions) -> ArgumentHelp? {
-        return "Only show \(value.rawValue) rules"
+        "Only show \(value.rawValue) rules"
     }
 }
 

--- a/Source/swiftlint/Extensions/Configuration+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Configuration+CommandLine.swift
@@ -41,7 +41,7 @@ private func scriptInputFiles() throws -> [SwiftLintFile] {
 }
 
 #if os(Linux)
-private func autoreleasepool<T>(block: () -> T) -> T { return block() }
+private func autoreleasepool<T>(block: () -> T) -> T { block() }
 #endif
 
 extension Configuration {

--- a/Source/swiftlint/Helpers/Benchmark.swift
+++ b/Source/swiftlint/Helpers/Benchmark.swift
@@ -31,7 +31,7 @@ struct Benchmark {
         let entriesKeyValues: [(String, Double)] = entriesDict.sorted { $0.1 < $1.1 }
         let lines: [String] = entriesKeyValues.map { id, time -> String in
             // swiftlint:disable:next legacy_objc_type
-            return "\(numberFormatter.string(from: NSNumber(value: time))!): \(id)"
+            "\(numberFormatter.string(from: NSNumber(value: time))!): \(id)"
         }
         let string: String = lines.joined(separator: "\n") + "\n"
         let url = URL(fileURLWithPath: "benchmark_\(name)_\(timestamp).txt", isDirectory: false)

--- a/Source/swiftlint/Helpers/CompilerArgumentsExtractor.swift
+++ b/Source/swiftlint/Helpers/CompilerArgumentsExtractor.swift
@@ -59,7 +59,7 @@ private func partiallyFilter(arguments args: [String]) -> ([String], Bool) {
 extension Array where Element == String {
     /// Return the full list of compiler arguments, replacing any response files with their contents.
     fileprivate var expandingResponseFiles: [String] {
-        return flatMap { arg -> [String] in
+        flatMap { arg -> [String] in
             guard arg.starts(with: "@") else {
                 return [arg]
             }

--- a/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
+++ b/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
@@ -152,7 +152,7 @@ struct LintOrAnalyzeCommand {
 
     private static func printStatus(violations: [StyleViolation], files: [SwiftLintFile], serious: Int, verb: String) {
         let pluralSuffix = { (collection: [Any]) -> String in
-            return collection.count != 1 ? "s" : ""
+            collection.count != 1 ? "s" : ""
         }
         queuedPrintError(
             "Done \(verb)! Found \(violations.count) violation\(pluralSuffix(violations)), " +
@@ -253,7 +253,7 @@ struct LintOrAnalyzeCommand {
             }
 
             let pluralSuffix = { (collection: [Any]) -> String in
-                return collection.count != 1 ? "s" : ""
+                collection.count != 1 ? "s" : ""
             }
             queuedPrintError("Done correcting \(files.count) file\(pluralSuffix(files))!")
         }

--- a/Source/swiftlint/Helpers/LintableFilesVisitor.swift
+++ b/Source/swiftlint/Helpers/LintableFilesVisitor.swift
@@ -7,11 +7,11 @@ typealias Arguments = [String]
 
 class CompilerInvocations {
     static func buildLog(compilerInvocations: [[String]]) -> CompilerInvocations {
-        return ArrayCompilerInvocations(invocations: compilerInvocations)
+        ArrayCompilerInvocations(invocations: compilerInvocations)
     }
 
     static func compilationDatabase(compileCommands: [File: Arguments]) -> CompilerInvocations {
-        return CompilationDatabaseInvocations(compileCommands: compileCommands)
+        CompilationDatabaseInvocations(compileCommands: compileCommands)
     }
 
     /// Default implementation
@@ -31,8 +31,8 @@ class CompilerInvocations {
         }
 
         override func arguments(forFile path: String?) -> Arguments {
-            return path.flatMap { path in
-                return invocationsByArgument[path]?.first
+            path.flatMap { path in
+                invocationsByArgument[path]?.first
             } ?? []
         }
     }
@@ -45,8 +45,8 @@ class CompilerInvocations {
         }
 
         override func arguments(forFile path: String?) -> Arguments {
-            return path.flatMap { path in
-                return compileCommands[path] ??
+            path.flatMap { path in
+                compileCommands[path] ??
                 compileCommands[path.path(relativeTo: FileManager.default.currentDirectoryPath)]
             } ?? []
         }
@@ -59,7 +59,7 @@ enum LintOrAnalyzeModeWithCompilerArguments {
 }
 
 private func resolveParamsFiles(args: [String]) -> [String] {
-    return args.reduce(into: []) { (allArgs: inout [String], arg: String) in
+    args.reduce(into: []) { (allArgs: inout [String], arg: String) in
         if arg.hasPrefix("@"), let contents = try? String(contentsOfFile: String(arg.dropFirst())) {
             allArgs.append(contentsOf: resolveParamsFiles(args: contents.split(separator: "\n").map(String.init)))
         } else {

--- a/Tests/CLITests/RulesFilterTests.swift
+++ b/Tests/CLITests/RulesFilterTests.swift
@@ -141,7 +141,7 @@ private struct RuleMock1: Rule {
     init(configuration: Any) throws { self.init() }
 
     func validate(file: SwiftLintFile) -> [StyleViolation] {
-        return []
+        []
     }
 }
 
@@ -156,7 +156,7 @@ private struct RuleMock2: Rule {
     init(configuration: Any) throws { self.init() }
 
     func validate(file: SwiftLintFile) -> [StyleViolation] {
-        return []
+        []
     }
 }
 
@@ -171,7 +171,7 @@ private struct CorrectableRuleMock: CorrectableRule {
     init(configuration: Any) throws { self.init() }
 
     func validate(file: SwiftLintFile) -> [StyleViolation] {
-        return []
+        []
     }
 
     func correct(file: SwiftLintFile) -> [Correction] {

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -152,7 +152,7 @@ private struct StaticStringImitator {
         }
 
         var staticString: StaticString {
-            return unsafeBitCast(self, to: StaticString.self)
+            unsafeBitCast(self, to: StaticString.self)
         }
     }
 }

--- a/Tests/SwiftLintFrameworkTests/CollectingRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CollectingRuleTests.swift
@@ -8,7 +8,7 @@ final class CollectingRuleTests: SwiftLintTestCase {
             var configuration = SeverityConfiguration<Self>(.warning)
 
             func collectInfo(for file: SwiftLintFile) -> Int {
-                return 42
+                42
             }
             func validate(file: SwiftLintFile, collectedInfo: [SwiftLintFile: Int]) -> [StyleViolation] {
                 XCTAssertEqual(collectedInfo[file], 42)
@@ -29,7 +29,7 @@ final class CollectingRuleTests: SwiftLintTestCase {
             var configuration = SeverityConfiguration<Self>(.warning)
 
             func collectInfo(for file: SwiftLintFile) -> String {
-                return file.contents
+                file.contents
             }
             func validate(file: SwiftLintFile, collectedInfo: [SwiftLintFile: String]) -> [StyleViolation] {
                 let values = collectedInfo.values
@@ -54,7 +54,7 @@ final class CollectingRuleTests: SwiftLintTestCase {
             var configuration = SeverityConfiguration<Self>(.warning)
 
             func collectInfo(for file: SwiftLintFile, compilerArguments: [String]) -> [String] {
-                return compilerArguments
+                compilerArguments
             }
             func validate(file: SwiftLintFile, collectedInfo: [SwiftLintFile: [String]], compilerArguments: [String])
                 -> [StyleViolation] {
@@ -76,7 +76,7 @@ final class CollectingRuleTests: SwiftLintTestCase {
             var configuration = SeverityConfiguration<Self>(.warning)
 
             func collectInfo(for file: SwiftLintFile) -> String {
-                return file.contents
+                file.contents
             }
 
             func validate(file: SwiftLintFile, collectedInfo: [SwiftLintFile: String]) -> [StyleViolation] {
@@ -108,7 +108,7 @@ final class CollectingRuleTests: SwiftLintTestCase {
             var configuration = SeverityConfiguration<Self>(.warning)
 
             func collectInfo(for file: SwiftLintFile, compilerArguments: [String]) -> String {
-                return file.contents
+                file.contents
             }
 
             func validate(file: SwiftLintFile, collectedInfo: [SwiftLintFile: String], compilerArguments: [String])
@@ -143,10 +143,10 @@ extension MockCollectingRule {
     @RuleConfigurationDescriptionBuilder
     var configurationDescription: some Documentable { RuleConfigurationOption.noOptions }
     static var description: RuleDescription {
-        return RuleDescription(identifier: "test_rule", name: "", description: "", kind: .lint)
+        RuleDescription(identifier: "test_rule", name: "", description: "", kind: .lint)
     }
     static var configuration: Configuration? {
-        return Configuration(rulesMode: .only([description.identifier]), ruleList: RuleList(rules: self))
+        Configuration(rulesMode: .only([description.identifier]), ruleList: RuleList(rules: self))
     }
 
     init(configuration: Any) throws { self.init() }

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -6,7 +6,7 @@ import XCTest
 
 private extension Configuration {
     func contains<T: Rule>(rule: T.Type) -> Bool {
-        return rules.contains { $0 is T }
+        rules.contains { $0 is T }
     }
 }
 
@@ -32,7 +32,7 @@ extension ConfigurationTests {
     // MARK: - Merging Aspects
     func testWarningThresholdMerging() {
         func configuration(forWarningThreshold warningThreshold: Int?) -> Configuration {
-            return Configuration(
+            Configuration(
                 warningThreshold: warningThreshold,
                 reporter: XcodeReporter.identifier
             )

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -251,7 +251,7 @@ final class ConfigurationTests: SwiftLintTestCase {
         }
 
         func modificationDate(forFileAtPath path: String) -> Date? {
-            return nil
+            nil
         }
 
         func isFile(atPath path: String) -> Bool {

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -251,6 +251,6 @@ final class CustomRulesTests: SwiftLintTestCase {
     }
 
     private func getTestTextFile() -> SwiftLintFile {
-        return SwiftLintFile(path: "\(testResourcesPath)/test.txt")!
+        SwiftLintFile(path: "\(testResourcesPath)/test.txt")!
     }
 }

--- a/Tests/SwiftLintFrameworkTests/ExpiringTodoRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExpiringTodoRuleTests.swift
@@ -141,7 +141,7 @@ final class ExpiringTodoRuleTests: SwiftLintTestCase {
     }
 
     private func violations(_ example: Example) -> [StyleViolation] {
-        return SwiftLintFrameworkTests.violations(example, config: config)
+        SwiftLintFrameworkTests.violations(example, config: config)
     }
 
     private func dateString(for status: ExpiringTodoRule.ExpiryViolationLevel) -> String {
@@ -198,6 +198,6 @@ final class ExpiringTodoRuleTests: SwiftLintTestCase {
 fileprivate extension Configuration {
     var ruleConfiguration: ExpiringTodoConfiguration {
         // swiftlint:disable:next force_cast
-        return (rules.first(where: { $0 is ExpiringTodoRule }) as! ExpiringTodoRule).configuration
+        (rules.first(where: { $0 is ExpiringTodoRule }) as! ExpiringTodoRule).configuration
     }
 }

--- a/Tests/SwiftLintFrameworkTests/FunctionBodyLengthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FunctionBodyLengthRuleTests.swift
@@ -10,7 +10,7 @@ private func funcWithBody(_ body: String,
 }
 
 private func violatingFuncWithBody(_ body: String, file: StaticString = #filePath, line: UInt = #line) -> Example {
-    return funcWithBody(body, violates: true, file: file, line: line)
+    funcWithBody(body, violates: true, file: file, line: line)
 }
 
 final class FunctionBodyLengthRuleTests: SwiftLintTestCase {

--- a/Tests/SwiftLintFrameworkTests/GlobTests.swift
+++ b/Tests/SwiftLintFrameworkTests/GlobTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class GlobTests: SwiftLintTestCase {
     private var mockPath: String {
-        return testResourcesPath.stringByAppendingPathComponent("ProjectMock")
+        testResourcesPath.stringByAppendingPathComponent("ProjectMock")
     }
 
     func testNonExistingDirectory() {

--- a/Tests/SwiftLintFrameworkTests/LinterCacheTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LinterCacheTests.swift
@@ -11,7 +11,7 @@ private struct CacheTestHelper {
 
     private var fileManager: TestFileManager {
         // swiftlint:disable:next force_cast
-        return cache.fileManager as! TestFileManager
+        cache.fileManager as! TestFileManager
     }
 
     fileprivate init(dict: [String: Any], cache: LinterCache) {
@@ -36,7 +36,7 @@ private struct CacheTestHelper {
     }
 
     fileprivate func makeConfig(dict: [String: Any]) -> Configuration {
-        return try! Configuration(dict: dict, ruleList: ruleList) // swiftlint:disable:this force_try
+        try! Configuration(dict: dict, ruleList: ruleList) // swiftlint:disable:this force_try
     }
 
     fileprivate func touch(file: String) {
@@ -48,19 +48,19 @@ private struct CacheTestHelper {
     }
 
     fileprivate func fileCount() -> Int {
-        return fileManager.stubbedModificationDateByPath.count
+        fileManager.stubbedModificationDateByPath.count
     }
 }
 
 private class TestFileManager: LintableFileManager {
     fileprivate func filesToLint(inPath: String, rootDirectory: String? = nil) -> [String] {
-        return []
+        []
     }
 
     fileprivate var stubbedModificationDateByPath = [String: Date]()
 
     fileprivate func modificationDate(forFileAtPath path: String) -> Date? {
-        return stubbedModificationDateByPath[path]
+        stubbedModificationDateByPath[path]
     }
 
     fileprivate func isFile(atPath path: String) -> Bool {
@@ -74,7 +74,7 @@ final class LinterCacheTests: SwiftLintTestCase {
     private var cache = LinterCache(fileManager: TestFileManager())
 
     private func makeCacheTestHelper(dict: [String: Any]) -> CacheTestHelper {
-        return CacheTestHelper(dict: dict, cache: cache)
+        CacheTestHelper(dict: dict, cache: cache)
     }
 
     private func cacheAndValidate(violations: [StyleViolation], forFile: String, configuration: Configuration,

--- a/Tests/SwiftLintFrameworkTests/ObjectLiteralRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ObjectLiteralRuleTests.swift
@@ -21,7 +21,7 @@ final class ObjectLiteralRuleTests: SwiftLintTestCase {
     }
 
     private var allTriggeringExamples: [Example] {
-        return imageLiteralTriggeringExamples + colorLiteralTriggeringExamples
+        imageLiteralTriggeringExamples + colorLiteralTriggeringExamples
     }
 
     // MARK: - Test Methods

--- a/Tests/SwiftLintFrameworkTests/ReporterTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ReporterTests.swift
@@ -12,7 +12,7 @@ final class ReporterTests: SwiftLintTestCase {
     }
 
     private func stringFromFile(_ filename: String) -> String {
-        return SwiftLintFile(path: "\(testResourcesPath)/\(filename)")!.contents
+        SwiftLintFile(path: "\(testResourcesPath)/\(filename)")!.contents
     }
 
     private func generateViolations() -> [StyleViolation] {

--- a/Tests/SwiftLintFrameworkTests/RuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleTests.swift
@@ -16,7 +16,7 @@ struct RuleWithLevelsMock: Rule {
         try self.configuration.apply(configuration: configuration)
     }
 
-    func validate(file: SwiftLintFile) -> [StyleViolation] { return [] }
+    func validate(file: SwiftLintFile) -> [StyleViolation] { [] }
 }
 
 final class RuleTests: SwiftLintTestCase {
@@ -30,7 +30,7 @@ final class RuleTests: SwiftLintTestCase {
         init(configuration: Any) throws { self.init() }
 
         func validate(file: SwiftLintFile) -> [StyleViolation] {
-            return []
+            []
         }
     }
 
@@ -44,7 +44,7 @@ final class RuleTests: SwiftLintTestCase {
         init(configuration: Any) throws { self.init() }
 
         func validate(file: SwiftLintFile) -> [StyleViolation] {
-            return []
+            []
         }
     }
 
@@ -61,7 +61,7 @@ final class RuleTests: SwiftLintTestCase {
             try self.configuration.apply(configuration: configuration)
         }
 
-        func validate(file: SwiftLintFile) -> [StyleViolation] { return [] }
+        func validate(file: SwiftLintFile) -> [StyleViolation] { [] }
     }
 
     func testRuleIsEqualTo() {

--- a/Tests/SwiftLintFrameworkTests/YamlSwiftLintTests.swift
+++ b/Tests/SwiftLintFrameworkTests/YamlSwiftLintTests.swift
@@ -39,6 +39,6 @@ final class YamlSwiftLintTests: SwiftLintTestCase {
     }
 
     private func getTestYaml() throws -> String {
-        return try String(contentsOfFile: "\(testResourcesPath)/test.yml", encoding: .utf8)
+        try String(contentsOfFile: "\(testResourcesPath)/test.yml", encoding: .utf8)
     }
 }

--- a/Tests/SwiftLintTestHelpers/TestHelpers.swift
+++ b/Tests/SwiftLintTestHelpers/TestHelpers.swift
@@ -43,7 +43,7 @@ private extension SwiftLintFile {
 
 public extension String {
     func stringByAppendingPathComponent(_ pathComponent: String) -> String {
-        return bridge().appendingPathComponent(pathComponent)
+        bridge().appendingPathComponent(pathComponent)
     }
 }
 
@@ -82,12 +82,12 @@ public func violations(_ example: Example, config inputConfig: Configuration = C
 public extension Collection where Element == String {
     func violations(config: Configuration = Configuration.default, requiresFileOnDisk: Bool = false)
         -> [StyleViolation] {
-            return map { SwiftLintFile.testFile(withContents: $0, persistToDisk: requiresFileOnDisk) }
+            map { SwiftLintFile.testFile(withContents: $0, persistToDisk: requiresFileOnDisk) }
                 .violations(config: config, requiresFileOnDisk: requiresFileOnDisk)
     }
 
     func corrections(config: Configuration = Configuration.default, requiresFileOnDisk: Bool = false) -> [Correction] {
-        return map { SwiftLintFile.testFile(withContents: $0, persistToDisk: requiresFileOnDisk) }
+        map { SwiftLintFile.testFile(withContents: $0, persistToDisk: requiresFileOnDisk) }
             .corrections(config: config, requiresFileOnDisk: requiresFileOnDisk)
     }
 }
@@ -123,7 +123,7 @@ public extension Collection where Element: SwiftLintFile {
 
 private extension Collection where Element == StyleViolation {
     func withoutFiles() -> [StyleViolation] {
-        return map { violation in
+        map { violation in
             let locationWithoutFile = Location(file: nil, line: violation.location.line,
                                                character: violation.location.character)
             return violation.with(location: locationWithoutFile)
@@ -133,7 +133,7 @@ private extension Collection where Element == StyleViolation {
 
 private extension Collection where Element == Correction {
     func withoutFiles() -> [Correction] {
-        return map { correction in
+        map { correction in
             let locationWithoutFile = Location(file: nil, line: correction.location.line,
                                                character: correction.location.character)
             return Correction(ruleDescription: correction.ruleDescription, location: locationWithoutFile)
@@ -146,7 +146,7 @@ public extension Collection where Element == Example {
     ///
     /// - returns: A new `Array`.
     func removingViolationMarkers() -> [Element] {
-        return map { $0.removingViolationMarkers() }
+        map { $0.removingViolationMarkers() }
     }
 }
 
@@ -260,7 +260,7 @@ private extension Configuration {
 
 private extension String {
     func toStringLiteral() -> String {
-        return "\"" + replacingOccurrences(of: "\n", with: "\\n") + "\""
+        "\"" + replacingOccurrences(of: "\n", with: "\\n") + "\""
     }
 }
 
@@ -307,11 +307,11 @@ private func testCorrection(_ correction: (Example, Example),
 }
 
 private func addEmoji(_ example: Example) -> Example {
-    return example.with(code: "/* 👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦 */\n\(example.code)")
+    example.with(code: "/* 👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦 */\n\(example.code)")
 }
 
 private func addShebang(_ example: Example) -> Example {
-    return example.with(code: "#!/usr/bin/env swift\n\(example.code)")
+    example.with(code: "#!/usr/bin/env swift\n\(example.code)")
 }
 
 public extension XCTestCase {
@@ -372,7 +372,7 @@ public extension XCTestCase {
                            requiresFileOnDisk: ruleDescription.requiresFileOnDisk)
         }
         func makeViolations(_ example: Example) -> [StyleViolation] {
-            return violations(example, config: config, requiresFileOnDisk: ruleDescription.requiresFileOnDisk)
+            violations(example, config: config, requiresFileOnDisk: ruleDescription.requiresFileOnDisk)
         }
 
         let ruleDescription = ruleDescription.focused()
@@ -574,6 +574,6 @@ private struct FocusedRuleDescription {
 
 private extension RuleDescription {
     func focused() -> FocusedRuleDescription {
-        return FocusedRuleDescription(rule: self)
+        FocusedRuleDescription(rule: self)
     }
 }


### PR DESCRIPTION

The only changes here are

1) Enabling (or not disabling) `implicit_return`
2) Fix all existing 300+ violations
3) Whitespace adjustments for parameter alignment where removing `return` threw things out.
