### PR TITLE
Enable `multiline_parameters` rule, and fix all cases

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -32,7 +32,6 @@ disabled_rules:
   - multiline_arguments
   - multiline_arguments_brackets
   - multiline_function_chains
-  - multiline_parameters
   - multiline_parameters_brackets
   - no_extension_access_modifier
   - no_grouping_extension

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
@@ -3,7 +3,8 @@ import SwiftSyntax
 private func embedInSwitch(
     _ text: String,
     case: String = "case .bar",
-    file: StaticString = #filePath, line: UInt = #line) -> Example {
+    file: StaticString = #filePath,
+    line: UInt = #line) -> Example {
     Example("""
         switch foo {
         \(`case`):

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityLabelForImageRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityLabelForImageRule.swift
@@ -25,7 +25,8 @@ struct AccessibilityLabelForImageRule: ASTRule, OptInRule {
 
     // MARK: AST Rule
 
-    func validate(file: SwiftLintFile, kind: SwiftDeclarationKind,
+    func validate(file: SwiftLintFile,
+                  kind: SwiftDeclarationKind,
                   dictionary: SourceKittenDictionary) -> [StyleViolation] {
         // Only proceed to check View structs.
         guard kind == .struct,

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityTraitForButtonRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityTraitForButtonRule.swift
@@ -23,7 +23,8 @@ struct AccessibilityTraitForButtonRule: ASTRule, OptInRule {
 
     // MARK: AST Rule
 
-    func validate(file: SwiftLintFile, kind: SwiftDeclarationKind,
+    func validate(file: SwiftLintFile,
+                  kind: SwiftDeclarationKind,
                   dictionary: SourceKittenDictionary) -> [StyleViolation] {
         // Only proceed to check View structs.
         guard kind == .struct,

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/CaptureVariableRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/CaptureVariableRule.swift
@@ -158,11 +158,9 @@ struct CaptureVariableRule: AnalyzerRule, CollectingRule {
         file.declaredVariables(compilerArguments: compilerArguments)
     }
 
-    func validate(
-        file: SwiftLintFile,
-        collectedInfo: [SwiftLintFile: Self.FileInfo],
-        compilerArguments: [String]
-    ) -> [StyleViolation] {
+    func validate(file: SwiftLintFile,
+                  collectedInfo: [SwiftLintFile: Self.FileInfo],
+                  compilerArguments: [String]) -> [StyleViolation] {
         file.captureListVariables(compilerArguments: compilerArguments)
             .filter { capturedVariable in collectedInfo.values.contains { $0.contains(capturedVariable.usr) } }
             .map {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/CaptureVariableRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/CaptureVariableRule.swift
@@ -158,8 +158,11 @@ struct CaptureVariableRule: AnalyzerRule, CollectingRule {
         file.declaredVariables(compilerArguments: compilerArguments)
     }
 
-    func validate(file: SwiftLintFile, collectedInfo: [SwiftLintFile: Self.FileInfo],
-                  compilerArguments: [String]) -> [StyleViolation] {
+    func validate(
+        file: SwiftLintFile,
+        collectedInfo: [SwiftLintFile: Self.FileInfo],
+        compilerArguments: [String]
+    ) -> [StyleViolation] {
         file.captureListVariables(compilerArguments: compilerArguments)
             .filter { capturedVariable in collectedInfo.values.contains { $0.contains(capturedVariable.usr) } }
             .map {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/LocalDocCommentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/LocalDocCommentRule.swift
@@ -53,7 +53,8 @@ private extension LocalDocCommentRule {
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         private let docCommentRanges: [ByteSourceRange]
 
-        init(configuration: ConfigurationType, file: SwiftLintFile,
+        init(configuration: ConfigurationType,
+             file: SwiftLintFile,
              classifications: [SyntaxClassifiedRange]) {
             self.docCommentRanges = classifications
                 .filter { $0.kind == .docLineComment || $0.kind == .docBlockComment }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/OverrideInExtensionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/OverrideInExtensionRule.swift
@@ -50,7 +50,8 @@ private extension OverrideInExtensionRule {
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         private let allowedExtensions: Set<String>
 
-        init(configuration: ConfigurationType, file: SwiftLintFile,
+        init(configuration: ConfigurationType,
+             file: SwiftLintFile,
              allowedExtensions: Set<String>) {
             self.allowedExtensions = allowedExtensions
             super.init(configuration: configuration, file: file)

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedDeclarationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedDeclarationRule.swift
@@ -54,7 +54,8 @@ struct UnusedDeclarationRule: AnalyzerRule, CollectingRule {
         )
     }
 
-    func validate(file: SwiftLintFile, collectedInfo: [SwiftLintFile: Self.FileUSRs],
+    func validate(file: SwiftLintFile,
+                  collectedInfo: [SwiftLintFile: Self.FileUSRs],
                   compilerArguments _: [String]) -> [StyleViolation] {
         let allReferencedUSRs = collectedInfo.values.reduce(into: Set()) { $0.formUnion($1.referenced) }
         return violationOffsets(declaredUSRs: collectedInfo[file]?.declared ?? [],
@@ -106,17 +107,20 @@ private extension SwiftLintFile {
         })
     }
 
-    func declaredUSRs(index: SourceKittenDictionary, editorOpen: SourceKittenDictionary,
-                      compilerArguments: [String], configuration: UnusedDeclarationConfiguration)
-    -> Set<UnusedDeclarationRule.DeclaredUSR> {
+    func declaredUSRs(index: SourceKittenDictionary,
+                      editorOpen: SourceKittenDictionary,
+                      compilerArguments: [String],
+                      configuration: UnusedDeclarationConfiguration) -> Set<UnusedDeclarationRule.DeclaredUSR> {
         Set(index.traverseEntitiesDepthFirst { _, indexEntity in
             self.declaredUSR(indexEntity: indexEntity, editorOpen: editorOpen, compilerArguments: compilerArguments,
                              configuration: configuration)
         })
     }
 
-    func declaredUSR(indexEntity: SourceKittenDictionary, editorOpen: SourceKittenDictionary,
-                     compilerArguments: [String], configuration: UnusedDeclarationConfiguration)
+    func declaredUSR(indexEntity: SourceKittenDictionary,
+                     editorOpen: SourceKittenDictionary,
+                     compilerArguments: [String],
+                     configuration: UnusedDeclarationConfiguration)
     -> UnusedDeclarationRule.DeclaredUSR? {
         guard let stringKind = indexEntity.kind,
               stringKind.starts(with: "source.lang.swift.decl."),

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedDeclarationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedDeclarationRule.swift
@@ -120,8 +120,7 @@ private extension SwiftLintFile {
     func declaredUSR(indexEntity: SourceKittenDictionary,
                      editorOpen: SourceKittenDictionary,
                      compilerArguments: [String],
-                     configuration: UnusedDeclarationConfiguration)
-    -> UnusedDeclarationRule.DeclaredUSR? {
+                     configuration: UnusedDeclarationConfiguration) -> UnusedDeclarationRule.DeclaredUSR? {
         guard let stringKind = indexEntity.kind,
               stringKind.starts(with: "source.lang.swift.decl."),
               !stringKind.contains(".accessor."),

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileHeaderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileHeaderConfiguration.swift
@@ -65,8 +65,10 @@ struct FileHeaderConfiguration: SeverityBasedRuleConfiguration {
         }
     }
 
-    private func makeRegex(for file: SwiftLintFile, using pattern: String,
-                           options: NSRegularExpression.Options, escapeFileName: Bool) -> NSRegularExpression? {
+    private func makeRegex(for file: SwiftLintFile,
+                           using pattern: String,
+                           options: NSRegularExpression.Options,
+                           escapeFileName: Bool) -> NSRegularExpression? {
         // Recompile the regex for this file...
         let replacedPattern = file.path.map { path in
             let fileName = path.bridge().lastPathComponent

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ClosureEndIndentationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ClosureEndIndentationRule.swift
@@ -119,7 +119,8 @@ extension ClosureEndIndentationRule {
         }
     }
 
-    private func violations(in file: SwiftLintFile, of kind: SwiftExpressionKind,
+    private func violations(in file: SwiftLintFile,
+                            of kind: SwiftExpressionKind,
                             dictionary: SourceKittenDictionary) -> [Violation] {
         guard kind == .call else {
             return []
@@ -269,7 +270,8 @@ extension ClosureEndIndentationRule {
     }
 
     private func isSingleLineClosure(dictionary: SourceKittenDictionary,
-                                     endPosition: ByteCount, file: SwiftLintFile) -> Bool {
+                                     endPosition: ByteCount,
+                                     file: SwiftLintFile) -> Bool {
         let contents = file.stringView
 
         guard let start = dictionary.bodyOffset,
@@ -282,7 +284,8 @@ extension ClosureEndIndentationRule {
     }
 
     private func containsSingleLineClosure(dictionary: SourceKittenDictionary,
-                                           endPosition: ByteCount, file: SwiftLintFile) -> Bool {
+                                           endPosition: ByteCount,
+                                           file: SwiftLintFile) -> Bool {
         let contents = file.stringView
 
         guard let closure = trailingClosure(dictionary: dictionary, file: file),

--- a/Source/SwiftLintBuiltInRules/Rules/Style/EmptyEnumArgumentsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/EmptyEnumArgumentsRule.swift
@@ -3,7 +3,8 @@ import SwiftSyntax
 private func wrapInSwitch(
     variable: String = "foo",
     _ str: String,
-    file: StaticString = #filePath, line: UInt = #line) -> Example {
+    file: StaticString = #filePath,
+    line: UInt = #line) -> Example {
     Example(
         """
         switch \(variable) {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/LiteralExpressionEndIndentationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/LiteralExpressionEndIndentationRule.swift
@@ -220,7 +220,8 @@ extension LiteralExpressionEndIndentationRule {
         }
     }
 
-    private func violation(in file: SwiftLintFile, of kind: SwiftExpressionKind,
+    private func violation(in file: SwiftLintFile,
+                           of kind: SwiftExpressionKind,
                            dictionary: SourceKittenDictionary) -> Violation? {
         guard kind == .dictionary || kind == .array else {
             return nil

--- a/Source/SwiftLintCore/Extensions/Configuration+LintableFiles.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+LintableFiles.swift
@@ -16,7 +16,8 @@ extension Configuration {
     /// - parameter excludeByPrefix: Whether or not uses excluding by prefix algorithm.
     ///
     /// - returns: Files to lint.
-    public func lintableFiles(inPath path: String, forceExclude: Bool,
+    public func lintableFiles(inPath path: String,
+                              forceExclude: Bool,
                               excludeBy: ExcludeBy) -> [SwiftLintFile] {
         lintablePaths(inPath: path, forceExclude: forceExclude, excludeBy: excludeBy)
             .compactMap(SwiftLintFile.init(pathDeferringReading:))

--- a/Source/SwiftLintCore/Models/Command.swift
+++ b/Source/SwiftLintCore/Models/Command.swift
@@ -67,8 +67,12 @@ public struct Command: Equatable {
     ///                              defined.
     /// - parameter modifier:        This command's modifier, if any.
     /// - parameter trailingComment: The comment following this command's `-` delimiter, if any.
-    public init(action: Action, ruleIdentifiers: Set<RuleIdentifier> = [], line: Int = 0,
-                character: Int? = nil, modifier: Modifier? = nil, trailingComment: String? = nil) {
+    public init(action: Action,
+                ruleIdentifiers: Set<RuleIdentifier> = [],
+                line: Int = 0,
+                character: Int? = nil,
+                modifier: Modifier? = nil,
+                trailingComment: String? = nil) {
         self.action = action
         self.ruleIdentifiers = ruleIdentifiers
         self.line = line

--- a/Source/SwiftLintCore/Models/Example.swift
+++ b/Source/SwiftLintCore/Models/Example.swift
@@ -59,9 +59,15 @@ public extension Example {
     ///                           Defaults to the file where this initializer is called.
     ///   - line:                 The line in the file where the example is located.
     ///                           Defaults to the line where this initializer is called.
-    init(_ code: String, configuration: [String: any Sendable]? = nil, testMultiByteOffsets: Bool = true,
-         testWrappingInComment: Bool = true, testWrappingInString: Bool = true, testDisableCommand: Bool = true,
-         testOnLinux: Bool = true, file: StaticString = #filePath, line: UInt = #line,
+    init(_ code: String,
+         configuration: [String: any Sendable]? = nil,
+         testMultiByteOffsets: Bool = true,
+         testWrappingInComment: Bool = true,
+         testWrappingInString: Bool = true,
+         testDisableCommand: Bool = true,
+         testOnLinux: Bool = true,
+         file: StaticString = #filePath,
+         line: UInt = #line,
          excludeFromDocumentation: Bool = false) {
         self.code = code
         self.configuration = configuration

--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -57,7 +57,9 @@ private extension Rule {
 
     // As we need the configuration to get custom identifiers.
     // swiftlint:disable:next function_parameter_count
-    func lint(file: SwiftLintFile, regions: [Region], benchmark: Bool,
+    func lint(file: SwiftLintFile,
+              regions: [Region],
+              benchmark: Bool,
               storage: RuleStorage,
               superfluousDisableCommandRule: SuperfluousDisableCommandRule?,
               compilerArguments: [String]) -> LintResult? {
@@ -143,7 +145,9 @@ public struct Linter {
     /// - parameter configuration:     The SwiftLint configuration to apply to this linter.
     /// - parameter cache:             The persisted cache to use for this linter.
     /// - parameter compilerArguments: The compiler arguments to use for this linter if it is to execute analyzer rules.
-    public init(file: SwiftLintFile, configuration: Configuration = Configuration.default, cache: LinterCache? = nil,
+    public init(file: SwiftLintFile,
+                configuration: Configuration = Configuration.default,
+                cache: LinterCache? = nil,
                 compilerArguments: [String] = []) {
         self.file = file
         self.cache = cache

--- a/Source/SwiftLintCore/Models/RuleDescription.swift
+++ b/Source/SwiftLintCore/Models/RuleDescription.swift
@@ -71,9 +71,13 @@ public struct RuleDescription: Equatable, Sendable {
     /// - parameter corrections:           Sets the description's `corrections` property.
     /// - parameter deprecatedAliases:     Sets the description's `deprecatedAliases` property.
     /// - parameter requiresFileOnDisk:    Sets the description's `requiresFileOnDisk` property.
-    public init(identifier: String, name: String, description: String, kind: RuleKind,
+    public init(identifier: String,
+                name: String,
+                description: String,
+                kind: RuleKind,
                 minSwiftVersion: SwiftVersion = .five,
-                nonTriggeringExamples: [Example] = [], triggeringExamples: [Example] = [],
+                nonTriggeringExamples: [Example] = [],
+                triggeringExamples: [Example] = [],
                 corrections: [Example: Example] = [:],
                 deprecatedAliases: Set<String> = [],
                 requiresFileOnDisk: Bool = false) {

--- a/Source/SwiftLintCore/Protocols/CollectingRule.swift
+++ b/Source/SwiftLintCore/Protocols/CollectingRule.swift
@@ -119,8 +119,8 @@ package protocol CollectingCorrectableRule: CollectingRule, CorrectableRule {
 
 package extension CollectingCorrectableRule {
     func correct(file: SwiftLintFile,
-        collectedInfo: [SwiftLintFile: FileInfo],
-        compilerArguments _: [String]) -> [Correction] {
+                 collectedInfo: [SwiftLintFile: FileInfo],
+                 compilerArguments _: [String]) -> [Correction] {
         correct(file: file, collectedInfo: collectedInfo)
     }
 

--- a/Source/SwiftLintCore/Protocols/CollectingRule.swift
+++ b/Source/SwiftLintCore/Protocols/CollectingRule.swift
@@ -118,11 +118,9 @@ package protocol CollectingCorrectableRule: CollectingRule, CorrectableRule {
 }
 
 package extension CollectingCorrectableRule {
-    func correct(
-        file: SwiftLintFile,
+    func correct(file: SwiftLintFile,
         collectedInfo: [SwiftLintFile: FileInfo],
-        compilerArguments _: [String]
-    ) -> [Correction] {
+        compilerArguments _: [String]) -> [Correction] {
         correct(file: file, collectedInfo: collectedInfo)
     }
 

--- a/Source/SwiftLintCore/Protocols/CollectingRule.swift
+++ b/Source/SwiftLintCore/Protocols/CollectingRule.swift
@@ -29,7 +29,8 @@ public protocol CollectingRule: AnyCollectingRule {
     /// - parameter compilerArguments: The compiler arguments needed to compile this file.
     ///
     /// - returns: All style violations to the rule's expectations.
-    func validate(file: SwiftLintFile, collectedInfo: [SwiftLintFile: FileInfo],
+    func validate(file: SwiftLintFile,
+                  collectedInfo: [SwiftLintFile: FileInfo],
                   compilerArguments: [String]) -> [StyleViolation]
 
     /// Executes the rule on a file after collecting file info for all files and returns any violations to the rule's
@@ -56,7 +57,9 @@ public extension CollectingRule {
     func collectInfo(for file: SwiftLintFile, compilerArguments _: [String]) -> FileInfo {
         collectInfo(for: file)
     }
-    func validate(file: SwiftLintFile, collectedInfo: [SwiftLintFile: FileInfo],
+
+    func validate(file: SwiftLintFile,
+                  collectedInfo: [SwiftLintFile: FileInfo],
                   compilerArguments _: [String]) -> [StyleViolation] {
         validate(file: file, collectedInfo: collectedInfo)
     }
@@ -98,7 +101,8 @@ package protocol CollectingCorrectableRule: CollectingRule, CorrectableRule {
     /// - parameter compilerArguments: The compiler arguments needed to compile this file.
     ///
     /// - returns: All corrections that were applied.
-    func correct(file: SwiftLintFile, collectedInfo: [SwiftLintFile: FileInfo],
+    func correct(file: SwiftLintFile,
+                 collectedInfo: [SwiftLintFile: FileInfo],
                  compilerArguments: [String]) -> [Correction]
 
     /// Attempts to correct the violations to this rule in the specified file after collecting file info for all files
@@ -114,8 +118,11 @@ package protocol CollectingCorrectableRule: CollectingRule, CorrectableRule {
 }
 
 package extension CollectingCorrectableRule {
-    func correct(file: SwiftLintFile, collectedInfo: [SwiftLintFile: FileInfo],
-                 compilerArguments _: [String]) -> [Correction] {
+    func correct(
+        file: SwiftLintFile,
+        collectedInfo: [SwiftLintFile: FileInfo],
+        compilerArguments _: [String]
+    ) -> [Correction] {
         correct(file: file, collectedInfo: collectedInfo)
     }
 

--- a/Source/SwiftLintCore/Protocols/Rule.swift
+++ b/Source/SwiftLintCore/Protocols/Rule.swift
@@ -82,8 +82,7 @@ public extension Rule {
         try self.configuration.apply(configuration: configuration)
     }
 
-    func validate(file: SwiftLintFile, using _: RuleStorage,
-                  compilerArguments: [String]) -> [StyleViolation] {
+    func validate(file: SwiftLintFile, using _: RuleStorage, compilerArguments: [String]) -> [StyleViolation] {
         validate(file: file, compilerArguments: compilerArguments)
     }
 

--- a/Source/SwiftLintCore/Reporters/HTMLReporter.swift
+++ b/Source/SwiftLintCore/Reporters/HTMLReporter.swift
@@ -21,7 +21,8 @@ struct HTMLReporter: Reporter {
     // MARK: - Internal
 
     // swiftlint:disable:next function_body_length
-    internal static func generateReport(_ violations: [StyleViolation], swiftlintVersion: String,
+    internal static func generateReport(_ violations: [StyleViolation],
+                                        swiftlintVersion: String,
                                         dateString: String) -> String {
         let rows = violations.enumerated()
             .map { generateSingleRow(for: $1, at: $0 + 1) }

--- a/Source/swiftlint/Commands/Rules.swift
+++ b/Source/swiftlint/Commands/Rules.swift
@@ -93,7 +93,8 @@ extension SwiftLint {
             }
         }
 
-        private func createInstance(of ruleType: any Rule.Type, using config: Configuration,
+        private func createInstance(of ruleType: any Rule.Type,
+                                    using config: Configuration,
                                     configure: Bool) -> any Rule {
             configure
                 ? config.configuredRule(forID: ruleType.identifier) ?? ruleType.init()

--- a/Source/swiftlint/Extensions/Configuration+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Configuration+CommandLine.swift
@@ -252,7 +252,9 @@ extension Configuration {
         }
     }
 
-    func visitLintableFiles(options: LintOrAnalyzeOptions, cache: LinterCache? = nil, storage: RuleStorage,
+    func visitLintableFiles(options: LintOrAnalyzeOptions,
+                            cache: LinterCache? = nil,
+                            storage: RuleStorage,
                             visitorBlock: @escaping (CollectedLinter) async -> Void) async throws -> [SwiftLintFile] {
         let visitor = try LintableFilesVisitor.create(options, cache: cache,
                                                       allowZeroLintableFiles: allowZeroLintableFiles,

--- a/Source/swiftlint/Helpers/LintableFilesVisitor.swift
+++ b/Source/swiftlint/Helpers/LintableFilesVisitor.swift
@@ -83,10 +83,18 @@ struct LintableFilesVisitor {
     let mode: LintOrAnalyzeModeWithCompilerArguments
     let block: (CollectedLinter) async -> Void
 
-    private init(paths: [String], action: String, useSTDIN: Bool, quiet: Bool, showProgressBar: Bool,
-                 useScriptInputFiles: Bool, forceExclude: Bool, useExcludingByPrefix: Bool,
-                 cache: LinterCache?, compilerInvocations: CompilerInvocations?,
-                 allowZeroLintableFiles: Bool, block: @escaping (CollectedLinter) async -> Void) {
+    private init(paths: [String],
+                 action: String,
+                 useSTDIN: Bool,
+                 quiet: Bool,
+                 showProgressBar: Bool,
+                 useScriptInputFiles: Bool,
+                 forceExclude: Bool,
+                 useExcludingByPrefix: Bool,
+                 cache: LinterCache?,
+                 compilerInvocations: CompilerInvocations?,
+                 allowZeroLintableFiles: Bool,
+                 block: @escaping (CollectedLinter) async -> Void) {
         self.paths = resolveParamsFiles(args: paths)
         self.action = action
         self.useSTDIN = useSTDIN

--- a/Tests/SwiftLintFrameworkTests/CollectingRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CollectingRuleTests.swift
@@ -124,7 +124,8 @@ final class CollectingRuleTests: SwiftLintTestCase {
                     return []
             }
 
-            func correct(file: SwiftLintFile, collectedInfo: [SwiftLintFile: String],
+            func correct(file: SwiftLintFile,
+                         collectedInfo: [SwiftLintFile: String],
                          compilerArguments _: [String]) -> [Correction] {
                 collectedInfo[file] == "baz"
                     ? [Correction(ruleDescription: Spec.description, location: Location(file: file, byteOffset: 2))]

--- a/Tests/SwiftLintFrameworkTests/FileNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FileNameRuleTests.swift
@@ -4,8 +4,10 @@ import XCTest
 private let fixturesDirectory = "\(TestResources.path)/FileNameRuleFixtures"
 
 final class FileNameRuleTests: SwiftLintTestCase {
-    private func validate(fileName: String, excludedOverride: [String]? = nil,
-                          prefixPattern: String? = nil, suffixPattern: String? = nil,
+    private func validate(fileName: String,
+                          excludedOverride: [String]? = nil,
+                          prefixPattern: String? = nil,
+                          suffixPattern: String? = nil,
                           nestedTypeSeparator: String? = nil) throws -> [StyleViolation] {
         let file = SwiftLintFile(path: fixturesDirectory.stringByAppendingPathComponent(fileName))!
         let rule: FileNameRule

--- a/Tests/SwiftLintFrameworkTests/LinterCacheTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LinterCacheTests.swift
@@ -77,8 +77,11 @@ final class LinterCacheTests: SwiftLintTestCase {
         CacheTestHelper(dict: dict, cache: cache)
     }
 
-    private func cacheAndValidate(violations: [StyleViolation], forFile: String, configuration: Configuration,
-                                  file: StaticString = #filePath, line: UInt = #line) {
+    private func cacheAndValidate(violations: [StyleViolation],
+                                  forFile: String,
+                                  configuration: Configuration,
+                                  file: StaticString = #filePath,
+                                  line: UInt = #line) {
         cache.cache(violations: violations, forFile: forFile, configuration: configuration)
         cache = cache.flushed()
         XCTAssertEqual(cache.violations(forFile: forFile, configuration: configuration)!,
@@ -86,7 +89,8 @@ final class LinterCacheTests: SwiftLintTestCase {
     }
 
     private func cacheAndValidateNoViolationsTwoFiles(configuration: Configuration,
-                                                      file: StaticString = #filePath, line: UInt = #line) {
+                                                      file: StaticString = #filePath,
+                                                      line: UInt = #line) {
         let (file1, file2) = ("file1.swift", "file2.swift")
         // swiftlint:disable:next force_cast
         let fileManager = cache.fileManager as! TestFileManager
@@ -96,8 +100,10 @@ final class LinterCacheTests: SwiftLintTestCase {
         cacheAndValidate(violations: [], forFile: file2, configuration: configuration, file: file, line: line)
     }
 
-    private func validateNewConfigDoesntHitCache(dict: [String: Any], initialConfig: Configuration,
-                                                 file: StaticString = #filePath, line: UInt = #line) throws {
+    private func validateNewConfigDoesntHitCache(dict: [String: Any],
+                                                 initialConfig: Configuration,
+                                                 file: StaticString = #filePath,
+                                                 line: UInt = #line) throws {
         let newConfig = try Configuration(dict: dict)
         let (file1, file2) = ("file1.swift", "file2.swift")
 

--- a/Tests/SwiftLintTestHelpers/TestHelpers.swift
+++ b/Tests/SwiftLintTestHelpers/TestHelpers.swift
@@ -60,7 +60,8 @@ public extension Configuration {
     }
 }
 
-public func violations(_ example: Example, config inputConfig: Configuration = Configuration.default,
+public func violations(_ example: Example,
+                       config inputConfig: Configuration = Configuration.default,
                        requiresFileOnDisk: Bool = false) -> [StyleViolation] {
     SwiftLintFile.clearCaches()
     let config = inputConfig.applyingConfiguration(from: example)
@@ -264,7 +265,8 @@ private extension String {
     }
 }
 
-public func makeConfig(_ ruleConfiguration: Any?, _ identifier: String,
+public func makeConfig(_ ruleConfiguration: Any?,
+                       _ identifier: String,
                        skipDisableCommandTests: Bool = false) -> Configuration? {
     let superfluousDisableCommandRuleIdentifier = SuperfluousDisableCommandRule.description.identifier
     let identifiers: Set<String> = skipDisableCommandTests ? [identifier]
@@ -433,8 +435,10 @@ public extension XCTestCase {
         }
     }
 
-    func verifyCorrections(_ ruleDescription: RuleDescription, config: Configuration,
-                           disableCommands: [String], testMultiByteOffsets: Bool,
+    func verifyCorrections(_ ruleDescription: RuleDescription,
+                           config: Configuration,
+                           disableCommands: [String],
+                           testMultiByteOffsets: Bool,
                            parserDiagnosticsDisabledForTests: Bool = true) {
         let ruleDescription = ruleDescription.focused()
 
@@ -459,8 +463,10 @@ public extension XCTestCase {
         }
     }
 
-    private func verifyExamples(triggers: [Example], nonTriggers: [Example],
-                                configuration config: Configuration, requiresFileOnDisk: Bool) {
+    private func verifyExamples(triggers: [Example],
+                                nonTriggers: [Example],
+                                configuration config: Configuration,
+                                requiresFileOnDisk: Bool) {
         // Non-triggering examples don't violate
         for nonTrigger in nonTriggers {
             let unexpectedViolations = violations(nonTrigger, config: config,


### PR DESCRIPTION
There were ~40 violations

In cases like 

```
func validate(file: SwiftLintFile, kind: SwiftDeclarationKind,
                  dictionary: SourceKittenDictionary) -> [StyleViolation] {
```

I mostly went for 

```
func validate(file: SwiftLintFile, 
              kind: SwiftDeclarationKind,
              dictionary: SourceKittenDictionary) -> [StyleViolation] {
```

instead of 

```
func validate(
    file: SwiftLintFile, 
     kind: SwiftDeclarationKind,
    dictionary: SourceKittenDictionary
) -> [StyleViolation] {
```

The latter would be enforced by `multiline_parameters_brackets` - we have about 200 violations of that rule, and about ~100 cases that comply with it (regex search for `func [a-zA-z]+\($`, but a lot of the hits may be examples), so I'm inclined to leave `multiline_parameters_brackets` off unless we really want to commit to the style in that last example.
