### PR TITLE
fix: compilation with Xcode 16.1b1

### DIFF
--- a/Source/SwiftLintCore/Extensions/Array+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/Array+SwiftLint.swift
@@ -103,12 +103,13 @@ public extension Array {
     func parallelMap<T>(transform: (Element) -> T) -> [T] {
         var result = ContiguousArray<T?>(repeating: nil, count: count)
         return result.withUnsafeMutableBufferPointer { buffer in
-            DispatchQueue.concurrentPerform(iterations: buffer.count) { idx in
-                buffer[idx] = transform(self[idx])
+            let localPointer = buffer
+            DispatchQueue.concurrentPerform(iterations: localPointer.count) { idx in
+                localPointer[idx] = transform(self[idx])
             }
-            return buffer.map { $0! }
+            return localPointer.map { $0! }
         }
-    }
+  }
 }
 
 public extension Collection {


### PR DESCRIPTION
This reduces a Swift concurrency error to a warning which resolves compiling with Xcode 16.1b1.

Fix comes from https://github.com/realm/SwiftLint/issues/5738#issuecomment-2282211903.
Resolves #5738.