### PR TITLE
Update Bazel bzlmod depedencies for `rules_swift` 2.x support

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,11 +8,11 @@ module(
 bazel_dep(name = "apple_support", version = "1.16.0", repo_name = "build_bazel_apple_support")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "platforms", version = "0.0.10")
-bazel_dep(name = "rules_apple", version = "3.6.0", repo_name = "build_bazel_rules_apple")
-bazel_dep(name = "rules_swift", version = "1.18.0", repo_name = "build_bazel_rules_swift")
-bazel_dep(name = "sourcekitten", version = "0.35.0", repo_name = "com_github_jpsim_sourcekitten")
-bazel_dep(name = "swift-syntax", version = "600.0.0-prerelease-2024-07-24", repo_name = "SwiftSyntax")
-bazel_dep(name = "swift_argument_parser", version = "1.3.1", repo_name = "sourcekitten_com_github_apple_swift_argument_parser")
+bazel_dep(name = "rules_apple", version = "3.8.0", repo_name = "build_bazel_rules_apple")
+bazel_dep(name = "rules_swift", version = "2.1.1", repo_name = "build_bazel_rules_swift")
+bazel_dep(name = "sourcekitten", version = "0.36.0", repo_name = "com_github_jpsim_sourcekitten")
+bazel_dep(name = "swift-syntax", version = "600.0.0-prerelease-2024-08-14", repo_name = "SwiftSyntax")
+bazel_dep(name = "swift_argument_parser", version = "1.3.1.1", repo_name = "sourcekitten_com_github_apple_swift_argument_parser")
 bazel_dep(name = "yams", version = "5.1.3", repo_name = "sourcekitten_com_github_jpsim_yams")
 
 swiftlint_repos = use_extension("//bazel:repos.bzl", "swiftlint_repos_bzlmod")
@@ -31,4 +31,4 @@ use_repo(apple_cc_configure, "local_config_apple_cc")
 
 # Dev Dependencies
 
-bazel_dep(name = "rules_xcodeproj", version = "1.13.0", dev_dependency = True)
+bazel_dep(name = "rules_xcodeproj", version = "2.6.1", dev_dependency = True)

--- a/Package.resolved
+++ b/Package.resolved
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "82a453c2dfa335c7e778695762438dfe72b328d2",
-        "version" : "600.0.0-prerelease-2024-07-24"
+        "revision" : "515f79b522918f83483068d99c68daeb5116342d",
+        "version" : "600.0.0-prerelease-2024-08-14"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.2.1"),
-        .package(url: "https://github.com/swiftlang/swift-syntax.git", exact: "600.0.0-prerelease-2024-07-24"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", exact: "600.0.0-prerelease-2024-08-14"),
         .package(url: "https://github.com/jpsim/SourceKitten.git", .upToNextMinor(from: "0.35.0")),
         .package(url: "https://github.com/jpsim/Yams.git", from: "5.0.6"),
         .package(url: "https://github.com/scottrhoyt/SwiftyTextTable.git", from: "0.9.0"),


### PR DESCRIPTION
Updates to the required versions to support rules_swift 2.x, this does force users of this change to use rules_swift >= 2.1.1 because SourceKitten requires use of the new `swift_interop_hints` rule. This will take effect in new Bazel registry releases.

- [x] Depends on https://github.com/swiftlang/swift-syntax/pull/2790 being merged and released

I'll be making a registry patch for supporting older swift-syntax versions for SwiftLint 0.55.1 