### PR TITLE
Silence `unneeded_override` rule on methods and initializers with attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@
   [SimplyDanny](https://github.com/SimplyDanny)
   [#5762](https://github.com/realm/SwiftLint/issues/5762)
 
+* Silence `unneeded_override` rule on methods and initializers with attributes.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#5753](https://github.com/realm/SwiftLint/issues/5753)
+
 ## 0.56.1: Heat Pump Dryer
 
 #### Breaking

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnneededOverrideRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnneededOverrideRule.swift
@@ -89,8 +89,8 @@ private extension OverridableDecl {
             return false
         }
 
-        // Assume having @available changes behavior.
-        if attributes.contains(attributeNamed: "available") {
+        // Assume attributes change behavior.
+        guard attributes.isEmpty else {
             return false
         }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnneededOverrideRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnneededOverrideRuleExamples.swift
@@ -18,6 +18,13 @@ struct UnneededOverrideRuleExamples {
         """),
         Example("""
         class Foo {
+            @objc override func bar() {
+                super.bar()
+            }
+        }
+        """),
+        Example("""
+        class Foo {
             override func bar() {
                 super.bar()
                 super.bar()


### PR DESCRIPTION
Fixes #5753.