### PR TITLE
SwiftLintPlugin execution from Script Build Phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,9 +347,11 @@ else
     echo "warning: `swiftlint` command not found - See https://github.com/realm/SwiftLint#installation for installation instructions."
 fi
 ```
+
 > [!NOTE]
-> The `SWIFTLINT_CMD` path use the default Xcode configuration and has been tested on Xcode 15/16, in case of another configuration like
-> custom Swift package path, please change the values accordinaly.
+> The `SWIFTLINT_CMD` path uses the default Xcode configuration and has been
+> tested on Xcode 15/16. In case of another configuration (e.g. a custom
+> Swift package path), please adapt the values accordingly.
 
 > [!TIP]
 > Uncheck `Based on dependency analysis` to run `swiftlint` on all incremental

--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ else
 fi
 ```
 > [!NOTE]
-> The `SWIFTLINT_CMD` path is using the default xcode condiguration and has been tested on xcode 15/16, in case of another configuration like
+> The `SWIFTLINT_CMD` path use the default xcode condiguration and has been tested on xcode 15/16, in case of another configuration like
 > custom package path, please change the values accordinaly.
 
 > [!TIP]

--- a/README.md
+++ b/README.md
@@ -332,8 +332,9 @@ else
 fi
 ```
 
-If you're using the SwiftLintPlugin from SPM. Use the
-following script implementation:
+If you're using the SwiftLintPlugin in a Swift package,
+you may refer to the `swiftlint` executable in the
+following way:
 
 ```bash
 SWIFT_PACKAGE_DIR="${BUILD_DIR%Build/*}SourcePackages/artifacts"

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ SWIFTLINT_CMD=$SWIFT_PACKAGE_DIR/swiftlintplugins/SwiftLintBinary/SwiftLintBinar
 
 if test -f $SWIFTLINT_CMD 2>&1
 then
-    $SWIFTLINT_CMD
+    "$SWIFTLINT_CMD"
 else
     echo "warning: `swiftlint` command not found - See https://github.com/realm/SwiftLint#installation for installation instructions."
 fi

--- a/README.md
+++ b/README.md
@@ -347,8 +347,7 @@ else
     echo "warning: `swiftlint` command not found - See https://github.com/realm/SwiftLint#installation for installation instructions."
 fi
 ```
-
-The `SWIFTLINT_CMD` path is using the default xcode condiguration and has been tested on xcode 15/16, in case of another configuration like custom package path, change the values accordinaly.
+> The `SWIFTLINT_CMD` path is using the default xcode condiguration and has been tested on xcode 15/16, in case of another configuration like custom package path, please change the values accordinaly.
 
 > [!TIP]
 > Uncheck `Based on dependency analysis` to run `swiftlint` on all incremental

--- a/README.md
+++ b/README.md
@@ -348,6 +348,8 @@ else
 fi
 ```
 
+The `SWIFTLINT_CMD` path is using the default xcode condiguration and has been tested on xcode 15/16, in case of another configuration like custom package path, change the values accordinaly.
+
 > [!TIP]
 > Uncheck `Based on dependency analysis` to run `swiftlint` on all incremental
 > builds, suppressing the unspecified outputs warning.

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ else
 fi
 ```
 
-If you're using the SwiftLintPlugin. Use the
+If you're using the SwiftLintPlugin from SPM. Use the
 following script implementation:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ fi
 ```
 > [!NOTE]
 > The `SWIFTLINT_CMD` path use the default xcode condiguration and has been tested on xcode 15/16, in case of another configuration like
-> custom package path, please change the values accordinaly.
+> custom Swift package path, please change the values accordinaly.
 
 > [!TIP]
 > Uncheck `Based on dependency analysis` to run `swiftlint` on all incremental

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ following way:
 SWIFT_PACKAGE_DIR="${BUILD_DIR%Build/*}SourcePackages/artifacts"
 SWIFTLINT_CMD=$SWIFT_PACKAGE_DIR/swiftlintplugins/SwiftLintBinary/SwiftLintBinary.artifactbundle/swiftlint-*/bin/swiftlint
 
