### PR TITLE
Add new `unused_parameter` rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -48,6 +48,7 @@ disabled_rules:
   - trailing_closure
   - type_contents_order
   - unused_capture_list
+  - unused_parameter
   - vertical_whitespace_between_cases
 
 # Configurations
@@ -62,7 +63,7 @@ balanced_xctest_lifecycle: &unit_test_configuration
     - XCTestCase
 closure_body_length:
     warning: 50
-    error: 100    
+    error: 100
 empty_xctest_method: *unit_test_configuration
 file_name:
   excluded:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,11 @@
   [Ueeek](https://github.com/Ueeek)
   [#5615](https://github.com/realm/SwiftLint/issues/5615)
 
+* Add new `unused_parameter` rule that triggers on function/initializer/subscript
+  parameters that are not used inside of the function/initializer/subscript.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#2120](https://github.com/realm/SwiftLint/issues/2120)
+
 * Add modified configurations to examples in rule documentation.  
   [SimplyDanny](https://github.com/SimplyDanny)
 

--- a/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
+++ b/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
@@ -226,6 +226,7 @@ public let builtInRules: [any Rule.Type] = [
     UnusedEnumeratedRule.self,
     UnusedImportRule.self,
     UnusedOptionalBindingRule.self,
+    UnusedParameterRule.self,
     UnusedSetterValueRule.self,
     ValidIBInspectableRule.self,
     VerticalParameterAlignmentOnCallRule.self,

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedParameterRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedParameterRule.swift
@@ -132,7 +132,7 @@ struct UnusedParameterRule: SwiftSyntaxCorrectableRule, OptInRule {
 
 private extension UnusedParameterRule {
     final class Visitor: DeclaredIdentifiersTrackingVisitor<ConfigurationType> {
-        private var referencedDeclarations = Set<Declaration>()
+        private var referencedDeclarations = Set<IdentifierDeclaration>()
 
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
 
@@ -193,7 +193,7 @@ private extension UnusedParameterRule {
         private func addReference(_ id: String) {
             let id = id.trimmingCharacters(in: .init(charactersIn: "`"))
             for declarations in scope.reversed() {
-                if declarations.onlyElement == .stopMarker {
+                if declarations.onlyElement == .lookupBoundary {
                     return
                 }
                 for declaration in declarations.reversed() where declaration.name == id {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedParameterRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedParameterRule.swift
@@ -1,0 +1,265 @@
+import SwiftLintCore
+import SwiftSyntax
+
+@SwiftSyntaxRule
+struct UnusedParameterRule: OptInRule {
+    var configuration = SeverityConfiguration<Self>(.warning)
+
+    static let description = RuleDescription(
+        identifier: "unused_parameter",
+        name: "Unused Parameter",
+        description: """
+            Other than unused local variable declarations, unused function/initializer/subscript parameters are not \
+            marked by the Swift compiler. Since unused parameters are code smells, they should either be removed \
+            or replaced/shadowed by a wildcard '_' to indicate that they are being deliberately disregarded.
+            """,
+        kind: .lint,
+        nonTriggeringExamples: [
+            Example("""
+            func f(a: Int) {
+                _ = a
+            }
+            """),
+            Example("""
+            func f(case: Int) {
+                _ = `case`
+            }
+            """),
+            Example("""
+            func f(a _: Int) {}
+            """),
+            Example("""
+            func f(_: Int) {}
+            """),
+            Example("""
+            func f(a: Int, b c: String) {
+                func g() {
+                    _ = a
+                    _ = c
+                }
+            }
+            """),
+            Example("""
+            class C1: C2 {
+                override func f(a: Int, b c: String) {}
+            }
+            """),
+            Example("""
+            func f(a: Int, c: Int) -> Int {
+                struct S {
+                    let b = 1
+                    func f(a: Int, b: Int = 2) -> Int { a + b }
+                }
+                return a + c
+            }
+            """),
+            Example("""
+            func f(a: Int?) {
+                if let a {}
+            }
+            """),
+        ],
+        triggeringExamples: [
+            Example("""
+            func f(↓a: Int) {}
+            """),
+            Example("""
+            func f(↓a: Int, b ↓c: String) {}
+            """),
+            Example("""
+            func f(↓a: Int, b ↓c: String) {
+                func g(a: Int, ↓b: Double) {
+                    _ = a
+                }
+            }
+            """),
+            Example("""
+            struct S {
+                let a: Int
+
+                init(a: Int, ↓b: Int) {
+                    func f(↓a: Int, b: Int) -> Int { b }
+                    self.a = f(a: a, b: 0)
+                }
+            }
+            """),
+            Example("""
+            struct S {
+                subscript(a: Int, ↓b: Int) {
+                    func f(↓a: Int, b: Int) -> Int { b }
+                    return f(a: a, b: 0)
+                }
+            }
+            """),
+            Example("""
+            func f(↓a: Int, ↓b: Int, c: Int) -> Int {
+                struct S {
+                    let b = 1
+                    func f(a: Int, ↓c: Int = 2) -> Int { a + b }
+                }
+                return S().f(a: c)
+            }
+            """),
+        ]
+    )
+}
+
+private class Parameter {
+    fileprivate static let stopParameter = Parameter(position: .init(utf8Offset: 0), name: "")
+
+    let position: AbsolutePosition
+    let name: String
+    var used = false
+
+    init(position: AbsolutePosition, name: String) {
+        self.position = position
+        self.name = name
+    }
+}
+
+private extension UnusedParameterRule {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
+        private static let parameterBoundary = [Parameter.stopParameter]
+
+        private var declaredParameters = Stack<[Parameter]>()
+        private var referencedVariables = Stack<Set<String>>()
+
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { [ProtocolDeclSyntax.self] }
+
+        // MARK: Parameter declarations
+
+        override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+            if !node.modifiers.contains(keyword: .override) {
+                initializeStacks(parameters: node.signature.parameterClause.parameters)
+            }
+            return .visitChildren
+        }
+
+        override func visit(_ node: InitializerDeclSyntax) -> SyntaxVisitorContinueKind {
+            if !node.modifiers.contains(keyword: .override) {
+                initializeStacks(parameters: node.signature.parameterClause.parameters)
+            }
+            return .visitChildren
+        }
+
+        override func visit(_ node: SubscriptDeclSyntax) -> SyntaxVisitorContinueKind {
+            if !node.modifiers.contains(keyword: .override) {
+                initializeStacks(parameters: node.parameterClause.parameters)
+            }
+            return .visitChildren
+        }
+
+        // MARK: Violation checking
+
+        override func visitPost(_ node: FunctionDeclSyntax) {
+            if !node.modifiers.contains(keyword: .override) {
+                collectViolations()
+            }
+        }
+
+        override func visitPost(_ node: InitializerDeclSyntax) {
+            if !node.modifiers.contains(keyword: .override) {
+                collectViolations()
+            }
+        }
+
+        override func visitPost(_ node: SubscriptDeclSyntax) {
+            if !node.modifiers.contains(keyword: .override) {
+                collectViolations()
+            }
+        }
+
+        // MARK: Reference collection
+
+        override func visitPost(_ node: DeclReferenceExprSyntax) {
+            addReference(node.baseName.text)
+        }
+
+        override func visitPost(_ node: OptionalBindingConditionSyntax) {
+            if node.initializer == nil, let id = node.pattern.as(IdentifierPatternSyntax.self)?.identifier.text {
+                addReference(id)
+            }
+        }
+
+        // MARK: Type declaration boundaries
+
+        override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind {
+            declaredParameters.push(Self.parameterBoundary)
+            return .visitChildren
+        }
+
+        override func visitPost(_ node: ActorDeclSyntax) {
+            declaredParameters.pop()
+        }
+
+        override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+            declaredParameters.push(Self.parameterBoundary)
+            return .visitChildren
+        }
+
+        override func visitPost(_ node: ClassDeclSyntax) {
+            declaredParameters.pop()
+        }
+
+        override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+            declaredParameters.push(Self.parameterBoundary)
+            return .visitChildren
+        }
+
+        override func visitPost(_ node: EnumDeclSyntax) {
+            declaredParameters.pop()
+        }
+
+        override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+            declaredParameters.push(Self.parameterBoundary)
+            return .visitChildren
+        }
+
+        override func visitPost(_ node: StructDeclSyntax) {
+            declaredParameters.pop()
+        }
+
+        // MARK: Private methods
+
+        private func initializeStacks(parameters: FunctionParameterListSyntax) {
+            let parameters = parameters.compactMap {
+                let name = $0.secondName ?? $0.firstName
+                return name.tokenKind == .wildcard
+                    ? nil
+                    : Parameter(position: name.positionAfterSkippingLeadingTrivia, name: name.text)
+            }
+            declaredParameters.push(parameters)
+            referencedVariables.push([])
+        }
+
+        private func addReference(_ id: String) {
+            referencedVariables.modifyLast {
+                $0.insert(id.trimmingCharacters(in: .init(charactersIn: "`")))
+            }
+        }
+
+        private func collectViolations() {
+            for reference in referencedVariables.pop() ?? [] {
+                parameters: for parameters in declaredParameters.reversed() {
+                    if parameters.onlyElement === Parameter.stopParameter {
+                        break parameters
+                    }
+                    for parameter in parameters where reference == parameter.name {
+                        parameter.used = true
+                        break parameters
+                    }
+                }
+            }
+            (declaredParameters.pop() ?? [])
+                .filter { !$0.used }
+                .forEach {
+                    let violation = ReasonedRuleViolation(
+                        position: $0.position,
+                        reason: "Parameter '\($0.name)' is unused; consider removing or replacing it with '_'",
+                        severity: configuration.severity
+                    )
+                    violations.append(violation)
+                }
+        }
+    }
+}

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedParameterRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedParameterRule.swift
@@ -59,6 +59,9 @@ struct UnusedParameterRule: SwiftSyntaxCorrectableRule, OptInRule {
                 return a
             }
             """),
+            Example("""
+            func f(`operator`: Int) -> Int { `operator` }
+            """),
         ],
         triggeringExamples: [
             Example("""
@@ -191,12 +194,11 @@ private extension UnusedParameterRule {
         // MARK: Private methods
 
         private func addReference(_ id: String) {
-            let id = id.trimmingCharacters(in: .init(charactersIn: "`"))
             for declarations in scope.reversed() {
                 if declarations.onlyElement == .lookupBoundary {
                     return
                 }
-                for declaration in declarations.reversed() where declaration.name == id {
+                for declaration in declarations.reversed() where declaration.declares(id: id) {
                     if referencedDeclarations.insert(declaration).inserted {
                         return
                     }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/RedundantSelfInClosureRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/RedundantSelfInClosureRuleExamples.swift
@@ -80,6 +80,19 @@ struct RedundantSelfInClosureRuleExamples {
                 }
             }
         """),
+        Example("""
+        class C {
+            var a = 0
+            init(_ a: Int) {
+                self.a = a
+                f { [weak self] in
+                    guard let self else { return }
+                    self.a = 1
+                }
+            }
+            func f(_: () -> Void) {}
+        }
+        """, excludeFromDocumentation: true),
     ]
 
     static let triggeringExamples = [

--- a/Source/SwiftLintCore/Helpers/Stack.swift
+++ b/Source/SwiftLintCore/Helpers/Stack.swift
@@ -49,6 +49,12 @@ public struct Stack<Element> {
     }
 }
 
+extension Stack: Sequence {
+    public func makeIterator() -> [Element].Iterator {
+        elements.makeIterator()
+    }
+}
+
 extension Stack: CustomDebugStringConvertible where Element: CustomDebugStringConvertible {
     public var debugDescription: String {
         let intermediateElements = count > 1 ? elements[1 ..< count - 1] : []

--- a/Tests/GeneratedTests/GeneratedTests.swift
+++ b/Tests/GeneratedTests/GeneratedTests.swift
@@ -1345,6 +1345,12 @@ final class UnusedOptionalBindingRuleGeneratedTests: SwiftLintTestCase {
     }
 }
 
+final class UnusedParameterRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(UnusedParameterRule.description)
+    }
+}
+
 final class UnusedSetterValueRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(UnusedSetterValueRule.description)

--- a/Tests/IntegrationTests/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/default_rule_configurations.yml
@@ -603,6 +603,8 @@ unused_import:
 unused_optional_binding:
   severity: warning
   ignore_optional_try: false
+unused_parameter:
+  severity: warning
 unused_setter_value:
   severity: warning
 valid_ibinspectable:


### PR DESCRIPTION
Partially implements #2120.

Even though [Periphery](https://github.com/peripheryapp/periphery) does the same (and much more the like) globally, e.g. by checking all protocol implementors, due to the restricted local scope of a function/initializer/subscript, a basic version of this check operating on syntax level can be implemented in SwiftLint as well.

The only issue concerns auto-fixes and documentation. Xcode puts the second parameter name into the comment. If auto-fixing changes the parameter name to a wildcard, documentation would have to be adapted likewise. While it's possible to fix this, it feels just out-of-scope for the first rule proposal and perhaps this would go too far generally.