### PR TITLE
Restrict `prefer_key_path` to standard functions and function arguments

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -78,6 +78,8 @@ identifier_name:
 large_tuple: 3
 number_separator:
   minimum_length: 5
+prefer_key_path:
+  restrict_to_standard_functions: false
 redundant_type_annotation:
   consider_default_literal_types_redundant: true
 single_test_class: *unit_test_configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,9 @@
   [woxtu](https://github.com/woxtu)  
   [SimplyDanny](https://github.com/SimplyDanny)  
 
-* Add new `prefer_key_path` rule that triggers when a trailing closure on a function 
-  call is only hosting a (chained) member access expression since the closure can be
-  replaced with a key path argument.  
+* Add new `prefer_key_path` rule that triggers when a trailing closure on a standard
+  function call is only hosting a (chained) member access expression since the closure
+  can be replaced with a key path argument. Likewise, it triggers on closure arguments.  
   [SimplyDanny](https://github.com/SimplyDanny)
 
 * Adds `baseline` and `write_baseline` configuration file settings, equivalent

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferKeyPathRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferKeyPathRule.swift
@@ -5,7 +5,7 @@ import SwiftSyntax
 struct PreferKeyPathRule: OptInRule {
     var configuration = PreferKeyPathConfiguration()
 
-    private static let checkAllClosures = ["restrict_to_standard_functions": false]
+    private static let extendedMode = ["restrict_to_standard_functions": false]
 
     static var description = RuleDescription(
         identifier: "prefer_key_path",
@@ -18,15 +18,17 @@ struct PreferKeyPathRule: OptInRule {
             Example("f { $0 }"),
             Example("f { $0.a }"),
             Example("let f = { $0.a }(b)"),
-            Example("f {}", configuration: checkAllClosures),
-            Example("f { $0 }", configuration: checkAllClosures),
-            Example("f() { g() }", configuration: checkAllClosures),
-            Example("f { a.b.c }", configuration: checkAllClosures),
-            Example("f { a in a }", configuration: checkAllClosures),
-            Example("f { a, b in a.b }", configuration: checkAllClosures),
-            Example("f { (a, b) in a.b }", configuration: checkAllClosures),
-            Example("f { $0.a } g: { $0.b }", configuration: checkAllClosures),
-            Example("[1, 2, 3].reduce(1) { $0 + $1 }", configuration: checkAllClosures),
+            Example("f {}", configuration: extendedMode),
+            Example("f { $0 }", configuration: extendedMode),
+            Example("f() { g() }", configuration: extendedMode),
+            Example("f { a.b.c }", configuration: extendedMode),
+            Example("f { a in a }", configuration: extendedMode),
+            Example("f { a, b in a.b }", configuration: extendedMode),
+            Example("f { (a, b) in a.b }", configuration: extendedMode),
+            Example("f { $0.a } g: { $0.b }", configuration: extendedMode),
+            Example("[1, 2, 3].reduce(1) { $0 + $1 }", configuration: extendedMode),
+            Example("f.map(1) { $0.a }"),
+            Example("f.filter({ $0.a }, x)"),
         ],
         triggeringExamples: [
             Example("f.map ↓{ $0.a }"),
@@ -34,15 +36,15 @@ struct PreferKeyPathRule: OptInRule {
             Example("f.first ↓{ $0.a }"),
             Example("f.contains ↓{ $0.a }"),
             Example("f.contains(where: ↓{ $0.a })"),
-            Example("f ↓{ $0.a }", configuration: checkAllClosures),
-            Example("f ↓{ a in a.b }", configuration: checkAllClosures),
-            Example("f ↓{ a in a.b.c }", configuration: checkAllClosures),
-            Example("f ↓{ (a: A) in a.b }", configuration: checkAllClosures),
-            Example("f ↓{ (a b: A) in b.c }", configuration: checkAllClosures),
-            Example("f ↓{ $0.0.a }", configuration: checkAllClosures),
-            Example("f(a: ↓{ $0.b })", configuration: checkAllClosures),
-            Example("f ↓{ $0.a.b }", configuration: checkAllClosures),
-            Example("let f: (Int) -> Int = ↓{ $0.bigEndian }", configuration: checkAllClosures),
+            Example("f(↓{ $0.a })", configuration: extendedMode),
+            Example("f(a: ↓{ $0.b })", configuration: extendedMode),
+            Example("f(a: ↓{ a in a.b }, x)", configuration: extendedMode),
+            Example("f.map ↓{ a in a.b.c }"),
+            Example("f.allSatisfy ↓{ (a: A) in a.b }"),
+            Example("f.first ↓{ (a b: A) in b.c }"),
+            Example("f.contains ↓{ $0.0.a }"),
+            Example("f.flatMap ↓{ $0.a.b }"),
+            Example("let f: (Int) -> Int = ↓{ $0.bigEndian }", configuration: extendedMode),
         ],
         corrections: [
             Example("f.map { $0.a }"):
@@ -57,22 +59,24 @@ struct PreferKeyPathRule: OptInRule {
                     """),
             Example("f.map({ $0.a })"):
                 Example("f.map(\\.a)"),
-            Example("f { $0.a }", configuration: checkAllClosures):
+            Example("f(a: { $0.a })", configuration: extendedMode):
+                Example("f(a: \\.a)"),
+            Example("f({ $0.a })", configuration: extendedMode):
                 Example("f(\\.a)"),
-            Example("f() { $0.a }", configuration: checkAllClosures):
-                Example("f(\\.a)"),
-            Example("let f = /* begin */ { $0.a } // end", configuration: checkAllClosures):
+            Example("let f = /* begin */ { $0.a } // end", configuration: extendedMode):
                 Example("let f = /* begin */ \\.a // end"),
             Example("let f = { $0.a }(b)"):
                 Example("let f = { $0.a }(b)"),
-            Example("let f: (Int) -> Int = ↓{ $0.bigEndian }", configuration: checkAllClosures):
+            Example("let f: (Int) -> Int = ↓{ $0.bigEndian }", configuration: extendedMode):
                 Example("let f: (Int) -> Int = \\.bigEndian"),
-            Example("f ↓{ $0.a.b }", configuration: checkAllClosures):
-                Example("f(\\.a.b)"),
-            Example("f.contains ↓{ $0.a.b }", configuration: checkAllClosures):
+            Example("f.partition ↓{ $0.a.b }"):
+                Example("f.partition(by: \\.a.b)"),
+            Example("f.contains ↓{ $0.a.b }"):
                 Example("f.contains(where: \\.a.b)"),
-            Example("f.first ↓{ element in element.a }", configuration: checkAllClosures):
+            Example("f.first ↓{ element in element.a }"):
                 Example("f.first(where: \\.a)"),
+            Example("f.drop ↓{ element in element.a }"):
+                Example("f.drop(while: \\.a)"),
         ]
     )
 }
@@ -80,7 +84,7 @@ struct PreferKeyPathRule: OptInRule {
 private extension PreferKeyPathRule {
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: ClosureExprSyntax) {
-            if node.isInvalid(standardFunctionsOnly: configuration.restrictToStandardFunctions) {
+            if node.isInvalid(restrictToStandardFunctions: configuration.restrictToStandardFunctions) {
                 return
             }
             if node.onlyExprStmt?.accesses(identifier: node.onlyParameter) == true {
@@ -91,14 +95,13 @@ private extension PreferKeyPathRule {
 
     final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: FunctionCallExprSyntax) -> ExprSyntax {
-            if configuration.restrictToStandardFunctions, !node.isStandardFunction {
-                return super.visit(node)
-            }
             guard node.additionalTrailingClosures.isEmpty,
                   let closure = node.trailingClosure,
+                  !closure.isInvalid(restrictToStandardFunctions: configuration.restrictToStandardFunctions),
                   let expr = closure.onlyExprStmt,
                   expr.accesses(identifier: closure.onlyParameter) == true,
-                  let declName = expr.as(MemberAccessExprSyntax.self) else {
+                  let declName = expr.as(MemberAccessExprSyntax.self),
+                  let calleeName = node.calleeName else {
                 return super.visit(node)
             }
             correctionPositions.append(closure.positionAfterSkippingLeadingTrivia)
@@ -107,12 +110,10 @@ private extension PreferKeyPathRule {
                 node = node.with(\.leftParen, .leftParenToken())
             }
             let newArg = LabeledExprSyntax(
-                label: ["contains", "first"].contains(node.calleeName) ? "where" : nil,
+                label: argumentLabelByStandardFunction[calleeName, default: nil],
                 expression: declName.asKeyPath
             )
-            node = node.with(
-                \.arguments,
-                node.arguments + [newArg]
+            node = node.with(\.arguments, [newArg]
             )
             if node.rightParen == nil {
                 node = node.with(\.rightParen, .rightParenToken())
@@ -124,7 +125,7 @@ private extension PreferKeyPathRule {
         }
 
         override func visit(_ node: ClosureExprSyntax) -> ExprSyntax {
-            if node.isInvalid(standardFunctionsOnly: configuration.restrictToStandardFunctions) {
+            if node.isInvalid(restrictToStandardFunctions: configuration.restrictToStandardFunctions) {
                 return super.visit(node)
             }
             if let expr = node.onlyExprStmt,
@@ -172,30 +173,37 @@ private extension ClosureExprSyntax {
         return nil
     }
 
-    private var surroundingFunction: FunctionCallExprSyntax? {
-           parent?.as(FunctionCallExprSyntax.self)
-        ?? parent?.as(LabeledExprSyntax.self)?.parent?.parent?.as(FunctionCallExprSyntax.self)
-    }
-
-    func isInvalid(standardFunctionsOnly: Bool) -> Bool {
-           keyPathInParent == \FunctionCallExprSyntax.calledExpression
-        || parent?.is(MultipleTrailingClosureElementSyntax.self) == true
-        || surroundingFunction?.additionalTrailingClosures.isNotEmpty == true
-        || standardFunctionsOnly && surroundingFunction?.isStandardFunction == false
+    func isInvalid(restrictToStandardFunctions: Bool) -> Bool {
+        if keyPathInParent == \FunctionCallExprSyntax.calledExpression {
+            return true
+        }
+        if parent?.is(MultipleTrailingClosureElementSyntax.self) == true {
+            return true
+        }
+        if let call = parent?.as(LabeledExprSyntax.self)?.parent?.parent?.as(FunctionCallExprSyntax.self) {
+            // Closure is function argument.
+            return restrictToStandardFunctions && !call.isStandardFunction
+        }
+        return parent?.as(FunctionCallExprSyntax.self)?.isStandardFunction == false
     }
 }
 
+private let argumentLabelByStandardFunction: [String: String?] = [
+    "allSatisfy": nil,
+    "contains": "where",
+    "drop": "while",
+    "filter": nil,
+    "first": "where",
+    "flatMap": nil,
+    "map": nil,
+    "partition": "by",
+    "prefix": "while",
+]
+
 private extension FunctionCallExprSyntax {
     var isStandardFunction: Bool {
-        if let calleeName {
-            return [
-                "allSatisfy",
-                "contains",
-                "filter",
-                "first",
-                "flatMap",
-                "map",
-            ].contains(calleeName)
+        if let calleeName, argumentLabelByStandardFunction.keys.contains(calleeName) {
+            return arguments.count + (trailingClosure == nil ? 0 : 1) == 1
         }
         return false
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/LetVarWhitespaceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/LetVarWhitespaceRule.swift
@@ -215,12 +215,12 @@ struct LetVarWhitespaceRule: OptInRule {
 private extension LetVarWhitespaceRule {
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: MemberBlockItemListSyntax) {
-            collectViolations(from: node, using: { $0.decl })
+            collectViolations(from: node, using: { $0.decl }) // swiftlint:disable:this prefer_key_path
         }
 
         override func visitPost(_ node: CodeBlockItemListSyntax) {
             if node.isInValidContext {
-                collectViolations(from: node, using: { $0.unwrap })
+                collectViolations(from: node, using: \.unwrap)
             }
         }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/TrailingClosureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/TrailingClosureRule.swift
@@ -256,7 +256,7 @@ private extension Trivia {
 
     func removingLeadingNewlines() -> Self {
         if startsWithNewline {
-            Trivia(pieces: pieces.drop(while: { $0.isNewline }))
+            Trivia(pieces: pieces.drop(while: \.isNewline))
         } else {
             self
         }


### PR DESCRIPTION
I wasn't satisfied with the `restrict_to_standard_functions` option being basically unusable in the real world.

By default, the rule now triggers on and corrects closures used in functions it "knows". With the option extending the rule, it now also triggers on closures used in "safe" contexts, where "safe" means that a correction would not lead to uncompilable code.

The set of "known" functions now also includes `drop`, `partition` and `prefix`.