-if test -f $SWIFTLINT_CMD 2>&1
+if test -f "$SWIFTLINT_CMD" 2>&1
 then
     "$SWIFTLINT_CMD"
 else

--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ following way:
 
 ```bash
 SWIFT_PACKAGE_DIR="${BUILD_DIR%Build/*}SourcePackages/artifacts"
-SWIFTLINT_CMD=$SWIFT_PACKAGE_DIR/swiftlintplugins/SwiftLintBinary/SwiftLintBinary.artifactbundle/swiftlint-*/bin/swiftlint
+SWIFTLINT_CMD=$(ls "$SWIFT_PACKAGE_DIR"/swiftlintplugins/SwiftLintBinary/SwiftLintBinary.artifactbundle/swiftlint-*/bin/swiftlint | head -n 1)
 
 if test -f "$SWIFTLINT_CMD" 2>&1
 then

--- a/README.md
+++ b/README.md
@@ -332,7 +332,7 @@ else
 fi
 ```
 
-If you're using the SwiftLintPlugins plugin. Use the
+If you're using the SwiftLintPlugin. Use the
 following script implementation:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -332,6 +332,21 @@ else
 fi
 ```
 
+If you're using the SwiftLintPlugins plugin. Use the
+following script implementation:
+
+```bash
+SWIFT_PACKAGE_DIR="${BUILD_DIR%Build/*}SourcePackages/artifacts"
+SWIFTLINT_CMD=$SWIFT_PACKAGE_DIR/swiftlintplugins/SwiftLintBinary/SwiftLintBinary.artifactbundle/swiftlint-*/bin/swiftlint
+
+if test -f $SWIFTLINT_CMD 2>&1
+then
+    $SWIFTLINT_CMD
+else
+    echo "warning: `swiftlint` command not found - See https://github.com/realm/SwiftLint#installation for installation instructions."
+fi
+```
+
 > [!TIP]
 > Uncheck `Based on dependency analysis` to run `swiftlint` on all incremental
 > builds, suppressing the unspecified outputs warning.

--- a/README.md
+++ b/README.md
@@ -347,7 +347,9 @@ else
     echo "warning: `swiftlint` command not found - See https://github.com/realm/SwiftLint#installation for installation instructions."
 fi
 ```
-> The `SWIFTLINT_CMD` path is using the default xcode condiguration and has been tested on xcode 15/16, in case of another configuration like custom package path, please change the values accordinaly.
+> [!NOTE]
+> The `SWIFTLINT_CMD` path is using the default xcode condiguration and has been tested on xcode 15/16, in case of another configuration like
+> custom package path, please change the values accordinaly.
 
 > [!TIP]
 > Uncheck `Based on dependency analysis` to run `swiftlint` on all incremental

--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ else
 fi
 ```
 > [!NOTE]
-> The `SWIFTLINT_CMD` path use the default xcode condiguration and has been tested on xcode 15/16, in case of another configuration like
+> The `SWIFTLINT_CMD` path use the default Xcode configuration and has been tested on Xcode 15/16, in case of another configuration like
 > custom Swift package path, please change the values accordinaly.
 
 > [!TIP]


### PR DESCRIPTION
When using the plugin from SPM, it's possible to run the switlint binary directly in the Script Build Phase, just like any other command.
The script locates the binary path and executes the command.

Sound like the CocoaPods integration.

I just added the script in the README and using the default value (xcode 15/16), these values can be wrong in previous xcode version or with custom package path.

```bash
SWIFT_PACKAGE_DIR="${BUILD_DIR%Build/*}SourcePackages/artifacts"
SWIFTLINT_CMD=$SWIFT_PACKAGE_DIR/swiftlintplugins/SwiftLintBinary/SwiftLintBinary.artifactbundle/swiftlint-*/bin/swiftlint

if test -f $SWIFTLINT_CMD 2>&1
then
    $SWIFTLINT_CMD
else
    echo "warning: `swiftlint` command not found - See https://github.com/realm/SwiftLint#installation for installation instructions."
fi
```