### PR TITLE
Adapt SwiftSyntax repository URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 #### Enhancements
 
 * Linting got around 20% faster due to the praisworthy performance
-  improvements done in the [SwiftSyntax](https://github.com/apple/swift-syntax)
+  improvements done in the [SwiftSyntax](https://github.com/swiftlang/swift-syntax)
   library.
 
 * Rewrite the following rules with SwiftSyntax:

--- a/Package.resolved
+++ b/Package.resolved
@@ -39,7 +39,7 @@
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-syntax.git",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
         "revision" : "55c4e4669c031d697e1924022b8ba250cfde0f2f",
         "version" : "600.0.0-prerelease-2024-04-02"

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.1"),
-        .package(url: "https://github.com/apple/swift-syntax.git", exact: "600.0.0-prerelease-2024-04-02"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", exact: "600.0.0-prerelease-2024-04-02"),
         .package(url: "https://github.com/jpsim/SourceKitten.git", .upToNextMinor(from: "0.35.0")),
         .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.6"),
         .package(url: "https://github.com/scottrhoyt/SwiftyTextTable.git", from: "0.9.0"),

--- a/bazel/repos.bzl
+++ b/bazel/repos.bzl
@@ -14,7 +14,7 @@ def swiftlint_repos(bzlmod = False):
             name = "SwiftSyntax",
             sha256 = "6572f60ca3c75c2a40f8ccec98c5cd0d3994599a39402d69b433381aaf2c1712",
             strip_prefix = "swift-syntax-510.0.2",
-            url = "https://github.com/apple/swift-syntax/archive/refs/tags/510.0.2.tar.gz",
+            url = "https://github.com/swiftlang/swift-syntax/archive/refs/tags/510.0.2.tar.gz",
         )
 
         http_archive(


### PR DESCRIPTION
Due to relocation of the repository to the [The Swift Programming Language](https://github.com/swiftlang) organization.