### PR TITLE
Started to add rationales

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,12 @@
   [#5018](https://github.com/realm/SwiftLint/issues/5018)
 
 ### Bug Fixes
+* Add a new rationale property to rule descriptions, providing a more expansive
+  description of the motivation behind each rule.
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#5681](https://github.com/realm/SwiftLint/issues/5681)
+
+#### Bug Fixes
 
 * Ignore TipKit's `#Rule` macro in `empty_count` rule.  
   [Ueeek](https://github.com/Ueeek)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@
   function parameter can be replaced with an opaque `some` type.  
   [SimplyDanny](https://github.com/SimplyDanny)
 
+* Add a new rationale property to rule descriptions, providing a more expansive
+  description of the motivation behind each rule.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#5681](https://github.com/realm/SwiftLint/issues/5681)
+
 ### Bug Fixes
 
 * Fix issue referencing the Tests package from another Bazel workspace.  
@@ -167,11 +172,6 @@
 * Improve performance when exclude patterns resolve to a large set of files.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#5018](https://github.com/realm/SwiftLint/issues/5018)
-
-* Add a new rationale property to rule descriptions, providing a more expansive
-  description of the motivation behind each rule.  
-  [Martin Redington](https://github.com/mildm8nnered)
-  [#5681](https://github.com/realm/SwiftLint/issues/5681)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,7 +170,7 @@
 
 ### Bug Fixes
 * Add a new rationale property to rule descriptions, providing a more expansive
-  description of the motivation behind each rule.
+  description of the motivation behind each rule.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#5681](https://github.com/realm/SwiftLint/issues/5681)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,7 +168,6 @@
   [SimplyDanny](https://github.com/SimplyDanny)
   [#5018](https://github.com/realm/SwiftLint/issues/5018)
 
-### Bug Fixes
 * Add a new rationale property to rule descriptions, providing a more expansive
   description of the motivation behind each rule.  
   [Martin Redington](https://github.com/mildm8nnered)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,7 +173,7 @@
   [SimplyDanny](https://github.com/SimplyDanny)
   [#5018](https://github.com/realm/SwiftLint/issues/5018)
 
-#### Bug Fixes
+### Bug Fixes
 
 * Ignore TipKit's `#Rule` macro in `empty_count` rule.  
   [Ueeek](https://github.com/Ueeek)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/AnonymousArgumentInMultilineClosureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/AnonymousArgumentInMultilineClosureRule.swift
@@ -21,7 +21,7 @@ struct AnonymousArgumentInMultilineClosureRule: Rule {
 
         ```
         closure {
-        print(↓$0)
+            print(↓$0)
         }
         ```
         """,

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/AnonymousArgumentInMultilineClosureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/AnonymousArgumentInMultilineClosureRule.swift
@@ -8,6 +8,23 @@ struct AnonymousArgumentInMultilineClosureRule: Rule {
         identifier: "anonymous_argument_in_multiline_closure",
         name: "Anonymous Argument in Multiline Closure",
         description: "Use named arguments in multiline closures",
+        rationale: """
+        In multiline closures, prefer
+
+        ```
+            closure { arg in
+                print(arg)
+            }
+        ```
+
+        to
+
+        ```
+            closure {
+                print(↓$0)
+            }
+        ```
+        """,
         kind: .idiomatic,
         nonTriggeringExamples: [
             Example("closure { $0 }"),

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/AnonymousArgumentInMultilineClosureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/AnonymousArgumentInMultilineClosureRule.swift
@@ -12,17 +12,17 @@ struct AnonymousArgumentInMultilineClosureRule: Rule {
         In multiline closures, for clarity, prefer using named arguments
 
         ```
-        closure { arg in
-            print(arg)
-        }
+            closure { arg in
+                print(arg)
+            }
         ```
 
         to anonymous arguments
 
         ```
-        closure {
-            print(↓$0)
-        }
+            closure {
+               print(↓$0)
+            }
         ```
         """,
         kind: .idiomatic,

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/AnonymousArgumentInMultilineClosureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/AnonymousArgumentInMultilineClosureRule.swift
@@ -9,7 +9,7 @@ struct AnonymousArgumentInMultilineClosureRule: Rule {
         name: "Anonymous Argument in Multiline Closure",
         description: "Use named arguments in multiline closures",
         rationale: """
-        In multiline closures, prefer using named arguments
+        In multiline closures, for clarity, prefer using named arguments
 
         ```
             closure { arg in

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/AnonymousArgumentInMultilineClosureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/AnonymousArgumentInMultilineClosureRule.swift
@@ -9,7 +9,7 @@ struct AnonymousArgumentInMultilineClosureRule: Rule {
         name: "Anonymous Argument in Multiline Closure",
         description: "Use named arguments in multiline closures",
         rationale: """
-        In multiline closures, prefer
+        In multiline closures, prefer using named arguments
 
         ```
             closure { arg in
@@ -17,7 +17,7 @@ struct AnonymousArgumentInMultilineClosureRule: Rule {
             }
         ```
 
-        to
+        to anonymous arguments
 
         ```
             closure {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/AnonymousArgumentInMultilineClosureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/AnonymousArgumentInMultilineClosureRule.swift
@@ -12,17 +12,17 @@ struct AnonymousArgumentInMultilineClosureRule: Rule {
         In multiline closures, for clarity, prefer using named arguments
 
         ```
-            closure { arg in
-                print(arg)
-            }
+        closure { arg in
+            print(arg)
+        }
         ```
 
         to anonymous arguments
 
         ```
-            closure {
-                print(↓$0)
-            }
+        closure {
+            print(↓$0)
+        }
         ```
         """,
         kind: .idiomatic,

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/AnonymousArgumentInMultilineClosureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/AnonymousArgumentInMultilineClosureRule.swift
@@ -12,17 +12,17 @@ struct AnonymousArgumentInMultilineClosureRule: Rule {
         In multiline closures, for clarity, prefer using named arguments
 
         ```
-            closure { arg in
-                print(arg)
-            }
+        closure { arg in
+            print(arg)
+        }
         ```
 
         to anonymous arguments
 
         ```
-            closure {
-               print(↓$0)
-            }
+        closure {
+        print(↓$0)
+        }
         ```
         """,
         kind: .idiomatic,

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityLabelForImageRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityLabelForImageRule.swift
@@ -1,14 +1,5 @@
 import SourceKittenFramework
 
-/// In UIKit, a `UIImageView` was by default not an accessibility element, and would only be visible to VoiceOver
-/// and other assistive technologies if the developer explicitly made them an accessibility element. In SwiftUI,
-/// however, an `Image` is an accessibility element by default. If the developer does not explicitly hide them from
-/// accessibility or give them an accessibility label, they will inherit the name of the image file, which often creates
-/// a poor experience when VoiceOver reads things like "close icon white".
-///
-/// Known false negatives for Images declared as instance variables and containers that provide a label but are
-/// not accessibility elements. Known false positives for Images created in a separate function from where they
-/// have accessibility properties applied.
 struct AccessibilityLabelForImageRule: ASTRule, OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
@@ -17,6 +8,17 @@ struct AccessibilityLabelForImageRule: ASTRule, OptInRule {
         name: "Accessibility Label for Image",
         description: "Images that provide context should have an accessibility label or should be explicitly hidden " +
                      "from accessibility",
+        rationale: """
+        In UIKit, a `UIImageView` was by default not an accessibility element, and would only be visible to VoiceOver
+        and other assistive technologies if the developer explicitly made them an accessibility element. In SwiftUI,
+        however, an `Image` is an accessibility element by default. If the developer does not explicitly hide them from
+        accessibility or give them an accessibility label, they will inherit the name of the image file, which often creates
+        a poor experience when VoiceOver reads things like "close icon white".
+
+        Known false negatives for Images declared as instance variables and containers that provide a label but are
+        not accessibility elements. Known false positives for Images created in a separate function from where they
+        have accessibility properties applied.
+        """,
         kind: .lint,
         minSwiftVersion: .fiveDotOne,
         nonTriggeringExamples: AccessibilityLabelForImageRuleExamples.nonTriggeringExamples,

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityLabelForImageRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityLabelForImageRule.swift
@@ -9,14 +9,14 @@ struct AccessibilityLabelForImageRule: ASTRule, OptInRule {
         description: "Images that provide context should have an accessibility label or should be explicitly hidden " +
                      "from accessibility",
         rationale: """
-        In UIKit, a `UIImageView` was by default not an accessibility element, and would only be visible to VoiceOver
-        and other assistive technologies if the developer explicitly made them an accessibility element. In SwiftUI,
-        however, an `Image` is an accessibility element by default. If the developer does not explicitly hide them from
-        accessibility or give them an accessibility label, they will inherit the name of the image file, which often creates
-        a poor experience when VoiceOver reads things like "close icon white".
+        In UIKit, a `UIImageView` was by default not an accessibility element, and would only be visible to VoiceOver \
+        and other assistive technologies if the developer explicitly made them an accessibility element. In SwiftUI, \
+        however, an `Image` is an accessibility element by default. If the developer does not explicitly hide them \
+        from accessibility or give them an accessibility label, they will inherit the name of the image file, which \
+        often creates a poor experience when VoiceOver reads things like "close icon white".
 
-        Known false negatives for Images declared as instance variables and containers that provide a label but are
-        not accessibility elements. Known false positives for Images created in a separate function from where they
+        Known false negatives for Images declared as instance variables and containers that provide a label but are \
+        not accessibility elements. Known false positives for Images created in a separate function from where they \
         have accessibility properties applied.
         """,
         kind: .lint,

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityTraitForButtonRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityTraitForButtonRule.swift
@@ -9,15 +9,15 @@ struct AccessibilityTraitForButtonRule: ASTRule, OptInRule {
         description: "All views with tap gestures added should include the .isButton or the .isLink accessibility " +
                      "traits",
         rationale: """
-        The accessibility button and link traits are used to tell assistive technologies that an element is tappable. When
-        an element has one of these traits, VoiceOver will automatically read "button" or "link" after the element's label
-        to let the user know that they can activate it.
+        The accessibility button and link traits are used to tell assistive technologies that an element is tappable. \
+        When an element has one of these traits, VoiceOver will automatically read "button" or "link" after the \
+        element's label to let the user know that they can activate it.
 
-        When using a UIKit `UIButton` or SwiftUI `Button` or `Link`, the button trait is added by default, but when you
-        manually add a tap gesture recognizer to an element, you need to explicitly add the button or link trait.
+        When using a UIKit `UIButton` or SwiftUI `Button` or `Link`, the button trait is added by default, but when \
+        you manually add a tap gesture recognizer to an element, you need to explicitly add the button or link trait. \
 
-        In most cases the button trait should be used, but for buttons that open a URL in an external browser we use
-        the link trait instead. This rule attempts to catch uses of the SwiftUI `.onTapGesture` modifier where the
+        In most cases the button trait should be used, but for buttons that open a URL in an external browser we use \
+        the link trait instead. This rule attempts to catch uses of the SwiftUI `.onTapGesture` modifier where the \
         `.isButton` or `.isLink` trait is not explicitly applied.
         """,
         kind: .lint,

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityTraitForButtonRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityTraitForButtonRule.swift
@@ -1,12 +1,5 @@
 import SourceKittenFramework
 
-/// The accessibility button and link traits are used to tell assistive technologies that an element is tappable. When
-/// an element has one of these traits, VoiceOver will automatically read "button" or "link" after the element's label
-/// to let the user know that they can activate it. When using a UIKit `UIButton` or SwiftUI `Button` or
-/// `Link`, the button trait is added by default, but when you manually add a tap gesture recognizer to an
-/// element, you need to explicitly add the button or link trait. In most cases the button trait should be used, but for
-/// buttons that open a URL in an external browser we use the link trait instead. This rule attempts to catch uses of
-/// the SwiftUI `.onTapGesture` modifier where the `.isButton` or `.isLink` trait is not explicitly applied.
 struct AccessibilityTraitForButtonRule: ASTRule, OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
@@ -15,6 +8,15 @@ struct AccessibilityTraitForButtonRule: ASTRule, OptInRule {
         name: "Accessibility Trait for Button",
         description: "All views with tap gestures added should include the .isButton or the .isLink accessibility " +
                      "traits",
+        rationale: """
+        The accessibility button and link traits are used to tell assistive technologies that an element is tappable. When
+        an element has one of these traits, VoiceOver will automatically read "button" or "link" after the element's label
+        to let the user know that they can activate it. When using a UIKit `UIButton` or SwiftUI `Button` or
+        `Link`, the button trait is added by default, but when you manually add a tap gesture recognizer to an
+        element, you need to explicitly add the button or link trait. In most cases the button trait should be used, but for
+        buttons that open a URL in an external browser we use the link trait instead. This rule attempts to catch uses of
+        the SwiftUI `.onTapGesture` modifier where the `.isButton` or `.isLink` trait is not explicitly applied.
+        """,
         kind: .lint,
         minSwiftVersion: .fiveDotOne,
         nonTriggeringExamples: AccessibilityTraitForButtonRuleExamples.nonTriggeringExamples,

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityTraitForButtonRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityTraitForButtonRule.swift
@@ -11,11 +11,14 @@ struct AccessibilityTraitForButtonRule: ASTRule, OptInRule {
         rationale: """
         The accessibility button and link traits are used to tell assistive technologies that an element is tappable. When
         an element has one of these traits, VoiceOver will automatically read "button" or "link" after the element's label
-        to let the user know that they can activate it. When using a UIKit `UIButton` or SwiftUI `Button` or
-        `Link`, the button trait is added by default, but when you manually add a tap gesture recognizer to an
-        element, you need to explicitly add the button or link trait. In most cases the button trait should be used, but for
-        buttons that open a URL in an external browser we use the link trait instead. This rule attempts to catch uses of
-        the SwiftUI `.onTapGesture` modifier where the `.isButton` or `.isLink` trait is not explicitly applied.
+        to let the user know that they can activate it.
+
+        When using a UIKit `UIButton` or SwiftUI `Button` or `Link`, the button trait is added by default, but when you
+        manually add a tap gesture recognizer to an element, you need to explicitly add the button or link trait.
+
+        In most cases the button trait should be used, but for buttons that open a URL in an external browser we use
+        the link trait instead. This rule attempts to catch uses of the SwiftUI `.onTapGesture` modifier where the
+        `.isButton` or `.isLink` trait is not explicitly applied.
         """,
         kind: .lint,
         minSwiftVersion: .fiveDotOne,

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ArrayInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ArrayInitRule.swift
@@ -13,27 +13,27 @@ struct ArrayInitRule: Rule, @unchecked Sendable {
         constructor over calling `map`. For example
 
         ```
-            Array(foo)
+        Array(foo)
         ```
 
         rather than
 
         ```
-            foo.↓map({ $0 })
+        foo.↓map({ $0 })
         ```
 
         If some processing of the elements is required, then using `map` is fine. For example
 
         ```
-            foo.map { !$0 }
+        foo.map { !$0 }
         ```
 
         Constructs like
 
         ```
-            enum MyError: Error {}
-            let myResult: Result<String, MyError> = .success("")
-            let result: Result<Any, MyError> = myResult.map { $0 }
+        enum MyError: Error {}
+        let myResult: Result<String, MyError> = .success("")
+        let result: Result<Any, MyError> = myResult.map { $0 }
         ```
 
         may be picked up as false positives by the `array_init` rule. If your codebase contains constructs like this, \

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ArrayInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ArrayInitRule.swift
@@ -9,7 +9,7 @@ struct ArrayInitRule: Rule, @unchecked Sendable {
         name: "Array Init",
         description: "Prefer using `Array(seq)` over `seq.map { $0 }` to convert a sequence into an Array",
         rationale: """
-        When converting the elements of sequence directly into an `Array`, for clarity, prefer using the `Array` \
+        When converting the elements of a sequence directly into an `Array`, for clarity, prefer using the `Array` \
         constructor over calling `map`. For example
 
         ```

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ArrayInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ArrayInitRule.swift
@@ -10,7 +10,7 @@ struct ArrayInitRule: Rule, @unchecked Sendable {
         description: "Prefer using `Array(seq)` over `seq.map { $0 }` to convert a sequence into an Array",
         rationale: """
         When converting a the elements of sequence directly into an `Array`, for clarity and to better convey \
-        intent, prefer using the `Array` constructor to `map`. For example
+        intent, prefer using the `Array` constructor over calling `map`. For example
 
         ```
             Array(foo)

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ArrayInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ArrayInitRule.swift
@@ -26,6 +26,16 @@ struct ArrayInitRule: Rule, @unchecked Sendable {
         ```
             foo.map { !$0 }
         ```
+
+        Constructs like
+
+        ```
+            enum MyError: Error {}
+            let myResult: Result<String, MyError> = .success("")
+            let result: Result<Any, MyError> = myResult.map { $0 }
+        ```
+
+        may be picked up as false positives by the `array_init` rule. If your codebase contains constructs like this, consider using the `typesafe_array_init` analyzer rule instead.
         """,
         kind: .lint,
         nonTriggeringExamples: [

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ArrayInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ArrayInitRule.swift
@@ -13,27 +13,27 @@ struct ArrayInitRule: Rule, @unchecked Sendable {
         constructor over calling `map`. For example
 
         ```
-        Array(foo)
+            Array(foo)
         ```
 
         rather than
 
         ```
-        foo.↓map({ $0 })
+            foo.↓map({ $0 })
         ```
 
         If some processing of the elements is required, then using `map` is fine. For example
 
         ```
-        foo.map { !$0 }
+            foo.map { !$0 }
         ```
 
         Constructs like
 
         ```
-        enum MyError: Error {}
-        let myResult: Result<String, MyError> = .success("")
-        let result: Result<Any, MyError> = myResult.map { $0 }
+            enum MyError: Error {}
+            let myResult: Result<String, MyError> = .success("")
+            let result: Result<Any, MyError> = myResult.map { $0 }
         ```
 
         may be picked up as false positives by the `array_init` rule. If your codebase contains constructs like this, \

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ArrayInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ArrayInitRule.swift
@@ -26,7 +26,7 @@ struct ArrayInitRule: Rule, @unchecked Sendable {
         ```
             foo.map { !$0 }
         ```
-        """
+        """,
         kind: .lint,
         nonTriggeringExamples: [
             Example("Array(foo)"),

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ArrayInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ArrayInitRule.swift
@@ -9,19 +9,20 @@ struct ArrayInitRule: Rule, @unchecked Sendable {
         name: "Array Init",
         description: "Prefer using `Array(seq)` over `seq.map { $0 }` to convert a sequence into an Array",
         rationale: """
-        Prefer
+        When converting a the elements of sequence directly into an `Array`, for clarity and to better convey \
+        intent, prefer using the `Array` constructor to `map`. For example
 
         ```
             Array(foo)
         ```
 
-        to
+        rather than
 
         ```
             foo.↓map({ $0 })
         ```
 
-        for cases where the argument to map is just the element. More complex closures are fine. For example
+        If some processing of the elements is required, then using `map` is fine. For example
 
         ```
             foo.map { !$0 }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ArrayInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ArrayInitRule.swift
@@ -9,8 +9,7 @@ struct ArrayInitRule: Rule, @unchecked Sendable {
         name: "Array Init",
         description: "Prefer using `Array(seq)` over `seq.map { $0 }` to convert a sequence into an Array",
         rationale: """
-        When converting a the elements of sequence directly into an `Array`, for clarity and to better convey \
-        intent, prefer using the `Array` constructor over calling `map`. For example
+        When converting the elements of sequence directly into an `Array`, for clarity, prefer using the `Array` constructor over calling `map`. For example
 
         ```
             Array(foo)

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ArrayInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ArrayInitRule.swift
@@ -9,7 +9,8 @@ struct ArrayInitRule: Rule, @unchecked Sendable {
         name: "Array Init",
         description: "Prefer using `Array(seq)` over `seq.map { $0 }` to convert a sequence into an Array",
         rationale: """
-        When converting the elements of sequence directly into an `Array`, for clarity, prefer using the `Array` constructor over calling `map`. For example
+        When converting the elements of sequence directly into an `Array`, for clarity, prefer using the `Array` \
+        constructor over calling `map`. For example
 
         ```
             Array(foo)
@@ -35,7 +36,8 @@ struct ArrayInitRule: Rule, @unchecked Sendable {
             let result: Result<Any, MyError> = myResult.map { $0 }
         ```
 
-        may be picked up as false positives by the `array_init` rule. If your codebase contains constructs like this, consider using the `typesafe_array_init` analyzer rule instead.
+        may be picked up as false positives by the `array_init` rule. If your codebase contains constructs like this, \
+        consider using the `typesafe_array_init` analyzer rule instead.
         """,
         kind: .lint,
         nonTriggeringExamples: [

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ArrayInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ArrayInitRule.swift
@@ -8,6 +8,25 @@ struct ArrayInitRule: Rule, @unchecked Sendable {
         identifier: "array_init",
         name: "Array Init",
         description: "Prefer using `Array(seq)` over `seq.map { $0 }` to convert a sequence into an Array",
+        rationale: """
+        Prefer
+
+        ```
+            Array(foo)
+        ```
+
+        to
+
+        ```
+            foo.↓map({ $0 })
+        ```
+
+        for cases where the argument to map is just the element. More complex closures are fine. For example
+
+        ```
+            foo.map { !$0 }
+        ```
+        """
         kind: .lint,
         nonTriggeringExamples: [
             Example("Array(foo)"),

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/BalancedXCTestLifecycleRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/BalancedXCTestLifecycleRule.swift
@@ -12,34 +12,11 @@ struct BalancedXCTestLifecycleRule: Rule {
         The `setUp` method of `XCTestCase` can be used to set up variables and resources before \
         each test is run (or with the `class` variant, before all tests are run).
 
-        The memory model for XCTestCase objects is non-obvious. An instance of the `XCTestCase` \
-        subclass will be created for each test method, and these will persist for the entire test run.
+        This rule verifies that every class with an implementation of a `setUp` method also has \
+        a `tearDown` method (and vice versa).
 
-        So in a test class with 10 tests, given
-
-        ```
-        private var foo: String = "Bar"
-        ```
-
-        "Bar" will be stored 10 times over, but with
-
-        ```
-        // swiftlint:disable:next implicitly_unwrapped_optional
-        private var foo: String!
-
-        func setUp() {
-            foo = "Bar"
-        }
-
-        func tearDown() {
-            foo = nil
-        }
-        ```
-
-        no memory will be consumed by the value of the variable.
-
-        More generally, if `setUp` is implemented, then `tearDown` should also be implemented, \
-        and cleanup performed there.
+        The `tearDown` method should be used to cleanup or reset any resources that could \
+        otherwise have any effects on subsequent tests, and to free up any instance variables.
         """,
         kind: .lint,
         nonTriggeringExamples: [

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/BalancedXCTestLifecycleRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/BalancedXCTestLifecycleRule.swift
@@ -36,7 +36,7 @@ struct BalancedXCTestLifecycleRule: Rule {
         }
         ```
 
-        No memory will be consumed by the value of the variable.
+        no memory will be consumed by the value of the variable.
 
         More generally, if `setUp` is implemented, then `tearDown` should also be implemented, \
         and cleanup performed there.

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/BalancedXCTestLifecycleRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/BalancedXCTestLifecycleRule.swift
@@ -8,6 +8,39 @@ struct BalancedXCTestLifecycleRule: Rule {
         identifier: "balanced_xctest_lifecycle",
         name: "Balanced XCTest Life Cycle",
         description: "Test classes must implement balanced setUp and tearDown methods",
+        rationale: """
+        The `setUp` method of `XCTestCase` can be used to set up variables and resources before \
+        each test is run (or with the `class` variant, before all tests are run).
+
+        The memory model for XCTestCase objects is non-obvious. An instance of the `XCTestCase` \
+        subclass will be created for each test method, and these will persist for the entire test run.
+
+        So in a test class with 10 tests, given
+
+        ```
+        private var foo: String = "Bar"
+        ```
+
+        "Bar" will be stored 10 times over, but with
+
+        ```
+        // swiftlint:disable:next implicitly_unwrapped_optional
+        private var foo: String!
+
+        func setUp() {
+            foo = "Bar"
+        }
+
+        func tearDown() {
+            foo = nil
+        }
+        ```
+
+        No memory will be consumed by the value of the variable.
+
+        More generally, if `setUp` is implemented, then `tearDown` should also be implemented, \
+        and cleanup performed there.
+        """,
         kind: .lint,
         nonTriggeringExamples: [
             Example(#"""

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/BalancedXCTestLifecycleRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/BalancedXCTestLifecycleRule.swift
@@ -18,22 +18,22 @@ struct BalancedXCTestLifecycleRule: Rule {
         So in a test class with 10 tests, given
 
         ```
-            private var foo: String = "Bar"
+        private var foo: String = "Bar"
         ```
 
         "Bar" will be stored 10 times over, but with
 
         ```
-            // swiftlint:disable:next implicitly_unwrapped_optional
-            private var foo: String!
+        // swiftlint:disable:next implicitly_unwrapped_optional
+        private var foo: String!
 
-            func setUp() {
-                foo = "Bar"
-            }
+        func setUp() {
+            foo = "Bar"
+        }
 
-            func tearDown() {
-                foo = nil
-            }
+        func tearDown() {
+            foo = nil
+        }
         ```
 
         No memory will be consumed by the value of the variable.

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/BalancedXCTestLifecycleRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/BalancedXCTestLifecycleRule.swift
@@ -18,22 +18,22 @@ struct BalancedXCTestLifecycleRule: Rule {
         So in a test class with 10 tests, given
 
         ```
-        private var foo: String = "Bar"
+            private var foo: String = "Bar"
         ```
 
         "Bar" will be stored 10 times over, but with
 
         ```
-        // swiftlint:disable:next implicitly_unwrapped_optional
-        private var foo: String!
+            // swiftlint:disable:next implicitly_unwrapped_optional
+            private var foo: String!
 
-        func setUp() {
-            foo = "Bar"
-        }
+            func setUp() {
+                foo = "Bar"
+            }
 
-        func tearDown() {
-            foo = nil
-        }
+            func tearDown() {
+                foo = nil
+            }
         ```
 
         No memory will be consumed by the value of the variable.

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/BlanketDisableCommandRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/BlanketDisableCommandRule.swift
@@ -13,8 +13,8 @@ struct BlanketDisableCommandRule: Rule, SourceKitFreeRule {
         The intent of this rule is to prevent code like
 
         ```
-        // swiftlint:disable force_unwrapping
-        let foo = bar!
+            // swiftlint:disable force_unwrapping
+            let foo = bar!
         ```
 
         which disables the `force_unwrapping` rule for the remainder the file, instead of just for the specific \
@@ -26,16 +26,10 @@ struct BlanketDisableCommandRule: Rule, SourceKitFreeRule {
         To disable this rule in code you will need to do something like
 
         ```
-        // swiftlint:disable:next blanket_disable_command
-        // swiftlint:disable force_unwrapping
+            // swiftlint:disable:next blanket_disable_command
+            // swiftlint:disable force_unwrapping
         ```
 
-        There are some rules which only make sense in the context of the entire file, for example `file_header`, \
-        `file_length`, `file_name`, `file_name_no_space`, and `single_test_class`. These can be configured with \
-        the `allowed_rules` configuration parameter.
-
-        You can also specify rules which must always be applied to the entire file, and should never be scoped or \
-        re-enabled with the `always_blanket_disable` configuration parameter.
         """,
         kind: .lint,
         nonTriggeringExamples: [

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/BlanketDisableCommandRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/BlanketDisableCommandRule.swift
@@ -10,7 +10,7 @@ struct BlanketDisableCommandRule: Rule, SourceKitFreeRule {
                      to be ignored, instead of disabling the rule for the rest of the file.
                      """,
         rationale: """
-        The intent of this rule is to prevent code like this
+        The intent of this rule is to prevent code like
 
         ```
         // swiftlint:disable force_unwrapping
@@ -20,7 +20,7 @@ struct BlanketDisableCommandRule: Rule, SourceKitFreeRule {
         which disables the `force_unwrapping` rule for the remainder the file, instead of just for the specific \
         violation.
 
-        `next`, `this`, or `previous` be used to restrict the disable commands scope to a single line, or it can be \
+        `next`, `this`, or `previous` can be used to restrict the disable command's scope to a single line, or it can be \
         re-enabled after the violations.
 
         To disable this rule in code you will need to do something like

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/BlanketDisableCommandRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/BlanketDisableCommandRule.swift
@@ -36,7 +36,7 @@ struct BlanketDisableCommandRule: Rule, SourceKitFreeRule {
 
         You can also specify rules which must always be applied to the entire file, and should never be scoped or \
         re-enabled with the `always_blanket_disable` configuration parameter.
-        """
+        """,
         kind: .lint,
         nonTriggeringExamples: [
             Example("""

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/BlanketDisableCommandRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/BlanketDisableCommandRule.swift
@@ -9,6 +9,34 @@ struct BlanketDisableCommandRule: Rule, SourceKitFreeRule {
                      single line, or `swiftlint:enable` to re-enable the rules immediately after the violations \
                      to be ignored, instead of disabling the rule for the rest of the file.
                      """,
+        rationale: """
+        The intent of this rule is to prevent code like this
+
+        ```
+        // swiftlint:disable force_unwrapping
+        let foo = bar!
+        ```
+
+        which disables the `force_unwrapping` rule for the remainder the file, instead of just for the specific \
+        violation.
+
+        `next`, `this`, or `previous` be used to restrict the disable commands scope to a single line, or it can be \
+        re-enabled after the violations.
+
+        To disable this rule in code you will need to do something like
+
+        ```
+        // swiftlint:disable:next blanket_disable_command
+        // swiftlint:disable force_unwrapping
+        ```
+
+        There are some rules which only make sense in the context of the entire file, for example `file_header`, \
+        `file_length`, `file_name`, `file_name_no_space`, and `single_test_class`. These can be configured with \
+        the `allowed_rules` configuration parameter.
+
+        You can also specify rules which must always be applied to the entire file, and should never be scoped or \
+        re-enabled with the `always_blanket_disable` configuration parameter.
+        """
         kind: .lint,
         nonTriggeringExamples: [
             Example("""

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/BlanketDisableCommandRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/BlanketDisableCommandRule.swift
@@ -17,7 +17,7 @@ struct BlanketDisableCommandRule: Rule, SourceKitFreeRule {
         let foo = bar!
         ```
 
-        which disables the `force_unwrapping` rule for the remainder the file, instead of just for the specific \
+        which disables the `force_unwrapping` rule for the remainder of the file, instead of just for the specific \
         violation.
 
         `next`, `this`, or `previous` can be used to restrict the disable command's scope to a single line, or it \

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/BlanketDisableCommandRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/BlanketDisableCommandRule.swift
@@ -20,8 +20,8 @@ struct BlanketDisableCommandRule: Rule, SourceKitFreeRule {
         which disables the `force_unwrapping` rule for the remainder the file, instead of just for the specific \
         violation.
 
-        `next`, `this`, or `previous` can be used to restrict the disable command's scope to a single line, or it can be \
-        re-enabled after the violations.
+        `next`, `this`, or `previous` can be used to restrict the disable command's scope to a single line, or it \
+        can be re-enabled after the violations.
 
         To disable this rule in code you will need to do something like
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/BlanketDisableCommandRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/BlanketDisableCommandRule.swift
@@ -13,8 +13,8 @@ struct BlanketDisableCommandRule: Rule, SourceKitFreeRule {
         The intent of this rule is to prevent code like
 
         ```
-            // swiftlint:disable force_unwrapping
-            let foo = bar!
+        // swiftlint:disable force_unwrapping
+        let foo = bar!
         ```
 
         which disables the `force_unwrapping` rule for the remainder the file, instead of just for the specific \
@@ -26,10 +26,9 @@ struct BlanketDisableCommandRule: Rule, SourceKitFreeRule {
         To disable this rule in code you will need to do something like
 
         ```
-            // swiftlint:disable:next blanket_disable_command
-            // swiftlint:disable force_unwrapping
+        // swiftlint:disable:next blanket_disable_command
+        // swiftlint:disable force_unwrapping
         ```
-
         """,
         kind: .lint,
         nonTriggeringExamples: [

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ClassDelegateProtocolRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ClassDelegateProtocolRule.swift
@@ -8,6 +8,24 @@ struct ClassDelegateProtocolRule: Rule {
         identifier: "class_delegate_protocol",
         name: "Class Delegate Protocol",
         description: "Delegate protocols should be class-only so they can be weakly referenced",
+        rationale: """
+        Delegate protocols are usually `weak`, to avoid retain cycles, or bad references to deallocated delegates.
+
+        The `weak` operator is only supported for classes, and so this rule enforces that protocols ending in \
+        "Delegate" are class based.
+
+        For example
+
+        ```
+            protocol FooDelegate: class {}
+        ```
+
+        versus
+
+        ```
+            ↓protocol FooDelegate {}
+        ```
+        """
         kind: .lint,
         nonTriggeringExamples: [
             Example("protocol FooDelegate: class {}"),

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ClassDelegateProtocolRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ClassDelegateProtocolRule.swift
@@ -9,7 +9,7 @@ struct ClassDelegateProtocolRule: Rule {
         name: "Class Delegate Protocol",
         description: "Delegate protocols should be class-only so they can be weakly referenced",
         rationale: """
-        Delegate protocols are usually `weak`, to avoid retain cycles, or bad references to deallocated delegates.
+        Delegate protocols are usually `weak` to avoid retain cycles, or bad references to deallocated delegates.
 
         The `weak` operator is only supported for classes, and so this rule enforces that protocols ending in \
         "Delegate" are class based.

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ClassDelegateProtocolRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ClassDelegateProtocolRule.swift
@@ -25,7 +25,7 @@ struct ClassDelegateProtocolRule: Rule {
         ```
             ↓protocol FooDelegate {}
         ```
-        """
+        """,
         kind: .lint,
         nonTriggeringExamples: [
             Example("protocol FooDelegate: class {}"),

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ClassDelegateProtocolRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ClassDelegateProtocolRule.swift
@@ -17,13 +17,13 @@ struct ClassDelegateProtocolRule: Rule {
         For example
 
         ```
-        protocol FooDelegate: class {}
+            protocol FooDelegate: class {}
         ```
 
         versus
 
         ```
-        ↓protocol FooDelegate {}
+            ↓protocol FooDelegate {}
         ```
         """,
         kind: .lint,

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ClassDelegateProtocolRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ClassDelegateProtocolRule.swift
@@ -17,13 +17,13 @@ struct ClassDelegateProtocolRule: Rule {
         For example
 
         ```
-            protocol FooDelegate: class {}
+        protocol FooDelegate: class {}
         ```
 
         versus
 
         ```
-            ↓protocol FooDelegate {}
+        ↓protocol FooDelegate {}
         ```
         """,
         kind: .lint,

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/ClosureBodyLengthRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/ClosureBodyLengthRule.swift
@@ -10,9 +10,6 @@ struct ClosureBodyLengthRule: OptInRule, SwiftSyntaxRule {
         "Closure bodies should not span too many lines" says it all.
 
         Possibly you could refactor your closure code and extract some of it into a function.
-
-        Many installations, including SwiftLint's, increase the default warning value from \
-        \(Self.defaultWarningThreshold) to 50, which is a bit more permissive.
         """,
         kind: .metrics,
         nonTriggeringExamples: ClosureBodyLengthRuleExamples.nonTriggeringExamples,

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/ClosureBodyLengthRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/ClosureBodyLengthRule.swift
@@ -1,6 +1,6 @@
 struct ClosureBodyLengthRule: OptInRule, SwiftSyntaxRule {
-    let defaultWarningThreshold = 30
-    var configuration = SeverityLevelsConfiguration<Self>(warning: defaultWarningThreshold, error: 100)
+    private static let defaultWarningThreshold = 30
+    var configuration = SeverityLevelsConfiguration<Self>(warning: Self.defaultWarningThreshold, error: 100)
 
     static let description = RuleDescription(
         identifier: "closure_body_length",
@@ -11,8 +11,8 @@ struct ClosureBodyLengthRule: OptInRule, SwiftSyntaxRule {
 
         Possibly you could refactor your closure code and extract some of it into a function.
 
-        Many installations, including SwiftLint's, increase the default warning value from \(defaultWarningThreshold) \
-        to 50, which is a bit more permissive.
+        Many installations, including SwiftLint's, increase the default warning value from \
+        \(Self.defaultWarningThreshold) to 50, which is a bit more permissive.
         """,
         kind: .metrics,
         nonTriggeringExamples: ClosureBodyLengthRuleExamples.nonTriggeringExamples,

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/ClosureBodyLengthRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/ClosureBodyLengthRule.swift
@@ -1,10 +1,19 @@
 struct ClosureBodyLengthRule: OptInRule, SwiftSyntaxRule {
-    var configuration = SeverityLevelsConfiguration<Self>(warning: 30, error: 100)
+    let defaultWarningThreshold = 30
+    var configuration = SeverityLevelsConfiguration<Self>(warning: defaultWarningThreshold, error: 100)
 
     static let description = RuleDescription(
         identifier: "closure_body_length",
         name: "Closure Body Length",
         description: "Closure bodies should not span too many lines",
+        rationale: """
+        "Closure bodies should not span too many lines" says it all.
+
+        Possibly you could refactor your closure code and extract some of it into a function.
+
+        Many installations, including SwiftLint's, increase the default warning value from \(defaultWarningThreshold) \
+        to 50, which is a bit more permissive.
+        """,
         kind: .metrics,
         nonTriggeringExamples: ClosureBodyLengthRuleExamples.nonTriggeringExamples,
         triggeringExamples: ClosureBodyLengthRuleExamples.triggeringExamples

--- a/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
@@ -20,7 +20,7 @@ struct AttributesRule: Rule {
 
         "This approach limits declaration length. It allows a member to float below its attribute and supports \
         flush-left access modifiers, so `internal`, `public`, etc appear in the leftmost column."
-        """
+        """,
         kind: .style,
         nonTriggeringExamples: AttributesRuleExamples.nonTriggeringExamples,
         triggeringExamples: AttributesRuleExamples.triggeringExamples

--- a/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
@@ -11,6 +11,16 @@ struct AttributesRule: Rule {
             Attributes should be on their own lines in functions and types, but on the same line as variables and \
             imports
             """,
+        rationale: """
+        See https://ericasadun.com/2016/10/02/quick-style-survey/ for discussion.
+
+        Summarizing here: "[Erica Sadun's] take on things after the poll and after talking directly with a number of \
+        developers is this: Placing attributes like `@objc`, `@testable`, `@available`, `@discardableResult` on \
+        their own lines before a member declaration has become a conventional Swift style."
+
+        "This approach limits declaration length. It allows a member to float below its attribute and supports \
+        flush-left access modifiers, so `internal`, `public`, etc appear in the leftmost column."
+        """
         kind: .style,
         nonTriggeringExamples: AttributesRuleExamples.nonTriggeringExamples,
         triggeringExamples: AttributesRuleExamples.triggeringExamples

--- a/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
@@ -19,7 +19,14 @@ struct AttributesRule: Rule {
         their own lines before a member declaration has become a conventional Swift style."
 
         "This approach limits declaration length. It allows a member to float below its attribute and supports \
-        flush-left access modifiers, so `internal`, `public`, etc appear in the leftmost column."
+        flush-left access modifiers, so `internal`, `public`, etc appear in the leftmost column. Many developers \
+        mix-and-match styles for short Swift attributes like `@objc`"
+
+        SwiftLint's rule requires attributes to be on their own lines for functions and types, but on the same line \
+        for variables and imports.
+
+        The `attributes_with_arguments_always_on_line_above`, `always_on_same_line`, and `always_on_line_above` \
+        configuration parameters can be used to fine-tune the rules behaviour for particular attributes.
         """,
         kind: .style,
         nonTriggeringExamples: AttributesRuleExamples.nonTriggeringExamples,

--- a/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
@@ -12,21 +12,20 @@ struct AttributesRule: Rule {
             imports
             """,
         rationale: """
-        See https://ericasadun.com/2016/10/02/quick-style-survey/ for discussion.
+        Erica Sadun says:
 
-        Summarizing here: "[Erica Sadun's] take on things after the poll and after talking directly with a number of \
+        > my take on things after the poll and after talking directly with a number of \
         developers is this: Placing attributes like `@objc`, `@testable`, `@available`, `@discardableResult` on \
-        their own lines before a member declaration has become a conventional Swift style."
+        their own lines before a member declaration has become a conventional Swift style.
 
-        "This approach limits declaration length. It allows a member to float below its attribute and supports \
+        > This approach limits declaration length. It allows a member to float below its attribute and supports \
         flush-left access modifiers, so `internal`, `public`, etc appear in the leftmost column. Many developers \
-        mix-and-match styles for short Swift attributes like `@objc`"
+        mix-and-match styles for short Swift attributes like `@objc`
+
+        See https://ericasadun.com/2016/10/02/quick-style-survey/ for discussion.
 
         SwiftLint's rule requires attributes to be on their own lines for functions and types, but on the same line \
         for variables and imports.
-
-        The `attributes_with_arguments_always_on_line_above`, `always_on_same_line`, and `always_on_line_above` \
-        configuration parameters can be used to fine-tune the rules behaviour for particular attributes.
         """,
         kind: .style,
         nonTriggeringExamples: AttributesRuleExamples.nonTriggeringExamples,

--- a/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
@@ -14,7 +14,7 @@ struct AttributesRule: Rule {
         rationale: """
         Erica Sadun says:
 
-        > my take on things after the poll and after talking directly with a number of \
+        > My take on things after the poll and after talking directly with a number of \
         developers is this: Placing attributes like `@objc`, `@testable`, `@available`, `@discardableResult` on \
         their own lines before a member declaration has become a conventional Swift style.
 

--- a/Source/SwiftLintCore/Models/RuleDescription.swift
+++ b/Source/SwiftLintCore/Models/RuleDescription.swift
@@ -62,10 +62,7 @@ public struct RuleDescription: Equatable, Sendable {
 
     /// The console-printable rationale for this description.
     public var consoleRationale: String? {
-        guard let rationale else {
-            return nil
-        }
-        return rationale.formattedAsConsoleRationale
+        rationale?.consoleRationale
     }
 
     /// All identifiers that have been used to uniquely identify this rule in past and current SwiftLint versions.

--- a/Source/SwiftLintCore/Models/RuleDescription.swift
+++ b/Source/SwiftLintCore/Models/RuleDescription.swift
@@ -59,6 +59,16 @@ public struct RuleDescription: Equatable, Sendable {
     /// The console-printable string for this description.
     public var consoleDescription: String { "\(name) (\(identifier)): \(description)" }
 
+    /// The console-printable rationale for this description.
+    public var consoleRationale: String? {
+        guard let rationale else {
+            return nil
+        }
+        return rationale.components(separatedBy: "\n").compactMap { line in
+            line.contains("```") ? nil : line
+        }.joined(separator: "\n")
+    }
+
     /// All identifiers that have been used to uniquely identify this rule in past and current SwiftLint versions.
     public var allIdentifiers: [String] {
         Array(deprecatedAliases) + [identifier]

--- a/Source/SwiftLintCore/Models/RuleDescription.swift
+++ b/Source/SwiftLintCore/Models/RuleDescription.swift
@@ -12,7 +12,8 @@ public struct RuleDescription: Equatable, Sendable {
     public let description: String
 
     /// A longer explanation of the rule's purpose and rationale. Typically defined as a multiline string, long text 
-    /// lines should be wrapped.
+    /// lines should be wrapped. Markdown formatting is supported. Multiline code blocks will be formatted as
+    /// `swift` code unless otherwise specified.
     public let rationale: String?
 
     /// The `RuleKind` that best categorizes this rule.

--- a/Source/SwiftLintCore/Models/RuleDescription.swift
+++ b/Source/SwiftLintCore/Models/RuleDescription.swift
@@ -64,7 +64,7 @@ public struct RuleDescription: Equatable, Sendable {
         guard let rationale else {
             return nil
         }
-        return rationale.formattedAsRationale
+        return rationale.formattedAsConsoleRationale
     }
 
     /// All identifiers that have been used to uniquely identify this rule in past and current SwiftLint versions.

--- a/Source/SwiftLintCore/Models/RuleDescription.swift
+++ b/Source/SwiftLintCore/Models/RuleDescription.swift
@@ -65,7 +65,7 @@ public struct RuleDescription: Equatable, Sendable {
         rationale?.consoleRationale
     }
 
-    /// The rationale for this description, with MarkDown formatting.
+    /// The rationale for this description, with Markdown formatting.
     public var formattedRationale: String? {
         rationale?.formattedRationale
     }

--- a/Source/SwiftLintCore/Models/RuleDescription.swift
+++ b/Source/SwiftLintCore/Models/RuleDescription.swift
@@ -11,8 +11,8 @@ public struct RuleDescription: Equatable, Sendable {
     /// explanation of the rule's purpose and rationale.
     public let description: String
 
-    /// A longer explanation of the rule's purpose and rationale. Typically defined as a multiline string, long text lines should
-    /// be wrapped.
+    /// A longer explanation of the rule's purpose and rationale. Typically defined as a multiline string, long text 
+    /// lines should be wrapped.
     public let rationale: String?
 
     /// The `RuleKind` that best categorizes this rule.

--- a/Source/SwiftLintCore/Models/RuleDescription.swift
+++ b/Source/SwiftLintCore/Models/RuleDescription.swift
@@ -65,6 +65,11 @@ public struct RuleDescription: Equatable, Sendable {
         rationale?.consoleRationale
     }
 
+    /// The rationale for this description, with MarkDown formatting.
+    public var formattedRationale: String? {
+        rationale?.formattedRationale
+    }
+
     /// All identifiers that have been used to uniquely identify this rule in past and current SwiftLint versions.
     public var allIdentifiers: [String] {
         Array(deprecatedAliases) + [identifier]
@@ -110,5 +115,32 @@ public struct RuleDescription: Equatable, Sendable {
 
     public static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.identifier == rhs.identifier
+    }
+}
+
+private extension String {
+    var formattedRationale: String {
+        formattedRationale(forConsole: false)
+    }
+
+    var consoleRationale: String {
+        formattedRationale(forConsole: true)
+    }
+
+    private func formattedRationale(forConsole: Bool) -> String {
+        var insideMultilineString = false
+        return components(separatedBy: "\n").compactMap { line -> String? in
+            if line.contains("```") {
+                if insideMultilineString {
+                    insideMultilineString = false
+                    return forConsole ? nil : line
+                }
+                insideMultilineString = true
+                if line.hasSuffix("```") {
+                    return forConsole ? nil : (line + "swift")
+                }
+            }
+            return line.indent(by: (insideMultilineString && forConsole) ? 4 : 0)
+        }.joined(separator: "\n")
     }
 }

--- a/Source/SwiftLintCore/Models/RuleDescription.swift
+++ b/Source/SwiftLintCore/Models/RuleDescription.swift
@@ -13,7 +13,8 @@ public struct RuleDescription: Equatable, Sendable {
 
     /// A longer explanation of the rule's purpose and rationale. Typically defined as a multiline string, long text 
     /// lines should be wrapped. Markdown formatting is supported. Multiline code blocks will be formatted as
-    /// `swift` code unless otherwise specified, and should be indented appropriately in the definition.
+    /// `swift` code unless otherwise specified, and will automatically be indented by four spaces when printed
+    /// to the console.
     public let rationale: String?
 
     /// The `RuleKind` that best categorizes this rule.

--- a/Source/SwiftLintCore/Models/RuleDescription.swift
+++ b/Source/SwiftLintCore/Models/RuleDescription.swift
@@ -64,8 +64,22 @@ public struct RuleDescription: Equatable, Sendable {
         guard let rationale else {
             return nil
         }
-        return rationale.components(separatedBy: "\n").compactMap { line in
-            line.contains("```") ? nil : line
+        var insideMultilineString = false
+        return rationale.components(separatedBy: "\n").map { line in
+            if line.contains("```") {
+                if insideMultilineString {
+                    insideMultilineString = false
+                } else {
+                    insideMultilineString = true
+                    if line.hasSuffix("```") {
+                        return line + "swift"
+                    }
+                }
+            }
+            if insideMultilineString {
+                return "     \(line)"
+            }
+            return line
         }.joined(separator: "\n")
     }
 

--- a/Source/SwiftLintCore/Models/RuleDescription.swift
+++ b/Source/SwiftLintCore/Models/RuleDescription.swift
@@ -13,7 +13,7 @@ public struct RuleDescription: Equatable, Sendable {
 
     /// A longer explanation of the rule's purpose and rationale. Typically defined as a multiline string, long text 
     /// lines should be wrapped. Markdown formatting is supported. Multiline code blocks will be formatted as
-    /// `swift` code unless otherwise specified.
+    /// `swift` code unless otherwise specified, and should be indented appropriately in the definition.
     public let rationale: String?
 
     /// The `RuleKind` that best categorizes this rule.

--- a/Source/SwiftLintCore/Models/RuleDescription.swift
+++ b/Source/SwiftLintCore/Models/RuleDescription.swift
@@ -11,7 +11,8 @@ public struct RuleDescription: Equatable, Sendable {
     /// explanation of the rule's purpose and rationale.
     public let description: String
 
-    /// A longer  explanation of the rule's purpose and rationale.
+    /// A longer explanation of the rule's purpose and rationale. Typically defined as a multiline string, long text lines should
+    /// be wrapped.
     public let rationale: String?
 
     /// The `RuleKind` that best categorizes this rule.

--- a/Source/SwiftLintCore/Models/RuleDescription.swift
+++ b/Source/SwiftLintCore/Models/RuleDescription.swift
@@ -64,23 +64,7 @@ public struct RuleDescription: Equatable, Sendable {
         guard let rationale else {
             return nil
         }
-        var insideMultilineString = false
-        return rationale.components(separatedBy: "\n").map { line in
-            if line.contains("```") {
-                if insideMultilineString {
-                    insideMultilineString = false
-                } else {
-                    insideMultilineString = true
-                    if line.hasSuffix("```") {
-                        return line + "swift"
-                    }
-                }
-            }
-            if insideMultilineString {
-                return "     \(line)"
-            }
-            return line
-        }.joined(separator: "\n")
+        return rationale.formattedAsRationale
     }
 
     /// All identifiers that have been used to uniquely identify this rule in past and current SwiftLint versions.

--- a/Source/SwiftLintCore/Models/RuleDescription.swift
+++ b/Source/SwiftLintCore/Models/RuleDescription.swift
@@ -11,6 +11,9 @@ public struct RuleDescription: Equatable, Sendable {
     /// explanation of the rule's purpose and rationale.
     public let description: String
 
+    /// A longer  explanation of the rule's purpose and rationale.
+    public let rationale: String?
+
     /// The `RuleKind` that best categorizes this rule.
     public let kind: RuleKind
 
@@ -74,6 +77,7 @@ public struct RuleDescription: Equatable, Sendable {
     public init(identifier: String,
                 name: String,
                 description: String,
+                rationale: String? = nil,
                 kind: RuleKind,
                 minSwiftVersion: SwiftVersion = .five,
                 nonTriggeringExamples: [Example] = [],
@@ -84,6 +88,7 @@ public struct RuleDescription: Equatable, Sendable {
         self.identifier = identifier
         self.name = name
         self.description = description
+        self.rationale = rationale
         self.kind = kind
         self.nonTriggeringExamples = nonTriggeringExamples
         self.triggeringExamples = triggeringExamples

--- a/Source/SwiftLintFramework/Documentation/RuleDocumentation.swift
+++ b/Source/SwiftLintFramework/Documentation/RuleDocumentation.swift
@@ -105,25 +105,28 @@ private func detailsSummary(_ rule: some Rule) -> String {
 
 extension String {
     var formattedAsRationale: String {
-        var insideMultilineString = false
-        return components(separatedBy: "\n").map { line in
-            if line.contains("```") {
-                if insideMultilineString {
-                    insideMultilineString = false
-                } else {
-                    insideMultilineString = true
-                    if line.hasSuffix("```") {
-                        return line + "swift"
-                    }
-                }
-            }
-            return line
-        }.joined(separator: "\n")
+        formattedRationale(forConsole: false)
     }
 
     var formattedAsConsoleRationale: String {
-        components(separatedBy: "\n").compactMap { line in
-            line.contains("```") ? nil : line
+        formattedRationale(forConsole: true)
+    }
+
+    private func formattedRationale(forConsole: Bool) -> String {
+        var insideMultilineString = false
+        return components(separatedBy: "\n").compactMap { line in
+            if line.contains("```") {
+                if insideMultilineString {
+                    insideMultilineString = false
+                    return forConsole ? nil : line
+                } else {
+                    insideMultilineString = true
+                    if line.hasSuffix("```") {
+                        return forConsole ? nil : (line + "swift")
+                    } 
+                }
+            }
+            return line.indent(by: (insideMultilineString && forConsole) ? 4 : 0)
         }.joined(separator: "\n")
     }
 }

--- a/Source/SwiftLintFramework/Documentation/RuleDocumentation.swift
+++ b/Source/SwiftLintFramework/Documentation/RuleDocumentation.swift
@@ -58,23 +58,20 @@ struct RuleDocumentation {
     }
 
     private func formattedRationale(_ rationale: String) -> String {
-        var result = ""
         var insideMultilineString = false
-        rationale.enumerateLines { line, _ in
-            var formattedLine = line
+        return rationale.components(separatedBy: "\n").map { line in
             if line.contains("```") {
                 if insideMultilineString {
                     insideMultilineString = false
                 } else {
                     insideMultilineString = true
                     if line.hasSuffix("```") {
-                        formattedLine += "swift"
+                        return line + "swift"
                     }
                 }
             }
-            result += formattedLine + "\n"
-        }
-        return result
+            return line
+        }.joined(separator: "\n")
     }
 
     private func formattedCode(_ example: Example) -> String {

--- a/Source/SwiftLintFramework/Documentation/RuleDocumentation.swift
+++ b/Source/SwiftLintFramework/Documentation/RuleDocumentation.swift
@@ -58,20 +58,7 @@ struct RuleDocumentation {
     }
 
     private func formattedRationale(_ rationale: String) -> String {
-        var insideMultilineString = false
-        return rationale.components(separatedBy: "\n").map { line in
-            if line.contains("```") {
-                if insideMultilineString {
-                    insideMultilineString = false
-                } else {
-                    insideMultilineString = true
-                    if line.hasSuffix("```") {
-                        return line + "swift"
-                    }
-                }
-            }
-            return line
-        }.joined(separator: "\n")
+        rationale.formattedAsRationale
     }
 
     private func formattedCode(_ example: Example) -> String {
@@ -118,4 +105,23 @@ private func detailsSummary(_ rule: some Rule) -> String {
             """
     }
     return ruleDescription
+}
+
+extension String {
+    var formattedAsRationale: String {
+        var insideMultilineString = false
+        return components(separatedBy: "\n").map { line in
+            if line.contains("```") {
+                if insideMultilineString {
+                    insideMultilineString = false
+                } else {
+                    insideMultilineString = true
+                    if line.hasSuffix("```") {
+                        return line + "swift"
+                    }
+                }
+            }
+            return line
+        }.joined(separator: "\n")
+    }
 }

--- a/Source/SwiftLintFramework/Documentation/RuleDocumentation.swift
+++ b/Source/SwiftLintFramework/Documentation/RuleDocumentation.swift
@@ -42,7 +42,7 @@ struct RuleDocumentation {
         var content = [h1(description.name), description.description, detailsSummary(ruleType.init())]
         if let rationale = description.rationale {
             content += [h2("Rationale")]
-            content.append(rationale.formattedAsRationale)
+            content.append(rationale.formattedRationale)
         }
         let nonTriggeringExamples = description.nonTriggeringExamples.filter { !$0.excludeFromDocumentation }
         if nonTriggeringExamples.isNotEmpty {
@@ -104,17 +104,17 @@ private func detailsSummary(_ rule: some Rule) -> String {
 }
 
 extension String {
-    var formattedAsRationale: String {
+    var formattedRationale: String {
         formattedRationale(forConsole: false)
     }
 
-    var formattedAsConsoleRationale: String {
+    var consoleRationale: String {
         formattedRationale(forConsole: true)
     }
 
     private func formattedRationale(forConsole: Bool) -> String {
         var insideMultilineString = false
-        return components(separatedBy: "\n").compactMap { line in
+        return components(separatedBy: "\n").compactMap { line -> String? in
             if line.contains("```") {
                 if insideMultilineString {
                     insideMultilineString = false

--- a/Source/SwiftLintFramework/Documentation/RuleDocumentation.swift
+++ b/Source/SwiftLintFramework/Documentation/RuleDocumentation.swift
@@ -40,9 +40,9 @@ struct RuleDocumentation {
     var fileContents: String {
         let description = ruleType.description
         var content = [h1(description.name), description.description, detailsSummary(ruleType.init())]
-        if let rationale = description.rationale {
+        if let formattedRationale = description.formattedRationale {
             content += [h2("Rationale")]
-            content.append(rationale.formattedRationale)
+            content.append(formattedRationale)
         }
         let nonTriggeringExamples = description.nonTriggeringExamples.filter { !$0.excludeFromDocumentation }
         if nonTriggeringExamples.isNotEmpty {
@@ -101,31 +101,4 @@ private func detailsSummary(_ rule: some Rule) -> String {
             """
     }
     return ruleDescription
-}
-
-extension String {
-    var formattedRationale: String {
-        formattedRationale(forConsole: false)
-    }
-
-    var consoleRationale: String {
-        formattedRationale(forConsole: true)
-    }
-
-    private func formattedRationale(forConsole: Bool) -> String {
-        var insideMultilineString = false
-        return components(separatedBy: "\n").compactMap { line -> String? in
-            if line.contains("```") {
-                if insideMultilineString {
-                    insideMultilineString = false
-                    return forConsole ? nil : line
-                }
-                insideMultilineString = true
-                if line.hasSuffix("```") {
-                    return forConsole ? nil : (line + "swift")
-                }
-            }
-            return line.indent(by: (insideMultilineString && forConsole) ? 4 : 0)
-        }.joined(separator: "\n")
-    }
 }

--- a/Source/SwiftLintFramework/Documentation/RuleDocumentation.swift
+++ b/Source/SwiftLintFramework/Documentation/RuleDocumentation.swift
@@ -40,6 +40,10 @@ struct RuleDocumentation {
     var fileContents: String {
         let description = ruleType.description
         var content = [h1(description.name), description.description, detailsSummary(ruleType.init())]
+        if let rationale = description.rationale {
+            content += [h2("Rationale")]
+            content.append(formattedRationale(rationale))
+        }
         let nonTriggeringExamples = description.nonTriggeringExamples.filter { !$0.excludeFromDocumentation }
         if nonTriggeringExamples.isNotEmpty {
             content += [h2("Non Triggering Examples")]
@@ -51,6 +55,26 @@ struct RuleDocumentation {
             content += triggeringExamples.map(formattedCode)
         }
         return content.joined(separator: "\n\n")
+    }
+
+    private func formattedRationale(_ rationale: String) -> String {
+        var result = ""
+        var insideMultilineString = false
+        rationale.enumerateLines { line, _ in
+            var formattedLine = line
+            if line.contains("```") {
+                if insideMultilineString {
+                    insideMultilineString = false
+                } else {
+                    insideMultilineString = true
+                    if line.hasSuffix("```") {
+                        formattedLine += "swift"
+                    }
+                }
+            }
+            result += formattedLine + "\n"
+        }
+        return result
     }
 
     private func formattedCode(_ example: Example) -> String {

--- a/Source/SwiftLintFramework/Documentation/RuleDocumentation.swift
+++ b/Source/SwiftLintFramework/Documentation/RuleDocumentation.swift
@@ -42,7 +42,7 @@ struct RuleDocumentation {
         var content = [h1(description.name), description.description, detailsSummary(ruleType.init())]
         if let rationale = description.rationale {
             content += [h2("Rationale")]
-            content.append(formattedRationale(rationale))
+            content.append(rationale.formattedAsRationale)
         }
         let nonTriggeringExamples = description.nonTriggeringExamples.filter { !$0.excludeFromDocumentation }
         if nonTriggeringExamples.isNotEmpty {
@@ -55,10 +55,6 @@ struct RuleDocumentation {
             content += triggeringExamples.map(formattedCode)
         }
         return content.joined(separator: "\n\n")
-    }
-
-    private func formattedRationale(_ rationale: String) -> String {
-        rationale.formattedAsRationale
     }
 
     private func formattedCode(_ example: Example) -> String {
@@ -122,6 +118,13 @@ extension String {
                 }
             }
             return line
+        }.joined(separator: "\n")
+    }
+
+    var formattedAsConsoleRationale: String {
+        var insideMultilineString = false
+        return components(separatedBy: "\n").compactMap { line in
+            line.contains("```") ? nil : line
         }.joined(separator: "\n")
     }
 }

--- a/Source/SwiftLintFramework/Documentation/RuleDocumentation.swift
+++ b/Source/SwiftLintFramework/Documentation/RuleDocumentation.swift
@@ -122,8 +122,7 @@ extension String {
     }
 
     var formattedAsConsoleRationale: String {
-        var insideMultilineString = false
-        return components(separatedBy: "\n").compactMap { line in
+        components(separatedBy: "\n").compactMap { line in
             line.contains("```") ? nil : line
         }.joined(separator: "\n")
     }

--- a/Source/SwiftLintFramework/Documentation/RuleDocumentation.swift
+++ b/Source/SwiftLintFramework/Documentation/RuleDocumentation.swift
@@ -119,11 +119,10 @@ extension String {
                 if insideMultilineString {
                     insideMultilineString = false
                     return forConsole ? nil : line
-                } else {
-                    insideMultilineString = true
-                    if line.hasSuffix("```") {
-                        return forConsole ? nil : (line + "swift")
-                    } 
+                }
+                insideMultilineString = true
+                if line.hasSuffix("```") {
+                    return forConsole ? nil : (line + "swift")
                 }
             }
             return line.indent(by: (insideMultilineString && forConsole) ? 4 : 0)

--- a/Source/swiftlint/Commands/Rules.swift
+++ b/Source/swiftlint/Commands/Rules.swift
@@ -58,8 +58,8 @@ extension SwiftLint {
             }
 
             print("\(description.consoleDescription)")
-            if let rationale = description.rationale {
-                print("\nRationale:\n\n\(rationale)")
+            if let consoleRationale = description.consoleRationale {
+                print("\nRationale:\n\n\(consoleRationale)")
             }
             let configDescription = rule.createConfigurationDescription()
             if configDescription.hasContent {

--- a/Source/swiftlint/Commands/Rules.swift
+++ b/Source/swiftlint/Commands/Rules.swift
@@ -58,6 +58,9 @@ extension SwiftLint {
             }
 
             print("\(description.consoleDescription)")
+            if let rationale = description.rationale {
+                print("\nRationale:\n\n\(rationale)")
+            }
             let configDescription = rule.createConfigurationDescription()
             if configDescription.hasContent {
                 print("\nConfiguration (YAML):\n")


### PR DESCRIPTION
Addresses #4811

The idea is to add a longer explanation of the purpose or motivation behind each rule.

You can now see the output via `swiftlint rules rule_name`

For example

```
% swiftlint.debug rules array_init
Array Init (array_init): Prefer using `Array(seq)` over `seq.map { $0 }` to convert a sequence into an Array

Rationale:

When converting the elements of a sequence directly into an `Array`, for clarity, prefer using the `Array` constructor over calling `map`. For example

    Array(foo)

rather than

    foo.↓map({ $0 })

If some processing of the elements is required, then using `map` is fine. For example

    foo.map { !$0 }

Constructs like

    enum MyError: Error {}
    let myResult: Result<String, MyError> = .success("")
    let result: Result<Any, MyError> = myResult.map { $0 }

may be picked up as false positives by the `array_init` rule. If your codebase contains constructs like this, consider using the `typesafe_array_init` analyzer rule instead.

Configuration (YAML):

  array_init:
    severity: warning

Triggering Examples (violations are marked with '↓'):

Example #1

    foo.↓map({ $0 })

Example #2

    foo.↓map { $0 }

Example #3

    foo.↓map { return $0 }

```

And when rendered via Jazzy:

<img width="891" alt="Screenshot 2024-12-01 at 21 04 11" src="https://github.com/user-attachments/assets/3de026da-08ec-4939-9f90-5d01a609c536">

Rationales may contain MarkDown formatting.

When formatting for the console, any lines containing "```" will be stripped from the output, and any lines between them will be indented by four spaces - so in the raitionale definition, code samples should not be indented - no other formatting will be performed, so any MarkDown will appear as is.

When formatting for jazzy, line containing "```" that start a code block will be assumed to be swift code, and will have `swift` appended to them. If you want to format for a different language, then specify that explicitly when starting the code block.

This assures that any code samples in the rationale will be formatted in a very similar way to any examples that are provided for the rules - see output and screenshots above.
