### PR TITLE
Fix typo of Swift Playground at CommentSpacingRule.swift

### DIFF
--- a/Source/SwiftLintBuiltInRules/Rules/Lint/CommentSpacingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/CommentSpacingRule.swift
@@ -57,7 +57,7 @@ struct CommentSpacingRule: SourceKitFreeRule, SubstitutionCorrectableRule {
             */
             """),
             Example("""
-            /*#-editable-code Swift Platground editable area*/default/*#-end-editable-code*/
+            /*#-editable-code Swift Playground editable area*/default/*#-end-editable-code*/
             """),
         ],
         triggeringExamples: [


### PR DESCRIPTION
Correct typo of Swift Playground at CommentSpacingRule.swift , it appears in production at https://realm.github.io/SwiftLint/comment_spacing.html .