### PR TITLE
Trigger `missing_docs` rule on declaration-introducing keyword

### DIFF
--- a/Source/SwiftLintBuiltInRules/Rules/Lint/MissingDocsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/MissingDocsRule.swift
@@ -73,15 +73,13 @@ private extension MissingDocsRule {
             }
             let acl = enumAcl ?? .internal
             if let parameter = configuration.parameters.first(where: { $0.value == acl }) {
-                node.elements.forEach {
-                    violations.append(
-                        ReasonedRuleViolation(
-                            position: $0.name.positionAfterSkippingLeadingTrivia,
-                            reason: "\(acl) declarations should be documented",
-                            severity: parameter.severity
-                        )
+                violations.append(
+                    ReasonedRuleViolation(
+                        position: node.caseKeyword.positionAfterSkippingLeadingTrivia,
+                        reason: "\(acl) declarations should be documented",
+                        severity: parameter.severity
                     )
-                }
+                )
             }
         }
 
@@ -191,7 +189,7 @@ private extension MissingDocsRule {
             if let parameter = configuration.parameters.first(where: { $0.value == acl }) {
                 violations.append(
                     ReasonedRuleViolation(
-                        position: (node.modifiers.staticOrClass ?? token).positionAfterSkippingLeadingTrivia,
+                        position: token.positionAfterSkippingLeadingTrivia,
                         reason: "\(acl) declarations should be documented",
                         severity: parameter.severity
                     )
@@ -236,10 +234,6 @@ private extension SyntaxProtocol {
 private extension DeclModifierListSyntax {
     var accessibility: AccessControlLevel? {
         filter { $0.detail == nil }.compactMap { AccessControlLevel(description: $0.name.text) }.first
-    }
-
-    var staticOrClass: TokenSyntax? {
-        first { $0.name.text == "static" || $0.name.text == "class" }?.name
     }
 }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/MissingDocsRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/MissingDocsRuleExamples.swift
@@ -94,14 +94,14 @@ struct MissingDocsRuleExamples {
         Example("""
         /// a doc
         public class C {
-            public ↓static let i = 1
+            public static ↓let i = 1
         }
         """),
         // `excludes_extensions` only excludes the extension declaration itself; not its children.
         Example("""
         public extension A {
             public ↓func f() {}
-            ↓static var i: Int { 1 }
+            static ↓var i: Int { 1 }
             ↓struct S {
                 func f() {}
             }
@@ -112,7 +112,7 @@ struct MissingDocsRuleExamples {
                 func f() {}
             }
             ↓enum E {
-                case ↓a
+                ↓case a
                 func f() {}
             }
         }
@@ -129,7 +129,7 @@ struct MissingDocsRuleExamples {
         Example("""
         extension E {
             public ↓struct S {
-                public ↓static let i = 1
+                public static ↓let i = 1
             }
         }
         """),
@@ -170,7 +170,7 @@ struct MissingDocsRuleExamples {
         """),
         Example("""
         public ↓enum E {
-            case ↓A
+            ↓case A, B
             func f() {}
             init(_ i: Int) { self = .A }
         }
@@ -178,7 +178,7 @@ struct MissingDocsRuleExamples {
         Example("""
         open ↓class C {
             public ↓enum E {
-                case ↓A
+                ↓case A
                 func f() {}
                 init(_ i: Int) { self = .A }
             }
@@ -190,7 +190,7 @@ struct MissingDocsRuleExamples {
         public struct S {}
         public extension S {
             ↓enum E {
-                case ↓A
+                ↓case A
             }
         }
         """),
@@ -199,7 +199,7 @@ struct MissingDocsRuleExamples {
             fileprivate enum E {
                 static let source = ""
             }
-            ↓static var a: Int { 1 }
+            static ↓var a: Int { 1 }
         }
         """, excludeFromDocumentation: true),
         Example("""


### PR DESCRIPTION
Only change violation positions.