### PR TITLE
[Docs] Commented also when `excludes_trivial_init` is false in `missing_docs` rule

### DIFF
--- a/Source/SwiftLintBuiltInRules/Rules/Lint/MissingDocsRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/MissingDocsRuleExamples.swift
@@ -211,7 +211,7 @@ struct MissingDocsRuleExamples {
         public ↓struct S: ~Copyable, ~Escapable {
             public ↓init() {}
         }
-        """),
+        """, configuration: ["excludes_trivial_init": false]),
         Example("""
         /// my doc
         #if os(macOS)


### PR DESCRIPTION
## Describe your changes

Already mentioned in docs when excludes_trivial_init is true, but not mentioned in docs when excludes_trivial_init is false.
At the moment, the documentation only mentions when excludes_trivial_init is true. ([Docs](https://realm.github.io/SwiftLint/missing_docs.html))


## Issue ticket number and link
None.
