### PR TITLE
Make sure that violations of the typesafe_array_init rule are correctly reported as violations of that rule rather than array_init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,12 @@
   [SimplyDanny](https://github.com/SimplyDanny)
   [#5598](https://github.com/realm/SwiftLint/issues/5598)
 
+* Violations of the `typesafe_array_init` rule will now be correctly
+  reported as such, instead of as violations of the `array_init`
+  rule.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#5709](https://github.com/realm/SwiftLint/issues/5709)
+
 ## 0.55.1: Universal Washing Powder
 
 #### Breaking

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/TypesafeArrayInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/TypesafeArrayInitRule.swift
@@ -76,7 +76,7 @@ struct TypesafeArrayInitRule: AnalyzerRule {
                     return false
                 }
                 return pointsToSystemMapType(pointee: request)
-            }
+            }.map { StyleViolation(ruleDescription: Self.description, location: $0.location ) }
     }
 
     private func pointsToSystemMapType(pointee: [String: any SourceKitRepresentable]) -> Bool {

--- a/Tests/SwiftLintFrameworkTests/TypesafeArrayInitRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TypesafeArrayInitRuleTests.swift
@@ -1,0 +1,19 @@
+@testable import SwiftLintBuiltInRules
+import XCTest
+
+final class TypesafeArrayInitRuleTests: SwiftLintTestCase {
+    func testViolationType() {
+        let baseDescription = TypesafeArrayInitRule.description
+        guard let triggeringExample = baseDescription.triggeringExamples.first else {
+            XCTFail("No triggering examples")
+            return
+        }
+        guard let config = makeConfig(nil, baseDescription.identifier) else {
+            XCTFail("Could not make configuration")
+            return
+        }
+        let violations = SwiftLintFrameworkTests.violations(triggeringExample, config: config, requiresFileOnDisk: true)
+        XCTAssertEqual(violations.count, 1)
+        XCTAssertEqual(violations.first?.ruleIdentifier, baseDescription.identifier)
+    }
+}

--- a/Tests/SwiftLintFrameworkTests/TypesafeArrayInitRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TypesafeArrayInitRuleTests.swift
@@ -2,18 +2,18 @@
 import XCTest
 
 final class TypesafeArrayInitRuleTests: SwiftLintTestCase {
-    func testViolationType() {
+    func testViolationRuleIdentifier() {
         let baseDescription = TypesafeArrayInitRule.description
         guard let triggeringExample = baseDescription.triggeringExamples.first else {
-            XCTFail("No triggering examples")
+            XCTFail("No triggering examples found")
             return
         }
         guard let config = makeConfig(nil, baseDescription.identifier) else {
-            XCTFail("Could not make configuration")
+            XCTFail("Failed to create configuration")
             return
         }
         let violations = SwiftLintFrameworkTests.violations(triggeringExample, config: config, requiresFileOnDisk: true)
-        XCTAssertEqual(violations.count, 1)
+        XCTAssertGreaterThanOrEqual(violations.count, 1)
         XCTAssertEqual(violations.first?.ruleIdentifier, baseDescription.identifier)
     }
 }


### PR DESCRIPTION
Addresses #5709

Violations of the typesafe_array_init rule will now be correctly reported as such, instead of being violations of `array_init`.
