### PR TITLE
Making 'actor' keyword keep from warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
 
 #### Enhancements
 
+* Make implicitly confirming to `Actor` to trigger warning.
+  [marunomi](https://github.com/marunomi)
+  [#5442](https://github.com/realm/SwiftLint/issues/5442)
+
 * Linting got around 20% faster due to the praisworthy performance
   improvements done in the [SwiftSyntax](https://github.com/apple/swift-syntax)
   library.

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/MissingDocsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/MissingDocsRule.swift
@@ -34,7 +34,7 @@ private extension MissingDocsRule {
         }
 
         override func visitPost(_ node: ActorDeclSyntax) {
-            aclScope.pop()
+          collectViolation(from: node, on: node.actorKeyword)
         }
 
         override func visitPost(_ node: AssociatedTypeDeclSyntax) {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/MissingDocsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/MissingDocsRule.swift
@@ -29,12 +29,11 @@ private extension MissingDocsRule {
             if node.inherits, configuration.excludesInheritedTypes {
                 return .skipChildren
             }
-            collectViolation(from: node, on: node.actorKeyword)
             return .visitChildren
         }
 
         override func visitPost(_ node: ActorDeclSyntax) {
-          collectViolation(from: node, on: node.actorKeyword)
+          aclScope.pop()
         }
 
         override func visitPost(_ node: AssociatedTypeDeclSyntax) {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/MissingDocsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/MissingDocsRule.swift
@@ -33,7 +33,7 @@ private extension MissingDocsRule {
         }
 
         override func visitPost(_ node: ActorDeclSyntax) {
-          aclScope.pop()
+            aclScope.pop()
         }
 
         override func visitPost(_ node: AssociatedTypeDeclSyntax) {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/MissingDocsRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/MissingDocsRuleExamples.swift
@@ -69,6 +69,18 @@ struct MissingDocsRuleExamples {
         public func f() async {}
         #endif
         """, excludeFromDocumentation: true),
+        Example("""
+        /// Docs
+        public final actor MyActor {
+            public nonisolated var unownedExecutor: UnownedSerialExecutor { }
+        }
+        """, configuration: ["excludes_inherited_types": true]),
+        Example("""
+        /// Docs
+        public final actor MyActor: Actor {
+            public nonisolated var unownedExecutor: UnownedSerialExecutor { }
+        }
+        """, configuration: ["excludes_inherited_types": true])
     ]
 
     static let triggeringExamples = [


### PR DESCRIPTION
This PR will resolve #5422  by adding checking for implicitly confirming to Actor protocol.

I used `override func visit(_ node: ActorDeclSyntax)` to determine if the actor keyword is used.