### PR TITLE
Add `--only-rule` command line option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,13 @@
   [Ian Leitch](https://github.com/ileitch)
   [#5613](https://github.com/realm/SwiftLint/issues/5613)
 
+* Add new `--only-rule` command line option for the `lint` and `analyze`,
+  subcommands that overrides configuration file rule enablement and
+  disablement, in particular to facilitate running `--fix` for single rules
+  without having to temporarily edit the configuration file.
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#5666](https://github.com/realm/SwiftLint/issues/5666)
+
 #### Bug Fixes
 
 * Fix a few false positives and negatives by updating the parser to support

--- a/Source/SwiftLintCore/Extensions/Configuration+FileGraph.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+FileGraph.swift
@@ -41,6 +41,7 @@ package extension Configuration {
         // MARK: - Methods
         internal mutating func resultingConfiguration(
             enableAllRules: Bool,
+            onlyRule: String?,
             cachePath: String?
         ) throws -> Configuration {
             // Build if needed
@@ -51,6 +52,7 @@ package extension Configuration {
             return try merged(
                 configurationData: try validate(),
                 enableAllRules: enableAllRules,
+                onlyRule: onlyRule,
                 cachePath: cachePath
             )
         }
@@ -248,6 +250,7 @@ package extension Configuration {
         private func merged(
             configurationData: [(configurationDict: [String: Any], rootDirectory: String)],
             enableAllRules: Bool,
+            onlyRule: String?,
             cachePath: String?
         ) throws -> Configuration {
             // Split into first & remainder; use empty dict for first if the array is empty
@@ -258,6 +261,7 @@ package extension Configuration {
             var firstConfiguration = try Configuration(
                 dict: firstConfigurationData.configurationDict,
                 enableAllRules: enableAllRules,
+                onlyRule: onlyRule,
                 cachePath: cachePath
             )
 
@@ -276,6 +280,7 @@ package extension Configuration {
                     parentConfiguration: $0,
                     dict: $1.configurationDict,
                     enableAllRules: enableAllRules,
+                    onlyRule: onlyRule,
                     cachePath: cachePath
                 )
                 childConfiguration.fileGraph = Self(rootDirectory: $1.rootDirectory)

--- a/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
@@ -42,6 +42,7 @@ extension Configuration {
         dict: [String: Any],
         ruleList: RuleList = RuleRegistry.shared.list,
         enableAllRules: Bool = false,
+        onlyRule: String? = nil,
         cachePath: String? = nil
     ) throws {
         func defaultStringArray(_ object: Any?) -> [String] { [String].array(of: object) ?? [] }

--- a/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
@@ -74,18 +74,21 @@ extension Configuration {
 
         let rulesMode = try RulesMode(
             enableAllRules: enableAllRules,
+            onlyRule: onlyRule,
             onlyRules: onlyRules,
             optInRules: optInRules,
             disabledRules: disabledRules,
             analyzerRules: analyzerRules
         )
 
-        Self.validateConfiguredRulesAreEnabled(
-            parentConfiguration: parentConfiguration,
-            configurationDictionary: dict,
-            ruleList: ruleList,
-            rulesMode: rulesMode
-        )
+        if onlyRule == nil {
+            Self.validateConfiguredRulesAreEnabled(
+                parentConfiguration: parentConfiguration,
+                configurationDictionary: dict,
+                ruleList: ruleList,
+                rulesMode: rulesMode
+            )
+        }
 
         self.init(
             rulesMode: rulesMode,

--- a/Source/SwiftLintCore/Extensions/Configuration+RulesMode.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+RulesMode.swift
@@ -31,6 +31,7 @@ public extension Configuration {
 
         internal init(
             enableAllRules: Bool,
+            onlyRule: String?,
             onlyRules: [String],
             optInRules: [String],
             disabledRules: [String],
@@ -48,6 +49,8 @@ public extension Configuration {
 
             if enableAllRules {
                 self = .allEnabled
+            } else if let onlyRule {
+                self = .only(Set([onlyRule]))
             } else if onlyRules.isNotEmpty {
                 if disabledRules.isNotEmpty || optInRules.isNotEmpty {
                     throw Issue.genericWarning(

--- a/Source/SwiftLintCore/Models/Configuration.swift
+++ b/Source/SwiftLintCore/Models/Configuration.swift
@@ -210,6 +210,7 @@ public struct Configuration {
     public init(
         configurationFiles: [String], // No default value here to avoid ambiguous Configuration() initializer
         enableAllRules: Bool = false,
+        onlyRule: String? = nil,
         cachePath: String? = nil,
         ignoreParentAndChildConfigs: Bool = false,
         mockedNetworkResults: [String: String] = [:],
@@ -247,6 +248,7 @@ public struct Configuration {
             )
             let resultingConfiguration = try fileGraph.resultingConfiguration(
                 enableAllRules: enableAllRules,
+                onlyRule: onlyRule,
                 cachePath: cachePath
             )
 

--- a/Source/swiftlint/Commands/Analyze.swift
+++ b/Source/swiftlint/Commands/Analyze.swift
@@ -13,7 +13,7 @@ extension SwiftLint {
         var compilerLogPath: String?
         @Option(help: "The path of a compilation database to use when running AnalyzerRules.")
         var compileCommands: String?
-        @Option(help: "Run only the specified rule, ignoring `only_rules`, `optin_rules` and `disabled_rules`.")
+        @Option(help: "Run only the specified rule, ignoring `only_rules`, `opt_in_rules` and `disabled_rules`.")
         var onlyRule: String?
         @Argument(help: pathsArgumentDescription(for: .analyze))
         var paths = [String]()

--- a/Source/swiftlint/Commands/Analyze.swift
+++ b/Source/swiftlint/Commands/Analyze.swift
@@ -13,6 +13,8 @@ extension SwiftLint {
         var compilerLogPath: String?
         @Option(help: "The path of a compilation database to use when running AnalyzerRules.")
         var compileCommands: String?
+        @Option(help: "Run only the specified rule, ignoring the configuration file.")
+        var onlyRule: String?
         @Argument(help: pathsArgumentDescription(for: .analyze))
         var paths = [String]()
 
@@ -40,6 +42,7 @@ extension SwiftLint {
                 cachePath: nil,
                 ignoreCache: true,
                 enableAllRules: false,
+                onlyRule: onlyRule,
                 autocorrect: common.fix,
                 format: common.format,
                 compilerLogPath: compilerLogPath,

--- a/Source/swiftlint/Commands/Analyze.swift
+++ b/Source/swiftlint/Commands/Analyze.swift
@@ -13,7 +13,7 @@ extension SwiftLint {
         var compilerLogPath: String?
         @Option(help: "The path of a compilation database to use when running AnalyzerRules.")
         var compileCommands: String?
-        @Option(help: "Run only the specified rule, ignoring the configuration file.")
+        @Option(help: "Run only the specified rule, ignoring `only_rules`, `optin_rules` and `disabled_rules`.")
         var onlyRule: String?
         @Argument(help: pathsArgumentDescription(for: .analyze))
         var paths = [String]()

--- a/Source/swiftlint/Commands/Lint.swift
+++ b/Source/swiftlint/Commands/Lint.swift
@@ -19,6 +19,8 @@ extension SwiftLint {
         var noCache = false
         @Flag(help: "Run all rules, even opt-in and disabled ones, ignoring `only_rules`.")
         var enableAllRules = false
+        @Option(help: "Run only the specified rule, ignoring the configuration file.")
+        var onlyRule: String?
         @Argument(help: pathsArgumentDescription(for: .lint))
         var paths = [String]()
 
@@ -52,6 +54,7 @@ extension SwiftLint {
                 cachePath: cachePath,
                 ignoreCache: noCache,
                 enableAllRules: enableAllRules,
+                onlyRule: onlyRule,
                 autocorrect: common.fix,
                 format: common.format,
                 compilerLogPath: nil,

--- a/Source/swiftlint/Commands/Lint.swift
+++ b/Source/swiftlint/Commands/Lint.swift
@@ -19,7 +19,7 @@ extension SwiftLint {
         var noCache = false
         @Flag(help: "Run all rules, even opt-in and disabled ones, ignoring `only_rules`.")
         var enableAllRules = false
-        @Option(help: "Run only the specified rule, ignoring the configuration file.")
+        @Option(help: "Run only the specified rule, ignoring `only_rules`, `optin_rules` and `disabled_rules`.")
         var onlyRule: String?
         @Argument(help: pathsArgumentDescription(for: .lint))
         var paths = [String]()

--- a/Source/swiftlint/Commands/Lint.swift
+++ b/Source/swiftlint/Commands/Lint.swift
@@ -19,7 +19,7 @@ extension SwiftLint {
         var noCache = false
         @Flag(help: "Run all rules, even opt-in and disabled ones, ignoring `only_rules`.")
         var enableAllRules = false
-        @Option(help: "Run only the specified rule, ignoring `only_rules`, `optin_rules` and `disabled_rules`.")
+        @Option(help: "Run only the specified rule, ignoring `only_rules`, `opt_in_rules` and `disabled_rules`.")
         var onlyRule: String?
         @Argument(help: pathsArgumentDescription(for: .lint))
         var paths = [String]()

--- a/Source/swiftlint/Extensions/Configuration+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Configuration+CommandLine.swift
@@ -266,6 +266,7 @@ extension Configuration {
         self.init(
             configurationFiles: options.configurationFiles,
             enableAllRules: options.enableAllRules,
+//            onlyRule: options.onlyRule,
             cachePath: options.cachePath
         )
     }

--- a/Source/swiftlint/Extensions/Configuration+CommandLine.swift
+++ b/Source/swiftlint/Extensions/Configuration+CommandLine.swift
@@ -266,7 +266,7 @@ extension Configuration {
         self.init(
             configurationFiles: options.configurationFiles,
             enableAllRules: options.enableAllRules,
-//            onlyRule: options.onlyRule,
+            onlyRule: options.onlyRule,
             cachePath: options.cachePath
         )
     }

--- a/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
+++ b/Source/swiftlint/Helpers/LintOrAnalyzeCommand.swift
@@ -281,6 +281,7 @@ struct LintOrAnalyzeOptions {
     let cachePath: String?
     let ignoreCache: Bool
     let enableAllRules: Bool
+    let onlyRule: String?
     let autocorrect: Bool
     let format: Bool
     let compilerLogPath: String?

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -87,7 +87,7 @@ final class ConfigurationTests: SwiftLintTestCase {
         XCTAssertEqual(configuration.rules.count, RuleRegistry.shared.list.list.count)
     }
 
-    func testEnableOnlyRule() throws {
+    func testOnlyRule() throws {
         let configuration = try Configuration(
             dict: [:],
             onlyRule: "nesting",

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -87,6 +87,16 @@ final class ConfigurationTests: SwiftLintTestCase {
         XCTAssertEqual(configuration.rules.count, RuleRegistry.shared.list.list.count)
     }
 
+    func testEnableOnlyRule() throws {
+        let configuration = try Configuration(
+            dict: [:],
+            onlyRule: "nesting",
+            cachePath: nil
+        )
+
+        XCTAssertEqual(configuration.rules.count, 1)
+    }
+
     func testOnlyRules() throws {
         let only = ["nesting", "todo"]
 


### PR DESCRIPTION
Addresses #5659

Adds an `--only-rule` option to the `lint` and `analyze` subcommands (`--fix` is also supported), which behaves as though that single rule was specified in `only_rules:` in the configuration file.

This is very similar in spirit to the `--enable-all-rules` command line option. Configuration file settings will be ignored.

A primary use case for this feature is to be able to autocorrect violations of a single rule at a time.

Previously the alternative was to hack the existing `.swiftlint.yml` file, or to provide a custom one.

```
 % swiftlint.debug help lint   
OVERVIEW: Print lint warnings and errors

USAGE: swiftlint lint [<options>] [<paths> ...]

ARGUMENTS:
  <paths>                 List of paths to the files or directories to lint.

OPTIONS:
  --only-rule <only-rule> Run only the specified rule, ignoring `only_rules`, `opt_in_rules` and `disabled_rules`.
```

```
% swiftlint help analyze
OVERVIEW: Run analysis rules

USAGE: swiftlint analyze [<options>] [<paths> ...]

ARGUMENTS:
  <paths>                 List of paths to the files or directories to analyze.

OPTIONS:
  --only-rule <only-rule> Run only the specified rule, ignoring `only_rules`, `opt_in_rules` and `disabled_rules`.
```
