### PR TITLE
make NoEmptyBlock rule to opt-in and add configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@
   [Martin Redington](https://github.com/mildm8nnered)
   [#5552](https://github.com/realm/SwiftLint/issues/5552)
 
-* Add `no_empty_block` default rule to validate that code blocks are not empty.
+* Add `no_empty_block` opt-in rule to validate that code blocks are not empty.
   They should at least contain a comment.  
   [Ueeek](https://github.com/Ueeek)
   [#5615](https://github.com/realm/SwiftLint/issues/5615)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoEmptyBlockRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoEmptyBlockRule.swift
@@ -12,121 +12,113 @@ struct NoEmptyBlockRule: OptInRule {
         kind: .idiomatic,
         nonTriggeringExamples: [
             Example("""
+            func f() {
+                /* do something */
+            }
+
             var flag = true {
                 willSet { /* do something */ }
             }
             """),
+
             Example("""
+            class Apple {
+                init() { /* do something */ }
+
+                deinit { /* do something */ }
+            }
+            """),
+
+            Example("""
+            for _ in 0..<10 { /* do something */ }
+
             do {
                 /* do something */
             } catch {
                 /* do something */
             }
-            """),
-            Example("""
+
             defer {
                 /* do something */
             }
-            """),
-            Example("""
-            deinit { /* do something */ }
-            """),
-            Example("""
-            for _ in 0..<10 { /* do something */ }
-            """),
-            Example("""
-            func f() {
-                /* do something */
-            }
-            """),
-            Example("""
+
             if flag {
                 /* do something */
             } else {
                 /* do something */
             }
-            """),
-            Example("""
-            init() { /* do something */ }
-            """),
-            Example("""
+
             repeat { /* do something */ } while (flag)
-            """),
-            Example("""
+
             while i < 10 { /* do something */ }
             """),
+
             Example("""
+            func f() {}
+
             var flag = true {
                 willSet {}
             }
             """, configuration: ["disabled_block_types": ["function_bodies"]]),
+
             Example("""
-            func f() {}
-            """, configuration: ["disabled_block_types": ["function_bodies"]]),
-            Example("""
-            deinit {}
+            class Apple {
+                init() {}
+
+                deinit {}
+            }
             """, configuration: ["disabled_block_types": ["initializer_bodies"]]),
-            Example("""
-            init() {}
-            """, configuration: ["disabled_block_types": ["initializer_bodies"]]),
+
             Example("""
             for _ in 0..<10 {}
-            """, configuration: ["disabled_block_types": ["statement_blocks"]]),
-            Example("""
+
             do {
             } catch {
             }
-            """, configuration: ["disabled_block_types": ["statement_blocks"]]),
-            Example("""
+
             defer {}
-            """, configuration: ["disabled_block_types": ["statement_blocks"]]),
-            Example("""
+
             if flag {
             } else {
             }
-            """, configuration: ["disabled_block_types": ["statement_blocks"]]),
-            Example("""
+
             repeat {} while (flag)
-            """, configuration: ["disabled_block_types": ["statement_blocks"]]),
-            Example("""
+
             while i < 10 {}
             """, configuration: ["disabled_block_types": ["statement_blocks"]]),
         ],
         triggeringExamples: [
             Example("""
+            func f() ↓{}
+
             var flag = true {
                 willSet ↓{}
             }
             """),
+
             Example("""
+            class Apple {
+                init() ↓{}
+
+                deinit ↓{}
+            }
+            """),
+
+            Example("""
+            for _ in 0..<10 ↓{}
+
             do ↓{
             } catch ↓{
             }
-            """),
-            Example("""
+
             defer ↓{}
-            """),
-            Example("""
-            deinit ↓{}
-            """),
-            Example("""
-            for _ in 0..<10 ↓{}
-            """),
-            Example("""
-            func f() ↓{}
-            """),
-            Example("""
+
             if flag ↓{
             } else ↓{
             }
-            """),
-            Example("""
-            init() ↓{}
-            """),
-            Example("""
+
             repeat ↓{} while (flag)
-            """),
-            Example("""
+
             while i < 10 ↓{}
             """),
         ]

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoEmptyBlockRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoEmptyBlockRule.swift
@@ -38,8 +38,11 @@ struct NoEmptyBlockRule: OptInRule {
                 /* do something */
             }
 
-            defer {
-                /* do something */
+            func f() {
+                defer {
+                    /* do something */
+                }
+                print("other code")
             }
 
             if flag {
@@ -76,7 +79,10 @@ struct NoEmptyBlockRule: OptInRule {
             } catch {
             }
 
-            defer {}
+            func f() {
+                defer {}
+                print("other code")
+            }
 
             if flag {
             } else {
@@ -111,7 +117,10 @@ struct NoEmptyBlockRule: OptInRule {
             } catch ↓{
             }
 
-            defer ↓{}
+            func f() {
+                defer ↓{}
+                print("other code")
+            }
 
             if flag ↓{
             } else ↓{

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoEmptyBlockRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoEmptyBlockRule.swift
@@ -154,9 +154,7 @@ private extension NoEmptyBlockRule {
 
 private extension CodeBlockSyntax {
     var codeBlockType: NoEmptyBlockConfiguration.CodeBlockType? {
-        guard let kind = self.parent?.kind else { return nil }
-
-        return switch kind {
+        switch parent?.kind {
         case .functionDecl, .accessorDecl:
             .functionBodies
         case .initializerDecl, .deinitializerDecl:

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NoEmptyBlockConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NoEmptyBlockConfiguration.swift
@@ -1,0 +1,26 @@
+import SwiftLintCore
+
+@AutoApply
+struct NoEmptyBlockConfiguration: SeverityBasedRuleConfiguration {
+    typealias Parent = NoEmptyBlockRule
+
+    @MakeAcceptableByConfigurationElement
+    enum CodeBlockType: String, CaseIterable {
+        case accessorBodies = "accessor_bodies"
+        case functionBodies = "function_bodies"
+        case initializerBodies = "initializer_bodies"
+        case statementBlocks = "statement_blocks"
+
+        static let all = Set(allCases)
+    }
+
+    @ConfigurationElement(key: "severity")
+    private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+
+    @ConfigurationElement(key: "disabled")
+    private(set) var disabledBlockTypes: [CodeBlockType] = []
+
+    var enabledBlockTypes: Set<CodeBlockType> {
+        CodeBlockType.all.subtracting(disabledBlockTypes)
+    }
+}

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NoEmptyBlockConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NoEmptyBlockConfiguration.swift
@@ -6,7 +6,6 @@ struct NoEmptyBlockConfiguration: SeverityBasedRuleConfiguration {
 
     @MakeAcceptableByConfigurationElement
     enum CodeBlockType: String, CaseIterable {
-        case accessorBodies = "accessor_bodies"
         case functionBodies = "function_bodies"
         case initializerBodies = "initializer_bodies"
         case statementBlocks = "statement_blocks"
@@ -17,7 +16,7 @@ struct NoEmptyBlockConfiguration: SeverityBasedRuleConfiguration {
     @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
 
-    @ConfigurationElement(key: "disabled")
+    @ConfigurationElement(key: "disabled_block_types")
     private(set) var disabledBlockTypes: [CodeBlockType] = []
 
     var enabledBlockTypes: Set<CodeBlockType> {

--- a/Tests/IntegrationTests/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/default_rule_configurations.yml
@@ -336,7 +336,7 @@ nimble_operator:
   severity: warning
 no_empty_block:
   severity: warning
-  disabled: []
+  disabled_block_types: []
 no_extension_access_modifier:
   severity: error
 no_fallthrough_only:

--- a/Tests/IntegrationTests/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/default_rule_configurations.yml
@@ -336,6 +336,7 @@ nimble_operator:
   severity: warning
 no_empty_block:
   severity: warning
+  disabled: []
 no_extension_access_modifier:
   severity: error
 no_fallthrough_only:

--- a/Tests/SwiftLintFrameworkTests/NoEmptyBlockConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/NoEmptyBlockConfigurationTests.swift
@@ -14,7 +14,7 @@ final class NoEmptyBlockConfigurationTests: SwiftLintTestCase {
         try config.apply(
             configuration: [
                 "severity": "error",
-                "disabled": ["function_bodies", "accessor_bodies"],
+                "disabled_block_types": ["function_bodies"],
             ] as [String: any Sendable]
         )
         XCTAssertEqual(config.severityConfiguration.severity, .error)
@@ -45,10 +45,10 @@ final class NoEmptyBlockConfigurationTests: SwiftLintTestCase {
 
     func testConsoleDescription() throws {
         var config = NoEmptyBlockConfiguration()
-        try config.apply(configuration: ["disabled": ["initializer_bodies", "statement_blocks"]])
+        try config.apply(configuration: ["disabled_block_types": ["initializer_bodies", "statement_blocks"]])
         XCTAssertEqual(
             RuleConfigurationDescription.from(configuration: config).oneLiner(),
-            "severity: warning; disabled: [initializer_bodies, statement_blocks]"
+            "severity: warning; disabled_block_types: [initializer_bodies, statement_blocks]"
         )
     }
 }

--- a/Tests/SwiftLintFrameworkTests/NoEmptyBlockConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/NoEmptyBlockConfigurationTests.swift
@@ -1,0 +1,54 @@
+@testable import SwiftLintBuiltInRules
+@testable import SwiftLintCore
+import XCTest
+
+final class NoEmptyBlockConfigurationTests: SwiftLintTestCase {
+    func testDefaultConfiguration() {
+        let config = NoEmptyBlockConfiguration()
+        XCTAssertEqual(config.severityConfiguration.severity, .warning)
+        XCTAssertEqual(config.enabledBlockTypes, NoEmptyBlockConfiguration.CodeBlockType.all)
+    }
+
+    func testApplyingCustomConfiguration() throws {
+        var config = NoEmptyBlockConfiguration()
+        try config.apply(
+            configuration: [
+                "severity": "error",
+                "disabled": ["function_bodies", "accessor_bodies"],
+            ] as [String: any Sendable]
+        )
+        XCTAssertEqual(config.severityConfiguration.severity, .error)
+        XCTAssertEqual(config.enabledBlockTypes, Set([.initializerBodies, .statementBlocks]))
+    }
+
+    func testInvalidKeyInCustomConfiguration() {
+        var config = NoEmptyBlockConfiguration()
+        XCTAssertEqual(
+            try Issue.captureConsole { try config.apply(configuration: ["invalidKey": "error"]) },
+            "warning: Configuration for 'no_empty_block' rule contains the invalid key(s) 'invalidKey'."
+        )
+    }
+
+    func testInvalidTypeOfCustomConfiguration() {
+        var config = NoEmptyBlockConfiguration()
+        checkError(Issue.invalidConfiguration(ruleID: NoEmptyBlockRule.description.identifier)) {
+            try config.apply(configuration: "invalidKey")
+        }
+    }
+
+    func testInvalidTypeOfValueInCustomConfiguration() {
+        var config = NoEmptyBlockConfiguration()
+        checkError(Issue.invalidConfiguration(ruleID: NoEmptyBlockRule.description.identifier)) {
+            try config.apply(configuration: ["severity": "foo"])
+        }
+    }
+
+    func testConsoleDescription() throws {
+        var config = NoEmptyBlockConfiguration()
+        try config.apply(configuration: ["disabled": ["initializer_bodies", "statement_blocks"]])
+        XCTAssertEqual(
+            RuleConfigurationDescription.from(configuration: config).oneLiner(),
+            "severity: warning; disabled: [initializer_bodies, statement_blocks]"
+        )
+    }
+}


### PR DESCRIPTION
As discussed in https://github.com/realm/SwiftLint/pull/5617,
This PR implements 2 changes on `no_empty_block` rule.
+ change rule type to `OptIn`
+ add configuration to disable the code block type. (initializer, function, accessor and statement)