### PR TITLE
Remove extra "case" syntax in documentation

### DIFF
--- a/Source/SwiftLintBuiltInRules/Rules/Style/EmptyEnumArgumentsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/EmptyEnumArgumentsRule.swift
@@ -17,7 +17,7 @@ private func wrapInFunc(_ str: String, file: StaticString = #filePath, line: UIn
     Example("""
     func example(foo: Foo) {
         switch foo {
-        case \(str):
+        \(str):
             break
         }
     }


### PR DESCRIPTION
The `wrapInFunc` method for the `EmptyEnumArgumentsRule.swift` code currently has an extra case statement in the output string, resulting in the following showing on the documentation

https://realm.github.io/SwiftLint/empty_enum_arguments.html
<img width="293" alt="Screenshot 2024-07-30 at 9 45 37 PM" src="https://github.com/user-attachments/assets/21b2f747-b196-4167-a64f-748473d27634">

This removes that extra `case` syntax from the function, so that `wrapInFunc` is called like the other methods (i.e. `wrapInSwitch`) with the `case` as part of the param instead of from the `Example` output.
