### PR TITLE
Fix superfluous disable command for `custom_rules`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
   custom rules.  
   [Marcelo Fabri](https://github.com/marcelofabri)
   [Martin Redington](https://github.com/mildm8nnered)
+  [SimplyDanny](https://github.com/SimplyDanny)
   [#4754](https://github.com/realm/SwiftLint/issues/4754)
 
 * Align left closure brace with associated parent function call in `contrasted_opening_brace` rule.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,11 @@
 * Check `if` expressions nested arbitrarily deep in `contrasted_opening_brace` rule.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#5752](https://github.com/realm/SwiftLint/issues/5752)
+* `superfluous_disable_command` violations are now triggered for
+  custom rules.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#4754](https://github.com/realm/SwiftLint/issues/4754)
 
 * Align left closure brace with associated parent function call in `contrasted_opening_brace` rule.  
   [SimplyDanny](https://github.com/SimplyDanny)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 * Check `if` expressions nested arbitrarily deep in `contrasted_opening_brace` rule.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#5752](https://github.com/realm/SwiftLint/issues/5752)
+
 * `superfluous_disable_command` violations are now triggered for
   custom rules.  
   [Marcelo Fabri](https://github.com/marcelofabri)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,12 @@
 
 #### Bug Fixes
 
-* None.
+* `superfluous_disable_command` violations are now triggered for
+  custom rules.  
+  [Marcelo Fabri](https://github.com/marcelofabri)
+  [Martin Redington](https://github.com/mildm8nnered)
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#4754](https://github.com/realm/SwiftLint/issues/4754)
 
 ## 0.56.2: Heat Pump Dryer
 
@@ -63,13 +68,6 @@
 * Check `if` expressions nested arbitrarily deep in `contrasted_opening_brace` rule.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#5752](https://github.com/realm/SwiftLint/issues/5752)
-
-* `superfluous_disable_command` violations are now triggered for
-  custom rules.  
-  [Marcelo Fabri](https://github.com/marcelofabri)
-  [Martin Redington](https://github.com/mildm8nnered)
-  [SimplyDanny](https://github.com/SimplyDanny)
-  [#4754](https://github.com/realm/SwiftLint/issues/4754)
 
 * Align left closure brace with associated parent function call in `contrasted_opening_brace` rule.  
   [SimplyDanny](https://github.com/SimplyDanny)

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/TypesafeArrayInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/TypesafeArrayInitRule.swift
@@ -31,21 +31,21 @@ struct TypesafeArrayInitRule: AnalyzerRule {
                 func f<Seq: Sequence>(s: Seq) -> [Seq.Element] {
                     s.↓map({ $0 })
                 }
-            """),
+                """),
             Example("""
                 func f(array: [Int]) -> [Int] {
                     array.↓map { $0 }
                 }
-            """),
+                """),
             Example("""
                 let myInts = [1, 2, 3].↓map { return $0 }
-            """),
+                """),
             Example("""
                 struct Generator: Sequence, IteratorProtocol {
                     func next() -> Int? { nil }
                 }
                 let array = Generator().↓map { i in i }
-            """),
+                """),
         ],
         requiresFileOnDisk: true
     )

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/TypesafeArrayInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/TypesafeArrayInitRule.swift
@@ -14,7 +14,7 @@ struct TypesafeArrayInitRule: AnalyzerRule {
                 enum MyError: Error {}
                 let myResult: Result<String, MyError> = .success("")
                 let result: Result<Any, MyError> = myResult.map { $0 }
-            """),
+                """),
             Example("""
                 struct IntArray {
                     let elements = [1, 2, 3]
@@ -24,7 +24,7 @@ struct TypesafeArrayInitRule: AnalyzerRule {
                 }
                 let ints = IntArray()
                 let intsCopy = ints.map { $0 }
-            """),
+                """),
         ],
         triggeringExamples: [
             Example("""

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/TypesafeArrayInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/TypesafeArrayInitRule.swift
@@ -31,21 +31,21 @@ struct TypesafeArrayInitRule: AnalyzerRule {
                 func f<Seq: Sequence>(s: Seq) -> [Seq.Element] {
                     s.↓map({ $0 })
                 }
-            """, testDisableCommand: false),
+            """),
             Example("""
                 func f(array: [Int]) -> [Int] {
                     array.↓map { $0 }
                 }
-            """, testDisableCommand: false),
+            """),
             Example("""
                 let myInts = [1, 2, 3].↓map { return $0 }
-            """, testDisableCommand: false),
+            """),
             Example("""
                 struct Generator: Sequence, IteratorProtocol {
                     func next() -> Int? { nil }
                 }
                 let array = Generator().↓map { i in i }
-            """, testDisableCommand: false),
+            """),
         ],
         requiresFileOnDisk: true
     )

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/TypesafeArrayInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/TypesafeArrayInitRule.swift
@@ -14,7 +14,7 @@ struct TypesafeArrayInitRule: AnalyzerRule {
                 enum MyError: Error {}
                 let myResult: Result<String, MyError> = .success("")
                 let result: Result<Any, MyError> = myResult.map { $0 }
-                """),
+            """),
             Example("""
                 struct IntArray {
                     let elements = [1, 2, 3]
@@ -24,28 +24,28 @@ struct TypesafeArrayInitRule: AnalyzerRule {
                 }
                 let ints = IntArray()
                 let intsCopy = ints.map { $0 }
-                """),
+            """),
         ],
         triggeringExamples: [
             Example("""
                 func f<Seq: Sequence>(s: Seq) -> [Seq.Element] {
                     s.↓map({ $0 })
                 }
-                """),
+            """, testDisableCommand: false),
             Example("""
                 func f(array: [Int]) -> [Int] {
                     array.↓map { $0 }
                 }
-                """),
+            """, testDisableCommand: false),
             Example("""
                 let myInts = [1, 2, 3].↓map { return $0 }
-                """),
+            """, testDisableCommand: false),
             Example("""
                 struct Generator: Sequence, IteratorProtocol {
                     func next() -> Int? { nil }
                 }
                 let array = Generator().↓map { i in i }
-                """),
+            """, testDisableCommand: false),
         ],
         requiresFileOnDisk: true
     )

--- a/Source/SwiftLintCore/Extensions/Configuration+RulesMode.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+RulesMode.swift
@@ -112,8 +112,7 @@ public extension Configuration {
             switch self {
             case let .only(onlyRules) where onlyRules.contains { $0 == CustomRules.description.identifier }:
                 let customRulesRule = (allRulesWrapped.first { $0.rule is CustomRules })?.rule as? CustomRules
-                let customRuleIdentifiers = customRulesRule?.customRuleIdentifiers
-                return .only(onlyRules.union(Set(customRuleIdentifiers ?? [])))
+                return .only(onlyRules.union(Set(customRulesRule?.customRuleIdentifiers ?? [])))
 
             default:
                 return self

--- a/Source/SwiftLintCore/Extensions/Configuration+RulesMode.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+RulesMode.swift
@@ -112,7 +112,7 @@ public extension Configuration {
             switch self {
             case let .only(onlyRules) where onlyRules.contains { $0 == CustomRules.description.identifier }:
                 let customRulesRule = (allRulesWrapped.first { $0.rule is CustomRules })?.rule as? CustomRules
-                let customRuleIdentifiers = customRulesRule?.configuration.customRuleConfigurations.map(\.identifier)
+                let customRuleIdentifiers = customRulesRule?.customRuleIdentifiers
                 return .only(onlyRules.union(Set(customRuleIdentifiers ?? [])))
 
             default:

--- a/Source/SwiftLintCore/Extensions/Configuration+RulesWrapper.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+RulesWrapper.swift
@@ -13,8 +13,7 @@ internal extension Configuration {
         private var validRuleIdentifiers: Set<String> {
             let regularRuleIdentifiers = allRulesWrapped.map { type(of: $0.rule).description.identifier }
             let configurationCustomRulesIdentifiers =
-                (allRulesWrapped.first { $0.rule is CustomRules }?.rule as? CustomRules)?
-                    .configuration.customRuleConfigurations.map(\.identifier) ?? []
+                (allRulesWrapped.first { $0.rule is CustomRules }?.rule as? CustomRules)?.customRuleIdentifiers ?? []
             return Set(regularRuleIdentifiers + configurationCustomRulesIdentifiers)
         }
 
@@ -247,7 +246,7 @@ internal extension Configuration {
                         as? CustomRules {
                         onlyRules = onlyRules.union(
                             Set(
-                                childCustomRulesRule.configuration.customRuleConfigurations.map(\.identifier)
+                                childCustomRulesRule.customRuleIdentifiers
                             )
                         )
                     }

--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -70,7 +70,7 @@ private extension Rule {
     }
 
     // As we need the configuration to get custom identifiers.
-    // swiftlint:disable:next function_parameter_count
+    // swiftlint:disable:next function_parameter_count function_body_length
     func lint(file: SwiftLintFile,
               regions: [Region],
               benchmark: Bool,

--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -29,12 +29,20 @@ private extension Rule {
 
         let regionsWithIdentifiers: [(String, [Region])] = {
             if let customRules = self as? CustomRules {
-                return customRules.configuration.customRuleConfigurations.map { configuration in
+                // So I think we only want to be returned from here if the identifier is explicitly cited
+                var result = customRules.configuration.customRuleConfigurations.map { configuration in
                     let regionsDisablingCurrentRule = regions.filter { region in
-                        region.isCustomRuleDisabled(customRuleIdentifier: configuration.identifier)
+                        region.isCustomRuleSpecificallyDisabled(customRuleIdentifier: configuration.identifier)
                     }
                     return (configuration.identifier, regionsDisablingCurrentRule)
                 }
+                let regionsDisablingAllCustomRules = regions.filter { region in
+                    region.areAllCustomRulesDisabled()
+                }
+                if regionsDisablingAllCustomRules.isNotEmpty {
+                    result.append(("custom_rules", regionsDisablingAllCustomRules))
+                }
+                return result
             }
             let regionsDisablingCurrentRule = regions.filter { region in
                 region.isRuleDisabled(self)

--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -28,7 +28,7 @@ private extension Rule {
             region.isRuleDisabled(superfluousDisableCommandRule)
         }
 
-        let regionsWithIdentifiers: [(String, [Region])] = {
+        let identifiersWithRegions: [(String, [Region])] = {
             if let customRules = self as? CustomRules {
                 // So I think we only want to be returned from here if the identifier is explicitly cited
                 var result = customRules.configuration.customRuleConfigurations.map { configuration in
@@ -51,7 +51,7 @@ private extension Rule {
             return [(Self.description.identifier, regionsDisablingCurrentRule)]
         }()
 
-        return regionsWithIdentifiers.flatMap { ruleIdentifier, regionsDisablingCurrentRule in
+        return identifiersWithRegions.flatMap { ruleIdentifier, regionsDisablingCurrentRule in
             regionsDisablingCurrentRule.compactMap { region -> StyleViolation? in
                 let isSuperfluousRuleDisabled = regionsDisablingSuperfluousDisableRule.contains {
                     $0.contains(region.start)

--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -29,25 +29,7 @@ private extension Rule {
         }
 
         let identifiersWithRegions: [(String, [Region])] = {
-            if let customRules = self as? CustomRules {
-                var result = customRules.configuration.customRuleConfigurations.map { configuration in
-                    let regionsDisablingCurrentRule = regions.filter { region in
-                        region.disabledRuleIdentifiers.contains(RuleIdentifier(configuration.identifier))
-                    }
-                    return (configuration.identifier, regionsDisablingCurrentRule)
-                }
-                let regionsDisablingAllCustomRules = regions.filter { region in
-                    region.areAllCustomRulesDisabled
-                }
-                if regionsDisablingAllCustomRules.isNotEmpty {
-                    result.append((CustomRules.description.identifier, regionsDisablingAllCustomRules))
-                }
-                return result
-            }
-            let regionsDisablingCurrentRule = regions.filter { region in
-                region.isRuleDisabled(self)
-            }
-            return [(Self.description.identifier, regionsDisablingCurrentRule)]
+            disabledRuleIdentifiersWithRegions(regions: regions)
         }().sorted { lhs, rhs -> Bool in // make sure that the results are consistently ordered
             lhs.0 < rhs.0
         }

--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -17,7 +17,6 @@ private struct LintResult {
 }
 
 private extension Rule {
-    // swiftlint:disable:next function_body_length
     func superfluousDisableCommandViolations(regions: [Region],
                                              superfluousDisableCommandRule: SuperfluousDisableCommandRule?,
                                              allViolations: [StyleViolation]) -> [StyleViolation] {

--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -31,7 +31,7 @@ private extension Rule {
             if let customRules = self as? CustomRules {
                 return customRules.configuration.customRuleConfigurations.map { configuration in
                     let regionsDisablingCurrentRule = regions.filter { region in
-                        region.isRuleDisabled(customRuleIdentifier: configuration.identifier)
+                        region.isCustomRuleDisabled(customRuleIdentifier: configuration.identifier)
                     }
                     return (configuration.identifier, regionsDisablingCurrentRule)
                 }
@@ -109,7 +109,7 @@ private extension Rule {
             (violation, regions.first { $0.contains(violation.location) })
         }.partitioned { violation, region in
             if self is CustomRules {
-                return !(region?.isRuleDisabled(customRuleIdentifier: violation.ruleIdentifier) ?? false)
+                return !(region?.isCustomRuleDisabled(customRuleIdentifier: violation.ruleIdentifier) ?? false)
             }
             return region?.isRuleEnabled(self) ?? true
         }

--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -37,7 +37,7 @@ private extension Rule {
                     return (configuration.identifier, regionsDisablingCurrentRule)
                 }
                 let regionsDisablingAllCustomRules = regions.filter { region in
-                    region.areAllCustomRulesDisabled()
+                    region.areAllCustomRulesDisabled
                 }
                 if regionsDisablingAllCustomRules.isNotEmpty {
                     result.append((CustomRules.description.identifier, regionsDisablingAllCustomRules))

--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -109,7 +109,7 @@ private extension Rule {
             (violation, regions.first { $0.contains(violation.location) })
         }.partitioned { violation, region in
             if self is CustomRules {
-                return !(region?.isRuleDisabled(customRuleIdentifier: violation.ruleIdentifier) ?? true)
+                return !(region?.isRuleDisabled(customRuleIdentifier: violation.ruleIdentifier) ?? false)
             }
             return region?.isRuleEnabled(self) ?? true
         }

--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -47,7 +47,6 @@ private extension Rule {
                 let isSuperfluousRuleDisabled = regionsDisablingSuperfluousDisableRule.contains {
                     $0.contains(region.start)
                 }
-
                 guard !isSuperfluousRuleDisabled else {
                     return nil
                 }

--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -48,7 +48,7 @@ private extension Rule {
                 region.isRuleDisabled(self)
             }
             return [(Self.description.identifier, regionsDisablingCurrentRule)]
-        }().sorted { (lhs, rhs) -> Bool in // make sure that the results are consistently ordered
+        }().sorted { lhs, rhs -> Bool in // make sure that the results are consistently ordered
             lhs.0 < rhs.0
         }
 

--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -62,7 +62,7 @@ private extension Rule {
                 }
 
                 let noViolationsInDisabledRegion = !allViolations.contains { violation in
-                    contains(violation: violation, in: region, disabledRuleIdentifier: ruleIdentifier)
+                    isViolationDisabled(violation: violation, in: region, byDisabledRuleIdentifier: ruleIdentifier)
                 }
                 guard noViolationsInDisabledRegion else {
                     return nil
@@ -78,7 +78,9 @@ private extension Rule {
         }
     }
 
-    private func contains(violation: StyleViolation, in region: Region, disabledRuleIdentifier: String) -> Bool {
+    private func isViolationDisabled(violation: StyleViolation,
+                                     in region: Region,
+                                     byDisabledRuleIdentifier disabledRuleIdentifier: String) -> Bool {
         guard region.contains(violation.location) else {
             return false
         }

--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -89,7 +89,7 @@ private extension Rule {
             return false
         }
         let customRulesIdentifiers = Set(customRules.configuration.customRuleConfigurations.map { $0.identifier })
-        return customRuleIdentifiers.contains(violation.ruleIdentifier)
+        return customRulesIdentifiers.contains(violation.ruleIdentifier)
     }
 
     // As we need the configuration to get custom identifiers.

--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -16,42 +16,56 @@ private struct LintResult {
 }
 
 private extension Rule {
-    static func superfluousDisableCommandViolations(regions: [Region],
-                                                    superfluousDisableCommandRule: SuperfluousDisableCommandRule?,
-                                                    allViolations: [StyleViolation]) -> [StyleViolation] {
+    func superfluousDisableCommandViolations(regions: [Region],
+                                             superfluousDisableCommandRule: SuperfluousDisableCommandRule?,
+                                             allViolations: [StyleViolation]) -> [StyleViolation] {
         guard regions.isNotEmpty, let superfluousDisableCommandRule else {
             return []
         }
 
-        let regionsDisablingCurrentRule = regions.filter { region in
-            region.isRuleDisabled(self.init())
-        }
         let regionsDisablingSuperfluousDisableRule = regions.filter { region in
             region.isRuleDisabled(superfluousDisableCommandRule)
         }
 
-        return regionsDisablingCurrentRule.compactMap { region -> StyleViolation? in
-            let isSuperfluousRuleDisabled = regionsDisablingSuperfluousDisableRule.contains {
-                $0.contains(region.start)
+        let regionsWithIdentifiers: [(String, [Region])] = {
+            if let customRules = self as? CustomRules {
+                return customRules.configuration.customRuleConfigurations.map { configuration in
+                    let regionsDisablingCurrentRule = regions.filter { region in
+                        region.isRuleDisabled(customRuleIdentifier: configuration.identifier)
+                    }
+                    return (configuration.identifier, regionsDisablingCurrentRule)
+                }
             }
+            let regionsDisablingCurrentRule = regions.filter { region in
+                region.isRuleDisabled(self)
+            }
+            return [(Self.description.identifier, regionsDisablingCurrentRule)]
+        }()
 
-            guard !isSuperfluousRuleDisabled else {
-                return nil
-            }
+        return regionsWithIdentifiers.flatMap { ruleIdentifier, regionsDisablingCurrentRule in
+            regionsDisablingCurrentRule.compactMap { region -> StyleViolation? in
+                let isSuperfluousRuleDisabled = regionsDisablingSuperfluousDisableRule.contains {
+                    $0.contains(region.start)
+                }
 
-            let noViolationsInDisabledRegion = !allViolations.contains { violation in
-                region.contains(violation.location)
-            }
-            guard noViolationsInDisabledRegion else {
-                return nil
-            }
+                guard !isSuperfluousRuleDisabled else {
+                    return nil
+                }
 
-            return StyleViolation(
-                ruleDescription: type(of: superfluousDisableCommandRule).description,
-                severity: superfluousDisableCommandRule.configuration.severity,
-                location: region.start,
-                reason: superfluousDisableCommandRule.reason(for: self)
-            )
+                let noViolationsInDisabledRegion = !allViolations.contains { violation in
+                    region.contains(violation.location) && violation.ruleIdentifier == ruleIdentifier
+                }
+                guard noViolationsInDisabledRegion else {
+                    return nil
+                }
+
+                return StyleViolation(
+                    ruleDescription: type(of: superfluousDisableCommandRule).description,
+                    severity: superfluousDisableCommandRule.configuration.severity,
+                    location: region.start,
+                    reason: superfluousDisableCommandRule.reason(forRuleIdentifier: ruleIdentifier)
+                )
+            }
         }
     }
 
@@ -93,16 +107,26 @@ private extension Rule {
 
         let (disabledViolationsAndRegions, enabledViolationsAndRegions) = violations.map { violation in
             (violation, regions.first { $0.contains(violation.location) })
-        }.partitioned { _, region in
-            region?.isRuleEnabled(self) ?? true
+        }.partitioned { violation, region in
+            if self is CustomRules {
+                return !(region?.isRuleDisabled(customRuleIdentifier: violation.ruleIdentifier) ?? true)
+            }
+            return region?.isRuleEnabled(self) ?? true
         }
 
+        let customRulesIDs: [String] = {
+             guard let customRules = self as? CustomRules else {
+                 return []
+             }
+             return customRules.configuration.customRuleConfigurations.map(\.identifier)
+         }()
         let ruleIDs = Self.description.allIdentifiers +
+            customRulesIDs +
             (superfluousDisableCommandRule.map({ type(of: $0) })?.description.allIdentifiers ?? []) +
             [RuleIdentifier.all.stringRepresentation]
         let ruleIdentifiers = Set(ruleIDs.map { RuleIdentifier($0) })
 
-        let superfluousDisableCommandViolations = Self.superfluousDisableCommandViolations(
+        let superfluousDisableCommandViolations = superfluousDisableCommandViolations(
             regions: regions.count > 1 ? file.regions(restrictingRuleIdentifiers: ruleIdentifiers) : regions,
             superfluousDisableCommandRule: superfluousDisableCommandRule,
             allViolations: violations

--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -85,10 +85,12 @@ private extension Rule {
         if violation.ruleIdentifier == disabledRuleIdentifier {
             return true
         }
-        guard let customRules = self as? CustomRules, region.areAllCustomRulesDisabled() else {
+        guard
+            let customRules = self as? CustomRules,
+            disabledRuleIdentifier == CustomRules.description.identifier else {
             return false
         }
-        let customRulesIdentifiers = Set(customRules.configuration.customRuleConfigurations.map { $0.identifier })
+        let customRulesIdentifiers = Set(customRules.configuration.customRuleConfigurations.map(\.identifier))
         return customRulesIdentifiers.contains(violation.ruleIdentifier)
     }
 

--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -30,7 +30,6 @@ private extension Rule {
 
         let identifiersWithRegions: [(String, [Region])] = {
             if let customRules = self as? CustomRules {
-                // So I think we only want to be returned from here if the identifier is explicitly cited
                 var result = customRules.configuration.customRuleConfigurations.map { configuration in
                     let regionsDisablingCurrentRule = regions.filter { region in
                         region.disabledRuleIdentifiers.contains(RuleIdentifier(configuration.identifier))

--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -40,7 +40,7 @@ private extension Rule {
                     region.areAllCustomRulesDisabled()
                 }
                 if regionsDisablingAllCustomRules.isNotEmpty {
-                    result.append(("custom_rules", regionsDisablingAllCustomRules))
+                    result.append((CustomRules.description.identifier, regionsDisablingAllCustomRules))
                 }
                 return result
             }

--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -48,7 +48,9 @@ private extension Rule {
                 region.isRuleDisabled(self)
             }
             return [(Self.description.identifier, regionsDisablingCurrentRule)]
-        }()
+        }().sorted { (lhs, rhs) -> Bool in // make sure that the results are consistently ordered
+            lhs.0 < rhs.0
+        }
 
         return identifiersWithRegions.flatMap { ruleIdentifier, regionsDisablingCurrentRule in
             regionsDisablingCurrentRule.compactMap { region -> StyleViolation? in

--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -92,7 +92,7 @@ private extension Rule {
             disabledRuleIdentifier == CustomRules.description.identifier else {
             return false
         }
-        let customRulesIdentifiers = Set(customRules.configuration.customRuleConfigurations.map(\.identifier))
+        let customRulesIdentifiers = Set(customRules.customRuleIdentifiers)
         return customRulesIdentifiers.contains(violation.ruleIdentifier)
     }
 
@@ -145,7 +145,7 @@ private extension Rule {
              guard let customRules = self as? CustomRules else {
                  return []
              }
-             return customRules.configuration.customRuleConfigurations.map(\.identifier)
+             return customRules.customRuleIdentifiers
          }()
         let ruleIDs = Self.description.allIdentifiers +
             customRulesIDs +

--- a/Source/SwiftLintCore/Models/Region.swift
+++ b/Source/SwiftLintCore/Models/Region.swift
@@ -44,12 +44,13 @@ public struct Region: Equatable {
     ///
     /// - parameter rule: The rule whose status should be determined.
     ///
+    /// - note: For CustomRules, this will only return true if the `custom_rules` identifier
+    ///         is used with the `swiftlint` disable command, but this method is never
+    ///         called for CustomRules.
+    ///
     /// - returns: True if the specified rule is disabled in this region.
     public func isRuleDisabled(_ rule: some Rule) -> Bool {
-        if let rule = rule as? CustomRules {
-            return areRulesDisabled(ruleIDs: rule.customRuleIdentifiers + [type(of: rule).description.identifier])
-        }
-        return areRulesDisabled(ruleIDs: type(of: rule).description.allIdentifiers)
+        areRulesDisabled(ruleIDs: type(of: rule).description.allIdentifiers)
     }
 
     /// Whether the given rules are disabled in this region.

--- a/Source/SwiftLintCore/Models/Region.swift
+++ b/Source/SwiftLintCore/Models/Region.swift
@@ -48,7 +48,7 @@ public struct Region: Equatable {
     public func isRuleDisabled(_ rule: some Rule) -> Bool {
         if rule is CustomRules {
             let customRulesConfiguration = rule.configuration as? CustomRulesConfiguration
-            let identifiers = customRulesConfiguration?.customRuleConfigurations.map { $0.identifier } ?? []
+            let identifiers = customRulesConfiguration?.customRuleConfigurations.map(\.identifier) ?? []
             return areRulesDisabled(ruleIDs: identifiers + [type(of: rule).description.identifier])
         }
         return areRulesDisabled(ruleIDs: type(of: rule).description.allIdentifiers)

--- a/Source/SwiftLintCore/Models/Region.swift
+++ b/Source/SwiftLintCore/Models/Region.swift
@@ -46,7 +46,12 @@ public struct Region: Equatable {
     ///
     /// - returns: True if the specified rule is disabled in this region.
     public func isRuleDisabled(_ rule: some Rule) -> Bool {
-        areRulesDisabled(ruleIDs: type(of: rule).description.allIdentifiers)
+        if rule is CustomRules {
+            let customRulesConfiguration = rule.configuration as? CustomRulesConfiguration
+            let identifiers = customRulesConfiguration?.customRuleConfigurations.map { $0.identifier } ?? []
+            return areRulesDisabled(ruleIDs: identifiers)
+        }
+        return areRulesDisabled(ruleIDs: type(of: rule).description.allIdentifiers)
     }
 
     /// Whether the given rules are disabled in this region.

--- a/Source/SwiftLintCore/Models/Region.swift
+++ b/Source/SwiftLintCore/Models/Region.swift
@@ -46,10 +46,8 @@ public struct Region: Equatable {
     ///
     /// - returns: True if the specified rule is disabled in this region.
     public func isRuleDisabled(_ rule: some Rule) -> Bool {
-        if rule is CustomRules {
-            let customRulesConfiguration = rule.configuration as? CustomRulesConfiguration
-            let identifiers = customRulesConfiguration?.customRuleConfigurations.map(\.identifier) ?? []
-            return areRulesDisabled(ruleIDs: identifiers + [type(of: rule).description.identifier])
+        if let rule = rule as? CustomRules {
+            return areRulesDisabled(ruleIDs: rule.customRuleIdentifiers + [type(of: rule).description.identifier])
         }
         return areRulesDisabled(ruleIDs: type(of: rule).description.allIdentifiers)
     }

--- a/Source/SwiftLintCore/Models/Region.swift
+++ b/Source/SwiftLintCore/Models/Region.swift
@@ -49,7 +49,7 @@ public struct Region: Equatable {
         if rule is CustomRules {
             let customRulesConfiguration = rule.configuration as? CustomRulesConfiguration
             let identifiers = customRulesConfiguration?.customRuleConfigurations.map { $0.identifier } ?? []
-            return areRulesDisabled(ruleIDs: identifiers)
+            return areRulesDisabled(ruleIDs: identifiers + [type(of: rule).description.identifier])
         }
         return areRulesDisabled(ruleIDs: type(of: rule).description.allIdentifiers)
     }

--- a/Source/SwiftLintCore/Protocols/Rule.swift
+++ b/Source/SwiftLintCore/Protocols/Rule.swift
@@ -70,6 +70,15 @@ public protocol Rule {
     ///
     /// - returns: All style violations to the rule's expectations.
     func validate(file: SwiftLintFile, using storage: RuleStorage, compilerArguments: [String]) -> [StyleViolation]
+
+    /// Returns the disabled rule identifiers and the regions that they are disabled in.
+    ///
+    /// - note: In the case of custom rules, the identifiers may be user defined.
+    ///
+    /// - parameter regions: The regions that are affected by `swiftlint:disable` commands.
+    ///
+    /// - returns:  An array of tuples of rule identifiers, and the regions that those identifiers are disabled in.
+    func disabledRuleIdentifiersWithRegions(regions: [Region]) -> [(String, [Region])]
 }
 
 public extension Rule {
@@ -109,6 +118,13 @@ public extension Rule {
 
     func createConfigurationDescription(exclusiveOptions: Set<String> = []) -> RuleConfigurationDescription {
         RuleConfigurationDescription.from(configuration: configuration, exclusiveOptions: exclusiveOptions)
+    }
+
+    func disabledRuleIdentifiersWithRegions(regions: [Region]) -> [(String, [Region])] {
+        let regionsDisablingCurrentRule = regions.filter { region in
+            region.isRuleDisabled(self)
+        }
+        return [(Self.description.identifier, regionsDisablingCurrentRule)]
     }
 }
 

--- a/Source/SwiftLintCore/Rules/CustomRules.swift
+++ b/Source/SwiftLintCore/Rules/CustomRules.swift
@@ -86,6 +86,20 @@ struct CustomRules: Rule, CacheDescriptionProvider {
             })
         }
     }
+
+    func disabledRuleIdentifiersWithRegions(regions: [Region]) -> [(String, [Region])] {
+        var result = configuration.customRuleConfigurations.map { configuration in
+            let regionsDisablingCurrentRule = regions.filter { region in
+                region.disabledRuleIdentifiers.contains(RuleIdentifier(configuration.identifier))
+            }
+            return (configuration.identifier, regionsDisablingCurrentRule)
+        }
+        let regionsDisablingAllCustomRules = regions.filter(\.areAllCustomRulesDisabled)
+        if regionsDisablingAllCustomRules.isNotEmpty {
+            result.append((Self.description.identifier, regionsDisablingAllCustomRules))
+        }
+        return result
+    }
 }
 
 extension Region {

--- a/Source/SwiftLintCore/Rules/CustomRules.swift
+++ b/Source/SwiftLintCore/Rules/CustomRules.swift
@@ -86,7 +86,12 @@ struct CustomRules: Rule, CacheDescriptionProvider {
 
 extension Region {
     func isRuleDisabled(customRuleIdentifier: String) -> Bool {
-        disabledRuleIdentifiers.contains(.all) ||
-            disabledRuleIdentifiers.contains(RuleIdentifier(customRuleIdentifier))
+        disabledRuleIdentifiers.intersection(
+            [
+                .all,
+                RuleIdentifier(customRuleIdentifier), 
+                RuleIdentifier(CustomRules.description.identifier),
+            ]
+        ).isNotEmpty
     }
 }

--- a/Source/SwiftLintCore/Rules/CustomRules.swift
+++ b/Source/SwiftLintCore/Rules/CustomRules.swift
@@ -90,13 +90,9 @@ struct CustomRules: Rule, CacheDescriptionProvider {
 
 extension Region {
     func isCustomRuleDisabled(customRuleIdentifier: String) -> Bool {
-        disabledRuleIdentifiers.intersection(
-            [
-                .all,
-                RuleIdentifier(customRuleIdentifier),
-                RuleIdentifier(CustomRules.description.identifier),
-            ]
-        ).isNotEmpty
+           areAllCustomRulesDisabled 
+        || isCustomRuleSpecificallyDisabled(customRuleIdentifier: customRuleIdentifier)
+        || disabledRuleIdentifiers.contains(.all)
     }
 
     func isCustomRuleSpecificallyDisabled(customRuleIdentifier: String) -> Bool {

--- a/Source/SwiftLintCore/Rules/CustomRules.swift
+++ b/Source/SwiftLintCore/Rules/CustomRules.swift
@@ -41,6 +41,10 @@ struct CustomRules: Rule, CacheDescriptionProvider {
         configuration.cacheDescription
     }
 
+    var customRuleIdentifiers: [String] {
+        configuration.customRuleConfigurations.map(\.identifier)
+    }
+
     static let description = RuleDescription(
         identifier: "custom_rules",
         name: "Custom Rules",

--- a/Source/SwiftLintCore/Rules/CustomRules.swift
+++ b/Source/SwiftLintCore/Rules/CustomRules.swift
@@ -79,19 +79,14 @@ struct CustomRules: Rule, CacheDescriptionProvider {
                                severity: configuration.severity,
                                location: Location(file: file, characterOffset: $0.location),
                                reason: configuration.message)
-            }).filter { violation in
-                guard let region = file.regions().first(where: { $0.contains(violation.location) }) else {
-                    return true
-                }
-
-                return !region.isRuleDisabled(customRuleIdentifier: configuration.identifier)
-            }
+            })
         }
     }
 }
 
-private extension Region {
+extension Region {
     func isRuleDisabled(customRuleIdentifier: String) -> Bool {
-        disabledRuleIdentifiers.contains(RuleIdentifier(customRuleIdentifier))
+        disabledRuleIdentifiers.contains(.all) ||
+          disabledRuleIdentifiers.contains(RuleIdentifier(customRuleIdentifier))
     }
 }

--- a/Source/SwiftLintCore/Rules/CustomRules.swift
+++ b/Source/SwiftLintCore/Rules/CustomRules.swift
@@ -94,4 +94,17 @@ extension Region {
             ]
         ).isNotEmpty
     }
+
+    func isCustomRuleSpecificallyDisabled(customRuleIdentifier: String) -> Bool {
+        disabledRuleIdentifiers.intersection(
+            [
+                .all,
+                RuleIdentifier(customRuleIdentifier),
+            ]
+        ).isNotEmpty
+    }
+
+    func areAllCustomRulesDisabled() -> Bool {
+        disabledRuleIdentifiers.contains(RuleIdentifier(CustomRules.description.identifier))
+    }
 }

--- a/Source/SwiftLintCore/Rules/CustomRules.swift
+++ b/Source/SwiftLintCore/Rules/CustomRules.swift
@@ -96,12 +96,7 @@ extension Region {
     }
 
     func isCustomRuleSpecificallyDisabled(customRuleIdentifier: String) -> Bool {
-        disabledRuleIdentifiers.intersection(
-            [
-                .all,
-                RuleIdentifier(customRuleIdentifier),
-            ]
-        ).isNotEmpty
+        disabledRuleIdentifiers.contains(RuleIdentifier(customRuleIdentifier))
     }
 
     func areAllCustomRulesDisabled() -> Bool {

--- a/Source/SwiftLintCore/Rules/CustomRules.swift
+++ b/Source/SwiftLintCore/Rules/CustomRules.swift
@@ -87,6 +87,6 @@ struct CustomRules: Rule, CacheDescriptionProvider {
 extension Region {
     func isRuleDisabled(customRuleIdentifier: String) -> Bool {
         disabledRuleIdentifiers.contains(.all) ||
-          disabledRuleIdentifiers.contains(RuleIdentifier(customRuleIdentifier))
+            disabledRuleIdentifiers.contains(RuleIdentifier(customRuleIdentifier))
     }
 }

--- a/Source/SwiftLintCore/Rules/CustomRules.swift
+++ b/Source/SwiftLintCore/Rules/CustomRules.swift
@@ -89,7 +89,7 @@ extension Region {
         disabledRuleIdentifiers.intersection(
             [
                 .all,
-                RuleIdentifier(customRuleIdentifier), 
+                RuleIdentifier(customRuleIdentifier),
                 RuleIdentifier(CustomRules.description.identifier),
             ]
         ).isNotEmpty

--- a/Source/SwiftLintCore/Rules/CustomRules.swift
+++ b/Source/SwiftLintCore/Rules/CustomRules.swift
@@ -90,7 +90,7 @@ struct CustomRules: Rule, CacheDescriptionProvider {
 
 extension Region {
     func isCustomRuleDisabled(customRuleIdentifier: String) -> Bool {
-           areAllCustomRulesDisabled 
+           areAllCustomRulesDisabled
         || isCustomRuleSpecificallyDisabled(customRuleIdentifier: customRuleIdentifier)
         || disabledRuleIdentifiers.contains(.all)
     }
@@ -99,7 +99,7 @@ extension Region {
         disabledRuleIdentifiers.contains(RuleIdentifier(customRuleIdentifier))
     }
 
-    func areAllCustomRulesDisabled() -> Bool {
+    var areAllCustomRulesDisabled: Bool {
         disabledRuleIdentifiers.contains(RuleIdentifier(CustomRules.description.identifier))
     }
 }

--- a/Source/SwiftLintCore/Rules/CustomRules.swift
+++ b/Source/SwiftLintCore/Rules/CustomRules.swift
@@ -85,7 +85,7 @@ struct CustomRules: Rule, CacheDescriptionProvider {
 }
 
 extension Region {
-    func isRuleDisabled(customRuleIdentifier: String) -> Bool {
+    func isCustomRuleDisabled(customRuleIdentifier: String) -> Bool {
         disabledRuleIdentifiers.intersection(
             [
                 .all,

--- a/Source/SwiftLintCore/Rules/SuperfluousDisableCommandRule.swift
+++ b/Source/SwiftLintCore/Rules/SuperfluousDisableCommandRule.swift
@@ -34,9 +34,9 @@ package struct SuperfluousDisableCommandRule: SourceKitFreeRule {
         []
     }
 
-    func reason(for rule: (some Rule).Type) -> String {
+    func reason(forRuleIdentifier ruleIdentifier: String) -> String {
         """
-        SwiftLint rule '\(rule.description.identifier)' did not trigger a violation in the disabled region; \
+        SwiftLint rule '\(ruleIdentifier)' did not trigger a violation in the disabled region; \
         remove the disable command
         """
     }

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -167,7 +167,7 @@ final class CustomRulesTests: SwiftLintTestCase {
         customRules.configuration = customRuleConfiguration
 
         let violations = customRules.validate(file: getTestTextFile())
-        XCTAssertEqual(violations.count, 0)
+        XCTAssertTrue(violations.isEmpty)
     }
 
     func testCustomRulesExcludedExcludesFile() {
@@ -178,7 +178,7 @@ final class CustomRulesTests: SwiftLintTestCase {
         customRules.configuration = customRuleConfiguration
 
         let violations = customRules.validate(file: getTestTextFile())
-        XCTAssertEqual(violations.count, 0)
+        XCTAssertTrue(violations.isEmpty)
     }
 
     func testCustomRulesExcludedArrayExcludesFile() {
@@ -189,7 +189,7 @@ final class CustomRulesTests: SwiftLintTestCase {
         customRules.configuration = customRuleConfiguration
 
         let violations = customRules.validate(file: getTestTextFile())
-        XCTAssertEqual(violations.count, 0)
+        XCTAssertTrue(violations.isEmpty)
     }
 
     func testCustomRulesCaptureGroup() {
@@ -221,8 +221,8 @@ final class CustomRulesTests: SwiftLintTestCase {
         let violations = try violations(forExample: example, customRules: customRules)
 
         XCTAssertEqual(violations.count, 1)
-        XCTAssertEqual(violations.first?.ruleIdentifier, SuperfluousDisableCommandRule.description.identifier)
-        XCTAssertEqual(violations.first?.didNotTrigger(for: "custom_rules"), true)
+        XCTAssertTrue(violations[0].isSuperfluousDisableCommandViolation())
+        XCTAssertEqual(violations[0].didNotTrigger(for: "custom_rules"), true)
     }
 
     func testSpecificCustomRuleSuperfluousDisableCommand() throws {
@@ -240,8 +240,8 @@ final class CustomRulesTests: SwiftLintTestCase {
 
         let violations = try violations(forExample: example, customRules: customRules)
         XCTAssertEqual(violations.count, 1)
-        XCTAssertEqual(violations.first?.ruleIdentifier, SuperfluousDisableCommandRule.description.identifier)
-        XCTAssertEqual(violations.first?.didNotTrigger(for: customRuleIdentifier), true)
+        XCTAssertTrue(violations[0].isSuperfluousDisableCommandViolation())
+        XCTAssertEqual(violations[0].didNotTrigger(for: customRuleIdentifier), true)
     }
 
     func testSpecificAndCustomRulesSuperfluousDisableCommand() throws {
@@ -261,9 +261,9 @@ final class CustomRulesTests: SwiftLintTestCase {
 
         XCTAssertEqual(violations.count, 2)
         let (firstViolation, secondViolation) = (violations[0], violations[1])
-        XCTAssertEqual(firstViolation.ruleIdentifier, SuperfluousDisableCommandRule.description.identifier)
+        XCTAssertTrue(firstViolation.isSuperfluousDisableCommandViolation())
         XCTAssertTrue(firstViolation.didNotTrigger(for: "custom_rules"))
-        XCTAssertEqual(secondViolation.ruleIdentifier, SuperfluousDisableCommandRule.description.identifier)
+        XCTAssertTrue(secondViolation.isSuperfluousDisableCommandViolation())
         XCTAssertTrue(secondViolation.didNotTrigger(for: "\(customRuleIdentifier)"))
     }
 
@@ -286,7 +286,7 @@ final class CustomRulesTests: SwiftLintTestCase {
         XCTAssertEqual(violations.count, 2)
         let (firstViolation, secondViolation) = (violations[0], violations[1])
         XCTAssertEqual(firstViolation.ruleIdentifier, customRuleIdentifier)
-        XCTAssertEqual(secondViolation.ruleIdentifier, SuperfluousDisableCommandRule.description.identifier)
+        XCTAssertTrue(secondViolation.isSuperfluousDisableCommandViolation())
         XCTAssertTrue(secondViolation.didNotTrigger(for: customRuleIdentifier))
     }
 
@@ -356,7 +356,7 @@ final class CustomRulesTests: SwiftLintTestCase {
             return
         }
         XCTAssertEqual(violations.count, 1)
-        XCTAssertEqual(violation.ruleIdentifier, SuperfluousDisableCommandRule.description.identifier)
+        XCTAssertTrue(violation.isSuperfluousDisableCommandViolation())
         XCTAssertTrue(violation.didNotTrigger(for: customRuleIdentifier))
     }
 
@@ -388,9 +388,9 @@ final class CustomRulesTests: SwiftLintTestCase {
         XCTAssertEqual(violations.count, 3)
         let (firstViolation, secondViolation, thirdViolation) = (violations[0], violations[1], violations[2])
         XCTAssertEqual(firstViolation.ruleIdentifier, "custom2")
-        XCTAssertEqual(secondViolation.ruleIdentifier, SuperfluousDisableCommandRule.description.identifier)
+        XCTAssertTrue(secondViolation.isSuperfluousDisableCommandViolation())
         XCTAssertTrue(secondViolation.didNotTrigger(for: "custom1"))
-        XCTAssertEqual(thirdViolation.ruleIdentifier, SuperfluousDisableCommandRule.description.identifier)
+        XCTAssertTrue(thirdViolation.isSuperfluousDisableCommandViolation())
         XCTAssertTrue(thirdViolation.didNotTrigger(for: "custom3"))
     }
 
@@ -531,5 +531,9 @@ final class CustomRulesTests: SwiftLintTestCase {
 private extension StyleViolation {
     func didNotTrigger(for ruleIdentifier: String) -> Bool {
         reason.contains("SwiftLint rule '\(ruleIdentifier)' did not trigger a violation")
+    }
+
+    func isSuperfluousDisableCommandViolation() -> Bool {
+        ruleIdentifier == SuperfluousDisableCommandRule.description.identifier
     }
 }

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -2,6 +2,7 @@ import SourceKittenFramework
 @testable import SwiftLintCore
 import XCTest
 
+// swiftlint:disable file_length
 final class CustomRulesTests: SwiftLintTestCase {
     typealias Configuration = RegexConfiguration<CustomRules>
     func testCustomRuleConfigurationSetsCorrectlyWithMatchKinds() {

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -238,6 +238,23 @@ final class CustomRulesTests: SwiftLintTestCase {
         XCTAssertEqual(violations.count, 0)
     }
 
+    func testSuperfluousCommandWorksForCustomRulesWorks() throws {
+        let customRules: [String: Any] = [
+            "forbidden": [
+                "regex": "FORBIDDEN",
+            ],
+        ]
+
+        let example = Example("""
+                              // swiftlint:disable:next custom_rules
+                              let ALLOWED = 2
+                              """)
+
+        let violations = try violations(forExample: example, customRules: customRules)
+        // Reports the superfluous_disable_command as being for `forbidden`??
+        XCTAssertEqual(violations.count, 1)
+    }
+
     func testSuperfluousDisableCommandWithCustomRules() throws {
         let customRules: [String: Any] = [
             "custom1": [

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -256,8 +256,16 @@ final class CustomRulesTests: SwiftLintTestCase {
                               """)
 
         let violations = try violations(forExample: example, customRules: customRules)
-        // Reports a superfluous_disable_command violation for each defined custom rule
         XCTAssertEqual(violations.count, 1)
+
+        let example2 = Example("""
+                              // swiftlint:disable:next forbidden forbidden2
+                              let ALLOWED = 2
+                              """)
+
+        let violations2 = try self.violations(forExample: example2, customRules: customRules)
+        // Should report a superfluous_disable_command violation for each explicitly mentioned rule
+        XCTAssertEqual(violations2.count, 2)
     }
 
     func testSuperfluousDisableCommandWithCustomRules() throws {

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -308,15 +308,7 @@ final class CustomRulesTests: SwiftLintTestCase {
     }
 
     func testSuperfluousCommandWorksForCustomRulesWorks() throws {
-        let customRules: [String: Any] = [
-            "forbidden": [
-                "regex": "FORBIDDEN",
-            ],
-            "forbidden2": [
-                "regex": "FORBIDDEN2",
-            ],
-        ]
-
+        let customRules = getForbiddenCustomRules()
         let example = Example("""
                               // swiftlint:disable:next custom_rules
                               let ALLOWED = 2
@@ -324,30 +316,39 @@ final class CustomRulesTests: SwiftLintTestCase {
 
         let violations = try violations(forExample: example, customRules: customRules)
         XCTAssertEqual(violations.count, 1)
+    }
 
-        let example2 = Example("""
+    func someOtherTest2() throws {
+        let customRules = getForbiddenCustomRules()
+        let example = Example("""
                               // swiftlint:disable:next forbidden forbidden2
                               let ALLOWED = 2
                               """)
 
-        let violations2 = try self.violations(forExample: example2, customRules: customRules)
-        XCTAssertEqual(violations2.count, 2)
+        let violations = try self.violations(forExample: example, customRules: customRules)
+        XCTAssertEqual(violations.count, 2)
+    }
 
-        let example3 = Example("""
+    func someOtherTest3() throws {
+        let customRules = getForbiddenCustomRules()
+        let example = Example("""
                               // swiftlint:disable:next forbidden forbidden2
                               let FORBIDDEN = 1
                               """)
 
-        let violations3 = try self.violations(forExample: example3, customRules: customRules)
-        XCTAssertEqual(violations3.count, 1)
+        let violations = try self.violations(forExample: example, customRules: customRules)
+        XCTAssertEqual(violations.count, 1)
+    }
 
-        let example4 = Example("""
+    func someOtherTest4() throws {
+        let customRules = getForbiddenCustomRules()
+        let example = Example("""
                               // swiftlint:disable:next forbidden forbidden2 custom_rules
                               let FORBIDDEN = 1
                               """)
 
-        let violations4 = try self.violations(forExample: example4, customRules: customRules)
-        XCTAssertEqual(violations4.count, 1)
+        let violations = try self.violations(forExample: example, customRules: customRules)
+        XCTAssertEqual(violations.count, 1)
     }
 
     func testSuperfluousDisableCommandWithCustomRules() throws {
@@ -403,15 +404,6 @@ final class CustomRulesTests: SwiftLintTestCase {
         XCTAssertTrue(secondViolation.didNotTrigger(for: "custom1"))
         XCTAssertEqual(thirdViolation.ruleIdentifier, SuperfluousDisableCommandRule.description.identifier)
         XCTAssertTrue(thirdViolation.didNotTrigger(for: "custom3"))
-
-//        XCTAssertEqual(violations.filter { $0.ruleIdentifier == "superfluous_disable_command" }.count, 2)
-//        XCTAssertEqual(violations.filter { $0.ruleIdentifier == "custom2" }.count, 1)
-//        XCTAssertTrue(violations.contains { violation in
-//            violation.description.contains("SwiftLint rule 'custom1' did not trigger a violation")
-//        })
-//        XCTAssertTrue(violations.contains { violation in
-//            violation.description.contains("SwiftLint rule 'custom3' did not trigger a violation")
-//        })
     }
 
     func testSuperfluousDisableCommandDoesNotViolate() throws {
@@ -487,6 +479,17 @@ final class CustomRulesTests: SwiftLintTestCase {
 
         let customRules = customRules(withConfigurations: [regexConfig1, regexConfig2])
         return ((regexConfig1, regexConfig2), customRules)
+    }
+
+    private func getForbiddenCustomRules() -> [String: Any] {
+        [
+            "forbidden": [
+                "regex": "FORBIDDEN",
+            ],
+            "forbidden2": [
+                "regex": "FORBIDDEN2",
+            ],
+        ]
     }
 
     private func getTestTextFile() -> SwiftLintFile {

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -245,6 +245,9 @@ final class CustomRulesTests: SwiftLintTestCase {
             "forbidden": [
                 "regex": "FORBIDDEN",
             ],
+            "forbidden2": [
+                "regex": "FORBIDDEN",
+            ],
         ]
 
         let example = Example("""
@@ -253,7 +256,7 @@ final class CustomRulesTests: SwiftLintTestCase {
                               """)
 
         let violations = try violations(forExample: example, customRules: customRules)
-        // Reports the superfluous_disable_command as being for `forbidden`??
+        // Reports a superfluous_disable_command violation for each defined custom rule
         XCTAssertEqual(violations.count, 1)
     }
 

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -344,18 +344,8 @@ final class CustomRulesTests: SwiftLintTestCase {
             "regex": "pattern",
         ]
 
-        var regexConfig = RegexConfiguration<CustomRules>(identifier: "custom")
-        do {
-            try regexConfig.apply(configuration: config)
-        } catch {
-            XCTFail("Failed regex config")
-        }
-
-        var customRuleConfiguration = CustomRulesConfiguration()
-        customRuleConfiguration.customRuleConfigurations = [regexConfig]
-
-        var customRules = CustomRules()
-        customRules.configuration = customRuleConfiguration
+        let regexConfig = configuration(withIdentifier: "custom", configurationDict: config)
+        let customRules = customRules(withConfigurations: [regexConfig])
 
         let file2 = SwiftLintFile(contents: "// swiftlint:disable custom\n")
         XCTAssertFalse(file2.regions().first?.isRuleEnabled(customRules) ?? true)
@@ -368,18 +358,8 @@ final class CustomRulesTests: SwiftLintTestCase {
         ]
         extraConfig.forEach { config[$0] = $1 }
 
-        var regexConfig = RegexConfiguration<CustomRules>(identifier: "custom")
-        do {
-            try regexConfig.apply(configuration: config)
-        } catch {
-            XCTFail("Failed regex config")
-        }
-
-        var customRuleConfiguration = CustomRulesConfiguration()
-        customRuleConfiguration.customRuleConfigurations = [regexConfig]
-
-        var customRules = CustomRules()
-        customRules.configuration = customRuleConfiguration
+        let regexConfig = configuration(withIdentifier: "custom", configurationDict: config)
+        let customRules = customRules(withConfigurations: [regexConfig])
         return (regexConfig, customRules)
     }
 
@@ -389,30 +369,16 @@ final class CustomRulesTests: SwiftLintTestCase {
             "match_kinds": "comment",
         ]
 
-        var regexConfig1 = Configuration(identifier: "custom1")
-        do {
-            try regexConfig1.apply(configuration: config1)
-        } catch {
-            XCTFail("Failed regex config")
-        }
+        let regexConfig1 = configuration(withIdentifier: "custom1", configurationDict: config1)
 
         let config2 = [
             "regex": "something",
             "match_kinds": "comment",
         ]
 
-        var regexConfig2 = Configuration(identifier: "custom2")
-        do {
-            try regexConfig2.apply(configuration: config2)
-        } catch {
-            XCTFail("Failed regex config")
-        }
+        let regexConfig2 = configuration(withIdentifier: "custom2", configurationDict: config2)
 
-        var customRuleConfiguration = CustomRulesConfiguration()
-        customRuleConfiguration.customRuleConfigurations = [regexConfig1, regexConfig2]
-
-        var customRules = CustomRules()
-        customRules.configuration = customRuleConfiguration
+        let customRules = customRules(withConfigurations: [regexConfig1, regexConfig2])
         return ((regexConfig1, regexConfig2), customRules)
     }
 
@@ -430,5 +396,23 @@ final class CustomRulesTests: SwiftLintTestCase {
             example.skipWrappingInCommentTest(),
             config: configuration
         )
+    }
+
+    private func configuration(withIdentifier identifier: String, configurationDict: [String:Any]) -> Configuration {
+        var regexConfig = Configuration(identifier: identifier)
+        do {
+            try regexConfig.apply(configuration: configurationDict)
+        } catch {
+            XCTFail("Failed regex config")
+        }
+        return regexConfig
+    }
+
+    private func customRules(withConfigurations configurations: [Configuration]) -> CustomRules {
+        var customRuleConfiguration = CustomRulesConfiguration()
+        customRuleConfiguration.customRuleConfigurations = configurations
+        var customRules = CustomRules()
+        customRules.configuration = customRuleConfiguration
+        return customRules
     }
 }

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -5,7 +5,10 @@ import XCTest
 // swiftlint:disable file_length
 // swiftlint:disable:next type_body_length
 final class CustomRulesTests: SwiftLintTestCase {
-    typealias Configuration = RegexConfiguration<CustomRules>
+    private typealias Configuration = RegexConfiguration<CustomRules>
+
+    private var testFile: SwiftLintFile { SwiftLintFile(path: "\(testResourcesPath)/test.txt")! }
+
     func testCustomRuleConfigurationSetsCorrectlyWithMatchKinds() {
         let configDict = [
             "my_custom_rule": [
@@ -155,7 +158,7 @@ final class CustomRulesTests: SwiftLintTestCase {
     func testCustomRulesIncludedDefault() {
         // Violation detected when included is omitted.
         let (_, customRules) = getCustomRules()
-        let violations = customRules.validate(file: getTestTextFile())
+        let violations = customRules.validate(file: testFile)
         XCTAssertEqual(violations.count, 1)
     }
 
@@ -166,7 +169,7 @@ final class CustomRulesTests: SwiftLintTestCase {
         customRuleConfiguration.customRuleConfigurations = [regexConfig]
         customRules.configuration = customRuleConfiguration
 
-        let violations = customRules.validate(file: getTestTextFile())
+        let violations = customRules.validate(file: testFile)
         XCTAssertTrue(violations.isEmpty)
     }
 
@@ -177,7 +180,7 @@ final class CustomRulesTests: SwiftLintTestCase {
         customRuleConfiguration.customRuleConfigurations = [regexConfig]
         customRules.configuration = customRuleConfiguration
 
-        let violations = customRules.validate(file: getTestTextFile())
+        let violations = customRules.validate(file: testFile)
         XCTAssertTrue(violations.isEmpty)
     }
 
@@ -188,7 +191,7 @@ final class CustomRulesTests: SwiftLintTestCase {
         customRuleConfiguration.customRuleConfigurations = [regexConfig]
         customRules.configuration = customRuleConfiguration
 
-        let violations = customRules.validate(file: getTestTextFile())
+        let violations = customRules.validate(file: testFile)
         XCTAssertTrue(violations.isEmpty)
     }
 
@@ -197,7 +200,7 @@ final class CustomRulesTests: SwiftLintTestCase {
             "regex": #"\ba\s+(\w+)"#,
             "capture_group": 1,
         ])
-        let violations = customRules.validate(file: getTestTextFile())
+        let violations = customRules.validate(file: testFile)
         XCTAssertEqual(violations.count, 1)
         XCTAssertEqual(violations[0].location.line, 2)
         XCTAssertEqual(violations[0].location.character, 6)
@@ -297,7 +300,14 @@ final class CustomRulesTests: SwiftLintTestCase {
     }
 
     func testMultipleSpecificCustomRulesTriggersSuperfluousDisableCommand() throws {
-        let customRules = getForbiddenCustomRules()
+        let customRules = [
+            "forbidden": [
+                "regex": "FORBIDDEN",
+            ],
+            "forbidden2": [
+                "regex": "FORBIDDEN2",
+            ],
+        ]
         let example = Example("""
                               // swiftlint:disable:next forbidden forbidden2
                               let ALLOWED = 2
@@ -310,7 +320,14 @@ final class CustomRulesTests: SwiftLintTestCase {
     }
 
     func testUnviolatedSpecificCustomRulesTriggersSuperfluousDisableCommand() throws {
-        let customRules = getForbiddenCustomRules()
+        let customRules = [
+            "forbidden": [
+                "regex": "FORBIDDEN",
+            ],
+            "forbidden2": [
+                "regex": "FORBIDDEN2",
+            ],
+        ]
         let example = Example("""
                               // swiftlint:disable:next forbidden forbidden2
                               let FORBIDDEN = 1
@@ -322,7 +339,14 @@ final class CustomRulesTests: SwiftLintTestCase {
     }
 
     func testViolatedSpecificAndGeneralCustomRulesTriggersSuperfluousDisableCommand() throws {
-        let customRules = getForbiddenCustomRules()
+        let customRules = [
+            "forbidden": [
+                "regex": "FORBIDDEN",
+            ],
+            "forbidden2": [
+                "regex": "FORBIDDEN2",
+            ],
+        ]
         let example = Example("""
                               // swiftlint:disable:next forbidden forbidden2 custom_rules
                               let FORBIDDEN = 1
@@ -434,21 +458,6 @@ final class CustomRulesTests: SwiftLintTestCase {
 
         let customRules = customRules(withConfigurations: [regexConfig1, regexConfig2])
         return ((regexConfig1, regexConfig2), customRules)
-    }
-
-    private func getForbiddenCustomRules() -> [String: Any] {
-        [
-            "forbidden": [
-                "regex": "FORBIDDEN",
-            ],
-            "forbidden2": [
-                "regex": "FORBIDDEN2",
-            ],
-        ]
-    }
-
-    private func getTestTextFile() -> SwiftLintFile {
-        SwiftLintFile(path: "\(testResourcesPath)/test.txt")!
     }
 
     private func violations(forExample example: Example, customRules: [String: Any]) throws -> [StyleViolation] {

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -265,7 +265,7 @@ final class CustomRulesTests: SwiftLintTestCase {
         XCTAssertEqual(firstViolation.ruleIdentifier, SuperfluousDisableCommandRule.description.identifier)
         XCTAssertTrue(firstViolation.didNotTrigger(for: "custom_rules"))
         XCTAssertEqual(secondViolation.ruleIdentifier, SuperfluousDisableCommandRule.description.identifier)
-        XCTAssertEqual(secondViolation.didNotTrigger(for: "\(customRuleIdentifier)"), true)
+        XCTAssertTrue(secondViolation.didNotTrigger(for: "\(customRuleIdentifier)"))
     }
 
     func testSuperfluousDisableCommandAndViolationWithCustomRules() throws {
@@ -291,7 +291,7 @@ final class CustomRulesTests: SwiftLintTestCase {
         XCTAssertTrue(secondViolation.didNotTrigger(for: customRuleIdentifier))
     }
 
-    func testDisablingCustomRulesWorks() throws {
+    func testDisablingCustomRules() throws {
         let customRules: [String: Any] = [
             "forbidden": [
                 "regex": "FORBIDDEN",
@@ -307,7 +307,7 @@ final class CustomRulesTests: SwiftLintTestCase {
         XCTAssertTrue(violations.isEmpty)
     }
 
-    func testSuperfluousCommandWorksForCustomRulesWorks() throws {
+    func testSuperfluousCommandWorksForCustomRules() throws {
         let customRules = getForbiddenCustomRules()
         let example = Example("""
                               // swiftlint:disable:next custom_rules
@@ -318,7 +318,7 @@ final class CustomRulesTests: SwiftLintTestCase {
         XCTAssertEqual(violations.count, 1)
     }
 
-    func someOtherTest2() throws {
+    func testSuperfluousCommandWorksForSpecificCustomRules() throws {
         let customRules = getForbiddenCustomRules()
         let example = Example("""
                               // swiftlint:disable:next forbidden forbidden2
@@ -329,7 +329,7 @@ final class CustomRulesTests: SwiftLintTestCase {
         XCTAssertEqual(violations.count, 2)
     }
 
-    func someOtherTest3() throws {
+    func testSuperfluousCommandWorksForSpecificCustomRulesWhenOneCustomRuleIsViolated() throws {
         let customRules = getForbiddenCustomRules()
         let example = Example("""
                               // swiftlint:disable:next forbidden forbidden2
@@ -340,7 +340,7 @@ final class CustomRulesTests: SwiftLintTestCase {
         XCTAssertEqual(violations.count, 1)
     }
 
-    func someOtherTest4() throws {
+    func testSuperfluousCommandWorksForSpecificAndGeneralCustomRulesWhenOneCustomRuleIsViolated() throws {
         let customRules = getForbiddenCustomRules()
         let example = Example("""
                               // swiftlint:disable:next forbidden forbidden2 custom_rules
@@ -427,6 +427,19 @@ final class CustomRulesTests: SwiftLintTestCase {
         ]
         let example = Example("""
                                // swiftlint:disable:next all
+                               print("Hello, world")
+                               """)
+        XCTAssertTrue(try violations(forExample: example, customRules: customRules).isEmpty)
+    }
+
+    func testDisableAllAndASpecificCustomRule() throws {
+        let customRules: [String: Any] = [
+            "dont_print": [
+                "regex": "print\\("
+            ],
+        ]
+        let example = Example("""
+                               // swiftlint:disable:next all dont_print
                                print("Hello, world")
                                """)
         XCTAssertTrue(try violations(forExample: example, customRules: customRules).isEmpty)

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -203,7 +203,6 @@ final class CustomRulesTests: SwiftLintTestCase {
         XCTAssertEqual(violations[0].location.character, 6)
     }
 
-    // superfluous_disable_command should work for disables of specfic custom rules.
     func testSpecificCustomRuleSuperfluousDisableCommand() throws {
         let customRuleIdentifier = "forbidden"
         let customRules: [String: Any] = [
@@ -223,7 +222,6 @@ final class CustomRulesTests: SwiftLintTestCase {
         XCTAssertEqual(violations.first?.didNotTrigger(for: customRuleIdentifier), true)
     }
 
-    // superfluous_disable_command of custom_rules should also still work.
     func testCustomRulesSuperfluousDisableCommand() throws {
         let customRuleIdentifier = "forbidden"
         let customRules: [String: Any] = [
@@ -244,7 +242,6 @@ final class CustomRulesTests: SwiftLintTestCase {
         XCTAssertEqual(violations.first?.didNotTrigger(for: "custom_rules"), true)
     }
 
-    // superfluous_disable_command of custom_rules should also still work.
     func testSpecificAndCustomRulesSuperfluousDisableCommand() throws {
         let customRuleIdentifier = "forbidden"
         let customRules: [String: Any] = [

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -203,6 +203,67 @@ final class CustomRulesTests: SwiftLintTestCase {
         XCTAssertEqual(violations[0].location.character, 6)
     }
 
+    // superfluous_disable_command should work for disables of specfic custom rules.
+    func testSpecificCustomRuleSuperfluousDisableCommand() throws {
+        let customRuleIdentifier = "forbidden"
+        let customRules: [String: Any] = [
+            customRuleIdentifier: [
+                "regex": "FORBIDDEN",
+            ],
+        ]
+
+        let example = Example("""
+                              // swiftlint:disable:next \(customRuleIdentifier)
+                              let ALLOWED = 2
+                              """)
+
+        let violations = try violations(forExample: example, customRules: customRules)
+
+        XCTAssertEqual(violations.count, 1)
+        XCTAssertEqual(violations.first?.ruleIdentifier, SuperfluousDisableCommandRule.description.identifier)
+    }
+
+    // superfluous_disable_command of custom_rules should also still work.
+    func testCustomRulesSuperfluousDisableCommand() throws {
+        let customRuleIdentifier = "forbidden"
+        let customRules: [String: Any] = [
+            customRuleIdentifier: [
+                "regex": "FORBIDDEN",
+            ],
+        ]
+
+        let example = Example("""
+                              // swiftlint:disable:next custom_rules
+                              let ALLOWED = 2
+                              """)
+
+        let violations = try violations(forExample: example, customRules: customRules)
+
+        XCTAssertEqual(violations.count, 1)
+        XCTAssertEqual(violations.first?.ruleIdentifier, SuperfluousDisableCommandRule.description.identifier)
+    }
+
+    // superfluous_disable_command of custom_rules should also still work.
+    func testSpecificAndCustomRulesSuperfluousDisableCommand() throws {
+        let customRuleIdentifier = "forbidden"
+        let customRules: [String: Any] = [
+            customRuleIdentifier: [
+                "regex": "FORBIDDEN",
+            ],
+        ]
+
+        let example = Example("""
+                              // swiftlint:disable:next custom_rules \(customRuleIdentifier)
+                              let ALLOWED = 2
+                              """)
+
+        let violations = try violations(forExample: example, customRules: customRules)
+
+        XCTAssertEqual(violations.count, 2)
+        XCTAssertEqual(violations.first?.ruleIdentifier, SuperfluousDisableCommandRule.description.identifier)
+        XCTAssertEqual(violations[1].ruleIdentifier, SuperfluousDisableCommandRule.description.identifier)
+    }
+
     func testSuperfluousDisableCommandAndViolationWithCustomRules() throws {
         let customRuleIdentifier = "forbidden"
         let customRules: [String: Any] = [
@@ -246,7 +307,7 @@ final class CustomRulesTests: SwiftLintTestCase {
                 "regex": "FORBIDDEN",
             ],
             "forbidden2": [
-                "regex": "FORBIDDEN",
+                "regex": "FORBIDDEN2",
             ],
         ]
 
@@ -264,8 +325,23 @@ final class CustomRulesTests: SwiftLintTestCase {
                               """)
 
         let violations2 = try self.violations(forExample: example2, customRules: customRules)
-        // Should report a superfluous_disable_command violation for each explicitly mentioned rule
         XCTAssertEqual(violations2.count, 2)
+
+        let example3 = Example("""
+                              // swiftlint:disable:next forbidden forbidden2
+                              let FORBIDDEN = 1
+                              """)
+
+        let violations3 = try self.violations(forExample: example3, customRules: customRules)
+        XCTAssertEqual(violations3.count, 1)
+
+        let example4 = Example("""
+                              // swiftlint:disable:next forbidden forbidden2 custom_rules
+                              let FORBIDDEN = 1
+                              """)
+
+        let violations4 = try self.violations(forExample: example4, customRules: customRules)
+        XCTAssertEqual(violations4.count, 1)
     }
 
     func testSuperfluousDisableCommandWithCustomRules() throws {

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -205,7 +205,7 @@ final class CustomRulesTests: SwiftLintTestCase {
 
     // MARK: - superfluous_disable_command support
 
-    func testCustomRulesSuperfluousDisableCommand() throws {
+    func testCustomRulesTriggersSuperfluousDisableCommand() throws {
         let customRuleIdentifier = "forbidden"
         let customRules: [String: Any] = [
             customRuleIdentifier: [
@@ -222,10 +222,10 @@ final class CustomRulesTests: SwiftLintTestCase {
 
         XCTAssertEqual(violations.count, 1)
         XCTAssertTrue(violations[0].isSuperfluousDisableCommandViolation())
-        XCTAssertEqual(violations[0].didNotTrigger(for: "custom_rules"), true)
+        XCTAssertTrue(violations[0].didNotTrigger(for: "custom_rules"))
     }
 
-    func testSpecificCustomRuleSuperfluousDisableCommand() throws {
+    func testSpecificCustomRuleTriggersSuperfluousDisableCommand() throws {
         let customRuleIdentifier = "forbidden"
         let customRules: [String: Any] = [
             customRuleIdentifier: [
@@ -241,7 +241,7 @@ final class CustomRulesTests: SwiftLintTestCase {
         let violations = try violations(forExample: example, customRules: customRules)
         XCTAssertEqual(violations.count, 1)
         XCTAssertTrue(violations[0].isSuperfluousDisableCommandViolation())
-        XCTAssertEqual(violations[0].didNotTrigger(for: customRuleIdentifier), true)
+        XCTAssertTrue(violations[0].didNotTrigger(for: customRuleIdentifier))
     }
 
     func testSpecificAndCustomRulesSuperfluousDisableCommand() throws {
@@ -260,11 +260,10 @@ final class CustomRulesTests: SwiftLintTestCase {
         let violations = try violations(forExample: example, customRules: customRules)
 
         XCTAssertEqual(violations.count, 2)
-        let (firstViolation, secondViolation) = (violations[0], violations[1])
-        XCTAssertTrue(firstViolation.isSuperfluousDisableCommandViolation())
-        XCTAssertTrue(firstViolation.didNotTrigger(for: "custom_rules"))
-        XCTAssertTrue(secondViolation.isSuperfluousDisableCommandViolation())
-        XCTAssertTrue(secondViolation.didNotTrigger(for: "\(customRuleIdentifier)"))
+        XCTAssertTrue(violations[0].isSuperfluousDisableCommandViolation())
+        XCTAssertTrue(violations[0].didNotTrigger(for: "custom_rules"))
+        XCTAssertTrue(violations[1].isSuperfluousDisableCommandViolation())
+        XCTAssertTrue(violations[1].didNotTrigger(for: "\(customRuleIdentifier)"))
     }
 
     func testSuperfluousDisableCommandAndViolationWithCustomRules() throws {
@@ -284,10 +283,9 @@ final class CustomRulesTests: SwiftLintTestCase {
         let violations = try violations(forExample: example, customRules: customRules)
 
         XCTAssertEqual(violations.count, 2)
-        let (firstViolation, secondViolation) = (violations[0], violations[1])
-        XCTAssertEqual(firstViolation.ruleIdentifier, customRuleIdentifier)
-        XCTAssertTrue(secondViolation.isSuperfluousDisableCommandViolation())
-        XCTAssertTrue(secondViolation.didNotTrigger(for: customRuleIdentifier))
+        XCTAssertEqual(violations[0].ruleIdentifier, customRuleIdentifier)
+        XCTAssertTrue(violations[1].isSuperfluousDisableCommandViolation())
+        XCTAssertTrue(violations[1].didNotTrigger(for: customRuleIdentifier))
     }
 
     func testDisablingCustomRules() throws {
@@ -386,12 +384,11 @@ final class CustomRulesTests: SwiftLintTestCase {
         let violations = try violations(forExample: example, customRules: customRules)
 
         XCTAssertEqual(violations.count, 3)
-        let (firstViolation, secondViolation, thirdViolation) = (violations[0], violations[1], violations[2])
-        XCTAssertEqual(firstViolation.ruleIdentifier, "custom2")
-        XCTAssertTrue(secondViolation.isSuperfluousDisableCommandViolation())
-        XCTAssertTrue(secondViolation.didNotTrigger(for: "custom1"))
-        XCTAssertTrue(thirdViolation.isSuperfluousDisableCommandViolation())
-        XCTAssertTrue(thirdViolation.didNotTrigger(for: "custom3"))
+        XCTAssertEqual(violations[0].ruleIdentifier, "custom2")
+        XCTAssertTrue(violations[1].isSuperfluousDisableCommandViolation())
+        XCTAssertTrue(violations[1].didNotTrigger(for: "custom1"))
+        XCTAssertTrue(violations[2].isSuperfluousDisableCommandViolation())
+        XCTAssertTrue(violations[2].didNotTrigger(for: "custom3"))
     }
 
     func testSuperfluousDisableCommandDoesNotViolate() throws {

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -204,23 +204,24 @@ final class CustomRulesTests: SwiftLintTestCase {
     }
 
     func testSuperfluousDisableCommandAndViolationWithCustomRules() throws {
+        let customRuleIdentifier = "forbidden"
         let customRules: [String: Any] = [
-            "forbidden": [
+            customRuleIdentifier: [
                 "regex": "FORBIDDEN",
             ],
         ]
 
         let example = Example("""
                               let FORBIDDEN = 1
-                              // swiftlint:disable:next forbidden
+                              // swiftlint:disable:next \(customRuleIdentifier)
                               let ALLOWED = 2
                               """)
 
         let violations = try violations(forExample: example, customRules: customRules)
 
-        // We should get a violation on the first line, and a superfluous_disable_command
-        // violation on the second
         XCTAssertEqual(violations.count, 2)
+        XCTAssertEqual(violations.first?.ruleIdentifier, customRuleIdentifier)
+        XCTAssertEqual(violations[1].ruleIdentifier, SuperfluousDisableCommandRule.description.identifier)
     }
 
     func testDisablingCustomRulesWorks() throws {
@@ -349,6 +350,9 @@ final class CustomRulesTests: SwiftLintTestCase {
 
         let file2 = SwiftLintFile(contents: "// swiftlint:disable custom\n")
         XCTAssertFalse(file2.regions().first?.isRuleEnabled(customRules) ?? true)
+
+        let file3 = SwiftLintFile(contents: "// swiftlint:disable all\n")
+        XCTAssertFalse(file3.regions().first?.isRuleEnabled(customRules) ?? true)
     }
 
     private func getCustomRules(_ extraConfig: [String: Any] = [:]) -> (Configuration, CustomRules) {

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -244,7 +244,6 @@ final class CustomRulesTests: SwiftLintTestCase {
         XCTAssertEqual(violations.first?.didNotTrigger(for: customRuleIdentifier), true)
     }
 
-
     func testSpecificAndCustomRulesSuperfluousDisableCommand() throws {
         let customRuleIdentifier = "forbidden"
         let customRules: [String: Any] = [

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -403,24 +403,6 @@ final class CustomRulesTests: SwiftLintTestCase {
         XCTAssertTrue(try violations(forExample: example, customRules: customRules).isEmpty)
     }
 
-    func testRegionsForCustomRules() {
-        let file = SwiftLintFile(contents: "// swiftlint:disable custom_rules\n")
-        XCTAssertFalse(file.regions().first?.isRuleEnabled(CustomRules()) ?? true)
-
-        let config: [String: Any] = [
-            "regex": "pattern",
-        ]
-
-        let regexConfig = configuration(withIdentifier: "custom", configurationDict: config)
-        let customRules = customRules(withConfigurations: [regexConfig])
-
-        let file2 = SwiftLintFile(contents: "// swiftlint:disable custom\n")
-        XCTAssertFalse(file2.regions().first?.isRuleEnabled(customRules) ?? true)
-
-        let file3 = SwiftLintFile(contents: "// swiftlint:disable all\n")
-        XCTAssertFalse(file3.regions().first?.isRuleEnabled(customRules) ?? true)
-    }
-
     // MARK: - Private
 
     private func getCustomRules(_ extraConfig: [String: Any] = [:]) -> (Configuration, CustomRules) {

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -2,7 +2,7 @@ import SourceKittenFramework
 @testable import SwiftLintCore
 import XCTest
 
-// swiftlint:disable file_length
+// swiftlint:disable file_length type_body_length
 final class CustomRulesTests: SwiftLintTestCase {
     typealias Configuration = RegexConfiguration<CustomRules>
     func testCustomRuleConfigurationSetsCorrectlyWithMatchKinds() {

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -212,17 +212,14 @@ final class CustomRulesTests: SwiftLintTestCase {
                 "regex": "FORBIDDEN",
             ],
         ]
-
         let example = Example("""
                               // swiftlint:disable:next custom_rules
                               let ALLOWED = 2
                               """)
 
         let violations = try violations(forExample: example, customRules: customRules)
-
         XCTAssertEqual(violations.count, 1)
-        XCTAssertTrue(violations[0].isSuperfluousDisableCommandViolation())
-        XCTAssertTrue(violations[0].didNotTrigger(for: "custom_rules"))
+        XCTAssertTrue(violations[0].isSuperfluousDisableCommandViolation(for: "custom_rules"))
     }
 
     func testSpecificCustomRuleTriggersSuperfluousDisableCommand() throws {
@@ -240,8 +237,7 @@ final class CustomRulesTests: SwiftLintTestCase {
 
         let violations = try violations(forExample: example, customRules: customRules)
         XCTAssertEqual(violations.count, 1)
-        XCTAssertTrue(violations[0].isSuperfluousDisableCommandViolation())
-        XCTAssertTrue(violations[0].didNotTrigger(for: customRuleIdentifier))
+        XCTAssertTrue(violations[0].isSuperfluousDisableCommandViolation(for: customRuleIdentifier))
     }
 
     func testSpecificAndCustomRulesSuperfluousDisableCommand() throws {
@@ -260,10 +256,8 @@ final class CustomRulesTests: SwiftLintTestCase {
         let violations = try violations(forExample: example, customRules: customRules)
 
         XCTAssertEqual(violations.count, 2)
-        XCTAssertTrue(violations[0].isSuperfluousDisableCommandViolation())
-        XCTAssertTrue(violations[0].didNotTrigger(for: "custom_rules"))
-        XCTAssertTrue(violations[1].isSuperfluousDisableCommandViolation())
-        XCTAssertTrue(violations[1].didNotTrigger(for: "\(customRuleIdentifier)"))
+        XCTAssertTrue(violations[0].isSuperfluousDisableCommandViolation(for: "custom_rules"))
+        XCTAssertTrue(violations[1].isSuperfluousDisableCommandViolation(for: "\(customRuleIdentifier)"))
     }
 
     func testSuperfluousDisableCommandAndViolationWithCustomRules() throws {
@@ -284,8 +278,7 @@ final class CustomRulesTests: SwiftLintTestCase {
 
         XCTAssertEqual(violations.count, 2)
         XCTAssertEqual(violations[0].ruleIdentifier, customRuleIdentifier)
-        XCTAssertTrue(violations[1].isSuperfluousDisableCommandViolation())
-        XCTAssertTrue(violations[1].didNotTrigger(for: customRuleIdentifier))
+        XCTAssertTrue(violations[1].isSuperfluousDisableCommandViolation(for: customRuleIdentifier))
     }
 
     func testDisablingCustomRules() throws {
@@ -354,8 +347,7 @@ final class CustomRulesTests: SwiftLintTestCase {
             return
         }
         XCTAssertEqual(violations.count, 1)
-        XCTAssertTrue(violation.isSuperfluousDisableCommandViolation())
-        XCTAssertTrue(violation.didNotTrigger(for: customRuleIdentifier))
+        XCTAssertTrue(violation.isSuperfluousDisableCommandViolation(for: customRuleIdentifier))
     }
 
     func testSuperfluousDisableCommandWithMultipleCustomRules() throws {
@@ -385,10 +377,8 @@ final class CustomRulesTests: SwiftLintTestCase {
 
         XCTAssertEqual(violations.count, 3)
         XCTAssertEqual(violations[0].ruleIdentifier, "custom2")
-        XCTAssertTrue(violations[1].isSuperfluousDisableCommandViolation())
-        XCTAssertTrue(violations[1].didNotTrigger(for: "custom1"))
-        XCTAssertTrue(violations[2].isSuperfluousDisableCommandViolation())
-        XCTAssertTrue(violations[2].didNotTrigger(for: "custom3"))
+        XCTAssertTrue(violations[1].isSuperfluousDisableCommandViolation(for: "custom1"))
+        XCTAssertTrue(violations[2].isSuperfluousDisableCommandViolation(for: "custom3"))
     }
 
     func testSuperfluousDisableCommandDoesNotViolate() throws {
@@ -526,11 +516,8 @@ final class CustomRulesTests: SwiftLintTestCase {
 }
 
 private extension StyleViolation {
-    func didNotTrigger(for ruleIdentifier: String) -> Bool {
-        reason.contains("SwiftLint rule '\(ruleIdentifier)' did not trigger a violation")
-    }
-
-    func isSuperfluousDisableCommandViolation() -> Bool {
-        ruleIdentifier == SuperfluousDisableCommandRule.description.identifier
+    func isSuperfluousDisableCommandViolation(for ruleIdentifier: String) -> Bool {
+        self.ruleIdentifier == SuperfluousDisableCommandRule.description.identifier &&
+            reason.contains("SwiftLint rule '\(ruleIdentifier)' did not trigger a violation")
     }
 }

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -202,6 +202,26 @@ final class CustomRulesTests: SwiftLintTestCase {
         XCTAssertEqual(violations[0].location.character, 6)
     }
 
+    func testSuperfluousDisableCommandAndViolationWithCustomRules() throws {
+        let customRules: [String: Any] = [
+            "forbidden": [
+                "regex": "FORBIDDEN",
+            ],
+        ]
+
+        let example = Example("""
+                              let FORBIDDEN = 1
+                              // swiftlint:disable:next forbidden
+                              let ALLOWED = 2
+                              """)
+
+        let violations = try violations(forExample: example, customRules: customRules)
+
+        // We should get a violation on the first line, and a superfluous_disable_command
+        // violation on the second
+        XCTAssertEqual(violations.count, 2)
+    }
+
     func testSuperfluousDisableCommandWithCustomRules() throws {
         let customRules: [String: Any] = [
             "custom1": [

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -336,6 +336,31 @@ final class CustomRulesTests: SwiftLintTestCase {
         XCTAssertTrue(try violations(forExample: example, customRules: customRules).isEmpty)
     }
 
+    func testRegionsForCustomRules() {
+        let file = SwiftLintFile(contents: "// swiftlint:disable custom_rules\n")
+        XCTAssertFalse(file.regions().first?.isRuleEnabled(CustomRules()) ?? true)
+
+        let config: [String: Any] = [
+            "regex": "pattern",
+        ]
+
+        var regexConfig = RegexConfiguration<CustomRules>(identifier: "custom")
+        do {
+            try regexConfig.apply(configuration: config)
+        } catch {
+            XCTFail("Failed regex config")
+        }
+
+        var customRuleConfiguration = CustomRulesConfiguration()
+        customRuleConfiguration.customRuleConfigurations = [regexConfig]
+
+        var customRules = CustomRules()
+        customRules.configuration = customRuleConfiguration
+
+        let file2 = SwiftLintFile(contents: "// swiftlint:disable custom\n")
+        XCTAssertFalse(file2.regions().first?.isRuleEnabled(customRules) ?? true)
+    }
+
     private func getCustomRules(_ extraConfig: [String: Any] = [:]) -> (Configuration, CustomRules) {
         var config: [String: Any] = [
             "regex": "pattern",

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -222,6 +222,22 @@ final class CustomRulesTests: SwiftLintTestCase {
         XCTAssertEqual(violations.count, 2)
     }
 
+    func testDisablingCustomRulesWorks() throws {
+        let customRules: [String: Any] = [
+            "forbidden": [
+                "regex": "FORBIDDEN",
+            ],
+        ]
+
+        let example = Example("""
+                              // swiftlint:disable:next custom_rules
+                              let FORBIDDEN = 1
+                              """)
+
+        let violations = try violations(forExample: example, customRules: customRules)
+        XCTAssertEqual(violations.count, 0)
+    }
+
     func testSuperfluousDisableCommandWithCustomRules() throws {
         let customRules: [String: Any] = [
             "custom1": [

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -413,7 +413,7 @@ final class CustomRulesTests: SwiftLintTestCase {
         )
     }
 
-    private func configuration(withIdentifier identifier: String, configurationDict: [String:Any]) -> Configuration {
+    private func configuration(withIdentifier identifier: String, configurationDict: [String: Any]) -> Configuration {
         var regexConfig = Configuration(identifier: identifier)
         do {
             try regexConfig.apply(configuration: configurationDict)

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -2,7 +2,8 @@ import SourceKittenFramework
 @testable import SwiftLintCore
 import XCTest
 
-// swiftlint:disable file_length type_body_length
+// swiftlint:disable file_length
+// swiftlint:disable:next type_body_length
 final class CustomRulesTests: SwiftLintTestCase {
     typealias Configuration = RegexConfiguration<CustomRules>
     func testCustomRuleConfigurationSetsCorrectlyWithMatchKinds() {

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -203,24 +203,7 @@ final class CustomRulesTests: SwiftLintTestCase {
         XCTAssertEqual(violations[0].location.character, 6)
     }
 
-    func testSpecificCustomRuleSuperfluousDisableCommand() throws {
-        let customRuleIdentifier = "forbidden"
-        let customRules: [String: Any] = [
-            customRuleIdentifier: [
-                "regex": "FORBIDDEN",
-            ],
-        ]
-
-        let example = Example("""
-                              // swiftlint:disable:next \(customRuleIdentifier)
-                              let ALLOWED = 2
-                              """)
-
-        let violations = try violations(forExample: example, customRules: customRules)
-        XCTAssertEqual(violations.count, 1)
-        XCTAssertEqual(violations.first?.ruleIdentifier, SuperfluousDisableCommandRule.description.identifier)
-        XCTAssertEqual(violations.first?.didNotTrigger(for: customRuleIdentifier), true)
-    }
+    // MARK: - superfluous_disable_command support
 
     func testCustomRulesSuperfluousDisableCommand() throws {
         let customRuleIdentifier = "forbidden"
@@ -241,6 +224,26 @@ final class CustomRulesTests: SwiftLintTestCase {
         XCTAssertEqual(violations.first?.ruleIdentifier, SuperfluousDisableCommandRule.description.identifier)
         XCTAssertEqual(violations.first?.didNotTrigger(for: "custom_rules"), true)
     }
+
+    func testSpecificCustomRuleSuperfluousDisableCommand() throws {
+        let customRuleIdentifier = "forbidden"
+        let customRules: [String: Any] = [
+            customRuleIdentifier: [
+                "regex": "FORBIDDEN",
+            ],
+        ]
+
+        let example = Example("""
+                              // swiftlint:disable:next \(customRuleIdentifier)
+                              let ALLOWED = 2
+                              """)
+
+        let violations = try violations(forExample: example, customRules: customRules)
+        XCTAssertEqual(violations.count, 1)
+        XCTAssertEqual(violations.first?.ruleIdentifier, SuperfluousDisableCommandRule.description.identifier)
+        XCTAssertEqual(violations.first?.didNotTrigger(for: customRuleIdentifier), true)
+    }
+
 
     func testSpecificAndCustomRulesSuperfluousDisableCommand() throws {
         let customRuleIdentifier = "forbidden"
@@ -302,17 +305,6 @@ final class CustomRulesTests: SwiftLintTestCase {
 
         let violations = try violations(forExample: example, customRules: customRules)
         XCTAssertTrue(violations.isEmpty)
-    }
-
-    func testSuperfluousCommandWorksForCustomRules() throws {
-        let customRules = getForbiddenCustomRules()
-        let example = Example("""
-                              // swiftlint:disable:next custom_rules
-                              let ALLOWED = 2
-                              """)
-
-        let violations = try violations(forExample: example, customRules: customRules)
-        XCTAssertEqual(violations.count, 1)
     }
 
     func testSuperfluousCommandWorksForSpecificCustomRules() throws {


### PR DESCRIPTION

So this is a kind of scary PR - addresses #4754 - The `superfluous_disable_command` rule should work for individual `custom_rules`. 

#4755 attempted to address this, but had issues, and was reverted in #5336

This PR is based on @marcelofabri 's work in #4755 with a few additional fixes.

A fair few times I thought I had this cracked, only to find a big hole. I think it's right now, but this PR definitely deserves additional scrutiny.

Consider the example below:

```
custom_rules:
  forbidden:
    regex: 'FORBIDDEN'
    message: "This is forbidden"
    severity: warning
```

The following code should trigger a `superfluous_disable_command` violation:

```
let FORBIDDEN = 1
// swiftlint:disable:next forbidden
let ALLOWED = 2
```

Today this would produce:

```
% swiftlint --config t.config t.swift --quiet
/Some/Path/To/t.swift:1:5: warning: forbidden Violation: This is forbidden (forbidden)
```

and after this PR is applied, we get:

```
% swiftlint.debug --config t.config t.swift --quiet
/Some/Path/To/t.swift:1:5: warning: forbidden Violation: This is forbidden (forbidden)
/Some/Path/To/t.swift:3:1: warning: Superfluous Disable Command Violation: SwiftLint rule 'forbidden' did not trigger a violation in the disabled region; remove the disable command (superfluous_disable_command)
```

It is currently also possible to disable all custom rules with:

```
// swiftlint:disable:next custom_rules
let FORBIDDEN = 1
```

That behaviour is still supported.

