### PR TITLE
Silence `prefer_key_path` rule on macro expansion expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
   [SimplyDanny](https://github.com/SimplyDanny)
   [#5153](https://github.com/realm/SwiftLint/issues/5153)
 
+* Silence `prefer_key_path` rule on macro expansion expressions.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#5744](https://github.com/realm/SwiftLint/issues/5744)
+
 * Check `if` expressions nested arbitrarily deep in `contrasted_opening_brace` rule.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#5752](https://github.com/realm/SwiftLint/issues/5752)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferKeyPathRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferKeyPathRule.swift
@@ -29,6 +29,7 @@ struct PreferKeyPathRule: OptInRule {
             Example("[1, 2, 3].reduce(1) { $0 + $1 }", configuration: extendedMode),
             Example("f.map(1) { $0.a }"),
             Example("f.filter({ $0.a }, x)"),
+            Example("#Predicate { $0.a }"),
         ],
         triggeringExamples: [
             Example("f.map ↓{ $0.a }"),
@@ -174,10 +175,9 @@ private extension ClosureExprSyntax {
     }
 
     func isInvalid(restrictToStandardFunctions: Bool) -> Bool {
-        if keyPathInParent == \FunctionCallExprSyntax.calledExpression {
-            return true
-        }
-        if parent?.is(MultipleTrailingClosureElementSyntax.self) == true {
+        guard keyPathInParent != \FunctionCallExprSyntax.calledExpression,
+              let parentKind = parent?.kind,
+              ![.macroExpansionExpr, .multipleTrailingClosureElement].contains(parentKind) else {
             return true
         }
         if let call = parent?.as(LabeledExprSyntax.self)?.parent?.parent?.as(FunctionCallExprSyntax.self) {


### PR DESCRIPTION
Fixes #5744.