### PR TITLE
Rename macros to something more descriptive

### DIFF
--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/AttributesConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/AttributesConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct AttributesConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = AttributesRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/BlanketDisableCommandConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/BlanketDisableCommandConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct BlanketDisableCommandConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = BlanketDisableCommandRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/CollectionAlignmentConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/CollectionAlignmentConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct CollectionAlignmentConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = CollectionAlignmentRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ColonConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ColonConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct ColonConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = ColonRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ComputedAccessorsOrderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ComputedAccessorsOrderConfiguration.swift
@@ -1,10 +1,10 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct ComputedAccessorsOrderConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = ComputedAccessorsOrderRule
 
-    @MakeAcceptableByConfigurationElement
+    @AcceptableByConfigurationElement
     enum Order: String {
         case getSet = "get_set"
         case setGet = "set_get"

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ConditionalReturnsOnNewlineConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ConditionalReturnsOnNewlineConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct ConditionalReturnsOnNewlineConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = ConditionalReturnsOnNewlineRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/CyclomaticComplexityConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/CyclomaticComplexityConfiguration.swift
@@ -1,7 +1,7 @@
 import SourceKittenFramework
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct CyclomaticComplexityConfiguration: RuleConfiguration {
     typealias Parent = CyclomaticComplexityRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/DiscouragedDirectInitConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/DiscouragedDirectInitConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct DiscouragedDirectInitConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = DiscouragedDirectInitRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/EmptyCountConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/EmptyCountConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct EmptyCountConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = EmptyCountRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ExpiringTodoConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ExpiringTodoConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct ExpiringTodoConfiguration: RuleConfiguration {
     typealias Parent = ExpiringTodoRule
     typealias Severity = SeverityConfiguration<Parent>

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ExplicitInitConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ExplicitInitConfiguration.swift
@@ -1,4 +1,4 @@
-@AutoApply
+@AutoConfigParser
 struct ExplicitInitConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = ExplicitInitRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ExplicitTypeInterfaceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ExplicitTypeInterfaceConfiguration.swift
@@ -1,10 +1,10 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct ExplicitTypeInterfaceConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = ExplicitTypeInterfaceRule
 
-    @MakeAcceptableByConfigurationElement
+    @AcceptableByConfigurationElement
     enum VariableKind: String, CaseIterable {
         case instance
         case local

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileLengthConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileLengthConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct FileLengthConfiguration: RuleConfiguration {
     typealias Parent = FileLengthRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileNameConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileNameConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct FileNameConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = FileNameRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileNameNoSpaceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileNameNoSpaceConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct FileNameNoSpaceConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = FileNameNoSpaceRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileTypesOrderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileTypesOrderConfiguration.swift
@@ -1,10 +1,10 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct FileTypesOrderConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = FileTypesOrderRule
 
-    @MakeAcceptableByConfigurationElement
+    @AcceptableByConfigurationElement
     enum FileType: String {
         case supportingType = "supporting_type"
         case mainType = "main_type"

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ForWhereConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ForWhereConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct ForWhereConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = ForWhereRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FunctionParameterCountConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FunctionParameterCountConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct FunctionParameterCountConfiguration: RuleConfiguration {
     typealias Parent = FunctionParameterCountRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/IdentifierNameConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/IdentifierNameConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct IdentifierNameConfiguration: RuleConfiguration {
     typealias Parent = IdentifierNameRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ImplicitReturnConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ImplicitReturnConfiguration.swift
@@ -1,10 +1,10 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct ImplicitReturnConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = ImplicitReturnRule
 
-    @MakeAcceptableByConfigurationElement
+    @AcceptableByConfigurationElement
     enum ReturnKind: String, CaseIterable, Comparable {
         case closure
         case function

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ImplicitlyUnwrappedOptionalConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ImplicitlyUnwrappedOptionalConfiguration.swift
@@ -1,10 +1,10 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct ImplicitlyUnwrappedOptionalConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = ImplicitlyUnwrappedOptionalRule
 
-    @MakeAcceptableByConfigurationElement
+    @AcceptableByConfigurationElement
     enum ImplicitlyUnwrappedOptionalModeConfiguration: String { // swiftlint:disable:this type_name
         case all = "all"
         case allExceptIBOutlets = "all_except_iboutlets"

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/InclusiveLanguageConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/InclusiveLanguageConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct InclusiveLanguageConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = InclusiveLanguageRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/IndentationWidthConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/IndentationWidthConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct IndentationWidthConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = IndentationWidthRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/LineLengthConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/LineLengthConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct LineLengthConfiguration: RuleConfiguration {
     typealias Parent = LineLengthRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ModifierOrderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ModifierOrderConfiguration.swift
@@ -1,7 +1,7 @@
 import SourceKittenFramework
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct ModifierOrderConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = ModifierOrderRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MultilineArgumentsConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MultilineArgumentsConfiguration.swift
@@ -1,10 +1,10 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct MultilineArgumentsConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = MultilineArgumentsRule
 
-    @MakeAcceptableByConfigurationElement
+    @AcceptableByConfigurationElement
     enum FirstArgumentLocation: String {
         case anyLine = "any_line"
         case sameLine = "same_line"

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MultilineParametersConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MultilineParametersConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct MultilineParametersConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = MultilineParametersRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NestingConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NestingConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct NestingConfiguration: RuleConfiguration {
     typealias Parent = NestingRule
     typealias Severity = SeverityLevelsConfiguration<Parent>

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NonOverridableClassDeclarationConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NonOverridableClassDeclarationConfiguration.swift
@@ -1,10 +1,10 @@
 import SwiftLintCore
 
-@AutoApply // swiftlint:disable:next type_name
+@AutoConfigParser // swiftlint:disable:next type_name
 struct NonOverridableClassDeclarationConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = NonOverridableClassDeclarationRule
 
-    @MakeAcceptableByConfigurationElement
+    @AcceptableByConfigurationElement
     enum FinalClassModifier: String {
         case finalClass = "final class"
         case `static` = "static"

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NumberSeparatorConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NumberSeparatorConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct NumberSeparatorConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = NumberSeparatorRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ObjectLiteralConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ObjectLiteralConfiguration.swift
@@ -2,7 +2,7 @@ import SwiftLintCore
 
 typealias DiscouragedObjectLiteralConfiguration = ObjectLiteralConfiguration<DiscouragedObjectLiteralRule>
 
-@AutoApply
+@AutoConfigParser
 struct ObjectLiteralConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration {
     @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OpeningBraceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OpeningBraceConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct OpeningBraceConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = OpeningBraceRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OperatorUsageWhitespaceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OperatorUsageWhitespaceConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct OperatorUsageWhitespaceConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = OperatorUsageWhitespaceRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OverriddenSuperCallConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OverriddenSuperCallConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct OverriddenSuperCallConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = OverriddenSuperCallRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrefixedTopLevelConstantConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrefixedTopLevelConstantConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct PrefixedTopLevelConstantConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = PrefixedTopLevelConstantRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateOutletConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateOutletConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct PrivateOutletConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = PrivateOutletRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateOverFilePrivateConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PrivateOverFilePrivateConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct PrivateOverFilePrivateConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = PrivateOverFilePrivateRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ProhibitedSuperConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ProhibitedSuperConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct ProhibitedSuperConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = ProhibitedSuperRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/RedundantTypeAnnotationConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/RedundantTypeAnnotationConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct RedundantTypeAnnotationConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = RedundantTypeAnnotationRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/RedundantVoidReturnConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/RedundantVoidReturnConfiguration.swift
@@ -1,4 +1,4 @@
-@AutoApply
+@AutoConfigParser
 struct RedundantVoidReturnConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = RedundantVoidReturnRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SelfBindingConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SelfBindingConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct SelfBindingConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = SelfBindingRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ShorthandArgumentConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/ShorthandArgumentConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct ShorthandArgumentConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = ShorthandArgumentRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SortedImportsConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SortedImportsConfiguration.swift
@@ -1,10 +1,10 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct SortedImportsConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = SortedImportsRule
 
-    @MakeAcceptableByConfigurationElement
+    @AcceptableByConfigurationElement
     enum SortedImportsGroupingConfiguration: String {
         /// Sorts import lines based on any import attributes (e.g. `@testable`, `@_exported`, etc.), followed by a case
         /// insensitive comparison of the imported module name.

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/StatementPositionConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/StatementPositionConfiguration.swift
@@ -1,10 +1,10 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct StatementPositionConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = StatementPositionRule
 
-    @MakeAcceptableByConfigurationElement
+    @AcceptableByConfigurationElement
     enum StatementModeConfiguration: String {
         case `default` = "default"
         case uncuddledElse = "uncuddled_else"

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SwitchCaseAlignmentConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SwitchCaseAlignmentConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct SwitchCaseAlignmentConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = SwitchCaseAlignmentRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TestCaseAccessibilityConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TestCaseAccessibilityConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct TestCaseAccessibilityConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = TestCaseAccessibilityRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TodoConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TodoConfiguration.swift
@@ -1,10 +1,10 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct TodoConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = TodoRule
 
-    @MakeAcceptableByConfigurationElement
+    @AcceptableByConfigurationElement
     enum TodoKeyword: String, CaseIterable {
         case todo = "TODO"
         case fixme = "FIXME"

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TrailingClosureConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TrailingClosureConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct TrailingClosureConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = TrailingClosureRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TrailingCommaConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TrailingCommaConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct TrailingCommaConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = TrailingCommaRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TrailingWhitespaceConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct TrailingWhitespaceConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = TrailingWhitespaceRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TypeContentsOrderConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TypeContentsOrderConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@MakeAcceptableByConfigurationElement
+@AcceptableByConfigurationElement
 enum TypeContent: String {
     case `case` = "case"
     case typeAlias = "type_alias"
@@ -19,7 +19,7 @@ enum TypeContent: String {
     case deinitializer = "deinitializer"
 }
 
-@AutoApply
+@AutoConfigParser
 struct TypeContentsOrderConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = TypeContentsOrderRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TypeNameConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/TypeNameConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct TypeNameConfiguration: RuleConfiguration {
     typealias Parent = TypeNameRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnitTestConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnitTestConfiguration.swift
@@ -6,7 +6,7 @@ typealias FinalTestCaseConfiguration = UnitTestConfiguration<FinalTestCaseRule>
 typealias NoMagicNumbersConfiguration = UnitTestConfiguration<NoMagicNumbersRule>
 typealias SingleTestClassConfiguration = UnitTestConfiguration<SingleTestClassRule>
 
-@AutoApply
+@AutoConfigParser
 struct UnitTestConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration {
     @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnneededOverrideRuleConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnneededOverrideRuleConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct UnneededOverrideRuleConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = UnneededOverrideRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedDeclarationConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedDeclarationConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct UnusedDeclarationConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = UnusedDeclarationRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedImportConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedImportConfiguration.swift
@@ -27,7 +27,7 @@ struct TransitiveModuleConfiguration<Parent: Rule>: Equatable, AcceptableByConfi
     }
 }
 
-@AutoApply
+@AutoConfigParser
 struct UnusedImportConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = UnusedImportRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedOptionalBindingConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedOptionalBindingConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct UnusedOptionalBindingConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = UnusedOptionalBindingRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/VerticalWhitespaceClosingBracesConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/VerticalWhitespaceClosingBracesConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply // swiftlint:disable:next type_name
+@AutoConfigParser // swiftlint:disable:next type_name
 struct VerticalWhitespaceClosingBracesConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = VerticalWhitespaceClosingBracesRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/VerticalWhitespaceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/VerticalWhitespaceConfiguration.swift
@@ -1,6 +1,6 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct VerticalWhitespaceConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = VerticalWhitespaceRule
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/XCTSpecificMatcherConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/XCTSpecificMatcherConfiguration.swift
@@ -1,10 +1,10 @@
 import SwiftLintCore
 
-@AutoApply
+@AutoConfigParser
 struct XCTSpecificMatcherConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = XCTSpecificMatcherRule
 
-    @MakeAcceptableByConfigurationElement
+    @AcceptableByConfigurationElement
     enum Matcher: String, CaseIterable {
         case oneArgumentAsserts = "one-argument-asserts"
         case twoArgumentAsserts = "two-argument-asserts"

--- a/Source/SwiftLintCore/Helpers/Macros.swift
+++ b/Source/SwiftLintCore/Helpers/Macros.swift
@@ -4,9 +4,20 @@
     member,
     names: named(apply)
 )
+public macro AutoConfigParser() = #externalMacro(
+    module: "SwiftLintCoreMacros",
+    type: "AutoConfigParser"
+)
+
+/// Deprecated. Use `AutoConfigParser` instead.
+@available(*, deprecated, renamed: "AutoConfigParser")
+@attached(
+    member,
+    names: named(apply)
+)
 public macro AutoApply() = #externalMacro(
     module: "SwiftLintCoreMacros",
-    type: "AutoApply"
+    type: "AutoConfigParser"
 )
 
 /// Macro that lets an enum with a ``String`` raw type automatically conform to ``AcceptableByConfigurationElement``.
@@ -15,9 +26,21 @@ public macro AutoApply() = #externalMacro(
     conformances: AcceptableByConfigurationElement,
     names: named(init(fromAny:context:)), named(asOption)
 )
+public macro AcceptableByConfigurationElement() = #externalMacro(
+    module: "SwiftLintCoreMacros",
+    type: "AcceptableByConfigurationElement"
+)
+
+/// Deprecated. Use `AcceptableByConfigurationElement` instead.
+@available(*, deprecated, renamed: "AcceptableByConfigurationElement")
+@attached(
+    extension,
+    conformances: AcceptableByConfigurationElement,
+    names: named(init(fromAny:context:)), named(asOption)
+)
 public macro MakeAcceptableByConfigurationElement() = #externalMacro(
     module: "SwiftLintCoreMacros",
-    type: "MakeAcceptableByConfigurationElement"
+    type: "AcceptableByConfigurationElement"
 )
 
 /// Macro that adds a conformance to the ``SwiftSyntaxRule`` protocol and a default `makeVisitor(file:)` implementation
@@ -27,7 +50,7 @@ public macro MakeAcceptableByConfigurationElement() = #externalMacro(
 ///   - foldExpressions: Setting it to `true` adds an implementation of `preprocess(file:)` which folds expressions
 ///                      before they are passed to the visitor.
 ///   - explicitRewriter: Set it to `true` to add a `makeRewriter(file:)` implementation which creates a rewriter
-///                       defined in the rule struct. In this case, the rule automatically conforms to 
+///                       defined in the rule struct. In this case, the rule automatically conforms to
 ///                       ``SwiftSyntaxCorrectableRule``.
 @attached(
     extension,

--- a/Source/SwiftLintCore/Models/ViolationSeverity.swift
+++ b/Source/SwiftLintCore/Models/ViolationSeverity.swift
@@ -1,5 +1,5 @@
 /// The magnitude of a `StyleViolation`.
-@MakeAcceptableByConfigurationElement
+@AcceptableByConfigurationElement
 public enum ViolationSeverity: String, Comparable, Codable, InlinableOptionType {
     /// Non-fatal. If using SwiftLint as an Xcode build phase, Xcode will mark the build as having succeeded.
     case warning

--- a/Source/SwiftLintCoreMacros/RuleConfigurationMacros.swift
+++ b/Source/SwiftLintCoreMacros/RuleConfigurationMacros.swift
@@ -3,7 +3,7 @@ import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
 
-enum AutoApply: MemberMacro {
+enum AutoConfigParser: MemberMacro {
     // swiftlint:disable:next function_body_length
     static func expansion(
         of _: AttributeSyntax,
@@ -88,7 +88,7 @@ enum AutoApply: MemberMacro {
     }
 }
 
-enum MakeAcceptableByConfigurationElement: ExtensionMacro {
+enum AcceptableByConfigurationElement: ExtensionMacro {
     static func expansion(
         of _: AttributeSyntax,
         attachedTo declaration: some DeclGroupSyntax,

--- a/Source/SwiftLintCoreMacros/SwiftLintCoreMacros.swift
+++ b/Source/SwiftLintCoreMacros/SwiftLintCoreMacros.swift
@@ -6,8 +6,8 @@ import SwiftSyntaxMacros
 @main
 struct SwiftLintCoreMacros: CompilerPlugin {
     let providingMacros: [any Macro.Type] = [
-        AutoApply.self,
-        MakeAcceptableByConfigurationElement.self,
+        AutoConfigParser.self,
+        AcceptableByConfigurationElement.self,
         SwiftSyntaxRule.self,
     ]
 }

--- a/Tests/MacroTests/AcceptableByConfigurationElementTests.swift
+++ b/Tests/MacroTests/AcceptableByConfigurationElementTests.swift
@@ -3,15 +3,14 @@ import SwiftSyntaxMacrosTestSupport
 import XCTest
 
 private let macros = [
-    "MakeAcceptableByConfigurationElement": MakeAcceptableByConfigurationElement.self
+    "AcceptableByConfigurationElement": AcceptableByConfigurationElement.self
 ]
 
-// swiftlint:disable:next type_name
-final class MakeAcceptableByConfigurationElementTests: XCTestCase {
+final class AcceptableByConfigurationElementTests: XCTestCase {
     func testNoEnum() {
         assertMacroExpansion(
             """
-            @MakeAcceptableByConfigurationElement
+            @AcceptableByConfigurationElement
             struct S {
             }
             """,
@@ -29,7 +28,7 @@ final class MakeAcceptableByConfigurationElementTests: XCTestCase {
     func testNoStringRawType() {
         assertMacroExpansion(
             """
-            @MakeAcceptableByConfigurationElement
+            @AcceptableByConfigurationElement
             enum E {
             }
             """,
@@ -47,7 +46,7 @@ final class MakeAcceptableByConfigurationElementTests: XCTestCase {
     func testPrivateEnum() {
         assertMacroExpansion(
             """
-            @MakeAcceptableByConfigurationElement
+            @AcceptableByConfigurationElement
             private enum E: String {
             }
             """,
@@ -75,7 +74,7 @@ final class MakeAcceptableByConfigurationElementTests: XCTestCase {
     func testPublicEnum() {
         assertMacroExpansion(
             """
-            @MakeAcceptableByConfigurationElement
+            @AcceptableByConfigurationElement
             public enum E: String {
             }
             """,

--- a/Tests/MacroTests/AutoConfigParserTests.swift
+++ b/Tests/MacroTests/AutoConfigParserTests.swift
@@ -3,14 +3,14 @@ import SwiftSyntaxMacrosTestSupport
 import XCTest
 
 private let macros = [
-    "AutoApply": AutoApply.self
+    "AutoConfigParser": AutoConfigParser.self
 ]
 
-final class AutoApplyTests: XCTestCase {
+final class AutoConfigParserTests: XCTestCase {
     func testAttachToClass() {
         assertMacroExpansion(
             """
-            @AutoApply
+            @AutoConfigParser
             class C {
             }
             """,
@@ -28,7 +28,7 @@ final class AutoApplyTests: XCTestCase {
     func testNoConfigurationElements() {
         assertMacroExpansion(
             """
-            @AutoApply
+            @AutoConfigParser
             struct S {
             }
             """,
@@ -54,7 +54,7 @@ final class AutoApplyTests: XCTestCase {
     func testConfigurationElementsWithoutKeys() {
         assertMacroExpansion(
             """
-            @AutoApply
+            @AutoConfigParser
             struct S {
                 @ConfigurationElement
                 var eA = 1
@@ -96,7 +96,7 @@ final class AutoApplyTests: XCTestCase {
     func testInlinedConfigurationElements() {
         assertMacroExpansion(
             """
-            @AutoApply
+            @AutoConfigParser
             struct S {
                 @ConfigurationElement(key: "eD")
                 var eA = 1
@@ -147,7 +147,7 @@ final class AutoApplyTests: XCTestCase {
     func testSeverityBasedConfigurationWithoutSeverityProperty() {
         assertMacroExpansion(
             """
-            @AutoApply
+            @AutoConfigParser
             struct S: SeverityBasedRuleConfiguration {
             }
             """,
@@ -180,7 +180,7 @@ final class AutoApplyTests: XCTestCase {
         // swiftlint:disable line_length
         assertMacroExpansion(
             """
-            @AutoApply
+            @AutoConfigParser
             struct S: SeverityBasedRuleConfiguration {
                 @ConfigurationElement
                 var severityConfiguration = .warning

--- a/Tests/SwiftLintFrameworkTests/RuleConfigurationDescriptionTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleConfigurationDescriptionTests.swift
@@ -6,7 +6,7 @@ import XCTest
 
 // swiftlint:disable:next type_body_length
 final class RuleConfigurationDescriptionTests: XCTestCase {
-    @AutoApply
+    @AutoConfigParser
     private struct TestConfiguration: RuleConfiguration {
         typealias Parent = RuleMock // swiftlint:disable:this nesting
 


### PR DESCRIPTION
`AutoApply` was chosen to match with the method name that it implements. If one has never seen the `apply` method, the name might be confusing. `AutoConfigParser` seems more descriptive here.

The `Make` in `MakeAcceptableByConfigurationElement` was prepended to avoid name clashes with the protocol it implements. Obviously, Swift can differentiate between the macro with the `@` and the protocol. The measure was thus unjustified and we can just omit the prefix.

The previous names are still there but deprecated in case people use them to implement their own custom rules. That's hopefully only for one more release.