### PR TITLE
Fix only rule config issues

### DIFF
--- a/Source/SwiftLintCore/Extensions/Configuration+RulesWrapper.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+RulesWrapper.swift
@@ -15,7 +15,11 @@ internal extension Configuration {
             let configurationCustomRulesIdentifiers =
                 (allRulesWrapped.first { $0.rule is CustomRules }?.rule as? CustomRules)?
                     .configuration.customRuleConfigurations.map(\.identifier) ?? []
-            return Set(regularRuleIdentifiers + configurationCustomRulesIdentifiers)
+            return Set(
+                regularRuleIdentifiers 
+                + configurationCustomRulesIdentifiers
+                + [RuleIdentifier.all.stringRepresentation]
+            )
         }
 
         private var cachedResultingRules: [any Rule]?

--- a/Source/SwiftLintCore/Extensions/Configuration+RulesWrapper.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+RulesWrapper.swift
@@ -16,7 +16,7 @@ internal extension Configuration {
                 (allRulesWrapped.first { $0.rule is CustomRules }?.rule as? CustomRules)?
                     .configuration.customRuleConfigurations.map(\.identifier) ?? []
             return Set(
-                regularRuleIdentifiers 
+                regularRuleIdentifiers
                 + configurationCustomRulesIdentifiers
                 + [RuleIdentifier.all.stringRepresentation]
             )

--- a/Source/SwiftLintCore/Models/Configuration.swift
+++ b/Source/SwiftLintCore/Models/Configuration.swift
@@ -230,7 +230,14 @@ public struct Configuration {
         defer { basedOnCustomConfigurationFiles = hasCustomConfigurationFiles }
 
         let currentWorkingDirectory = FileManager.default.currentDirectoryPath.bridge().absolutePathStandardized()
-        let rulesMode: RulesMode = enableAllRules ? .allEnabled : .default(disabled: [], optIn: [])
+        let rulesMode: RulesMode
+        if enableAllRules {
+            rulesMode = .allEnabled
+        } else if let onlyRule {
+            rulesMode = .only(Set([onlyRule]))
+        } else {
+            rulesMode = .default(disabled: [], optIn: [])
+        }
 
         // Try obtaining cached config
         let cacheIdentifier = "\(currentWorkingDirectory) - \(configurationFiles)"


### PR DESCRIPTION
WIP

Partly addresses #5711 

`func merged(with child: RulesWrapper) -> RulesWrapper` is a problem, as this will not respect `--only-rules` - we may need a dedicated `onlyRule` RulesMode to get this to work in all cases.
