### PR TITLE
Fix `--only-rule` config issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@
   [Martin Redington](https://github.com/mildm8nnered)
   [#5788](https://github.com/realm/SwiftLint/issues/5788)
 
+* Fixes the `--only-rule` command line option, when a default `.swiftlint.yml`
+  is absent. Additionally rules specified with `--only-rule` on the command
+  line can now be disabled in a child configuration, to allow specific
+  directories to be excluded from the rule (or from being auto-corrected by
+  the rule).  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#5711](https://github.com/realm/SwiftLint/issues/5711)
+
 ## 0.57.0: Squeaky Clean Cycle
 
 #### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,8 @@
   is absent. Additionally rules specified with `--only-rule` on the command
   line can now be disabled in a child configuration, to allow specific
   directories to be excluded from the rule (or from being auto-corrected by
-  the rule).  
+  the rule), and `--only-rule` can now be specified multiple times
+  to run multiple rules.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#5711](https://github.com/realm/SwiftLint/issues/5711)
 

--- a/Source/SwiftLintCore/Extensions/Configuration+FileGraph.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+FileGraph.swift
@@ -41,7 +41,7 @@ package extension Configuration {
         // MARK: - Methods
         internal mutating func resultingConfiguration(
             enableAllRules: Bool,
-            onlyRule: String?,
+            onlyRule: [String],
             cachePath: String?
         ) throws -> Configuration {
             // Build if needed
@@ -250,7 +250,7 @@ package extension Configuration {
         private func merged(
             configurationData: [(configurationDict: [String: Any], rootDirectory: String)],
             enableAllRules: Bool,
-            onlyRule: String?,
+            onlyRule: [String],
             cachePath: String?
         ) throws -> Configuration {
             // Split into first & remainder; use empty dict for first if the array is empty

--- a/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
@@ -42,7 +42,7 @@ extension Configuration {
         dict: [String: Any],
         ruleList: RuleList = RuleRegistry.shared.list,
         enableAllRules: Bool = false,
-        onlyRule: String? = nil,
+        onlyRule: [String] = [],
         cachePath: String? = nil
     ) throws {
         func defaultStringArray(_ object: Any?) -> [String] { [String].array(of: object) ?? [] }
@@ -81,7 +81,7 @@ extension Configuration {
             analyzerRules: analyzerRules
         )
 
-        if onlyRule == nil {
+        if onlyRule.isEmpty {
             Self.validateConfiguredRulesAreEnabled(
                 parentConfiguration: parentConfiguration,
                 configurationDictionary: dict,

--- a/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
@@ -174,7 +174,7 @@ extension Configuration {
             }
 
             switch rulesMode {
-            case .allEnabled:
+            case .allEnabled, .onlyRule:
                 return
             case .only(let onlyRules):
                 let issue = validateConfiguredRuleIsEnabled(onlyRules: onlyRules, ruleType: ruleType)

--- a/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
@@ -174,12 +174,12 @@ extension Configuration {
             }
 
             switch rulesMode {
-            case .allEnabled, .onlyRule:
+            case .allCommandLine, .onlyCommandLine:
                 return
-            case .only(let onlyRules):
+            case .onlyConfiguration(let onlyRules):
                 let issue = validateConfiguredRuleIsEnabled(onlyRules: onlyRules, ruleType: ruleType)
                 issue?.print()
-            case let .default(disabled: disabledRules, optIn: optInRules):
+            case let .defaultConfiguration(disabled: disabledRules, optIn: optInRules):
                 let issue = validateConfiguredRuleIsEnabled(
                     parentConfiguration: parentConfiguration,
                     disabledRules: disabledRules,
@@ -201,9 +201,11 @@ extension Configuration {
         var disabledInParentRules: Set<String> = []
         var allEnabledRules: Set<String> = []
 
-        if case .only(let onlyRules) = parentConfiguration?.rulesMode {
+        if case .onlyConfiguration(let onlyRules) = parentConfiguration?.rulesMode {
             enabledInParentRules = onlyRules
-        } else if case .default(let parentDisabledRules, let parentOptInRules) = parentConfiguration?.rulesMode {
+        } else if case .defaultConfiguration(
+            let parentDisabledRules, let parentOptInRules
+        ) = parentConfiguration?.rulesMode {
             enabledInParentRules = parentOptInRules
             disabledInParentRules = parentDisabledRules
         }
@@ -243,7 +245,7 @@ extension Configuration {
         allEnabledRules: Set<String>,
         ruleType: any Rule.Type
     ) -> Issue? {
-        if case .allEnabled = parentConfiguration?.rulesMode {
+        if case .allCommandLine = parentConfiguration?.rulesMode {
             if disabledRules.contains(ruleType.identifier) {
                 return Issue.ruleDisabledInDisabledRules(ruleID: ruleType.identifier)
             }
@@ -264,7 +266,7 @@ extension Configuration {
                 if enabledInParentRules.union(optInRules).isDisjoint(with: allIdentifiers) {
                     return Issue.ruleNotEnabledInOptInRules(ruleID: ruleType.identifier)
                 }
-            } else if case .only(let enabledInParentRules) = parentConfiguration?.rulesMode,
+            } else if case .onlyConfiguration(let enabledInParentRules) = parentConfiguration?.rulesMode,
                       enabledInParentRules.isDisjoint(with: allIdentifiers) {
                 return Issue.ruleNotEnabledInParentOnlyRules(ruleID: ruleType.identifier)
             }

--- a/Source/SwiftLintCore/Extensions/Configuration+RulesMode.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+RulesMode.swift
@@ -26,7 +26,7 @@ public extension Configuration {
         /// Only enable the rules explicitly listed in the configuration files.
         case only(Set<String>)
 
-        /// Only enable the rules explicitly listed on the command line.
+        /// Only enable the rule explicitly listed on the command line (and it's aliases).
         case onlyRule(Set<String>)
 
         /// Enable all available rules.

--- a/Source/SwiftLintCore/Extensions/Configuration+RulesMode.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+RulesMode.swift
@@ -34,7 +34,7 @@ public extension Configuration {
 
         internal init(
             enableAllRules: Bool,
-            onlyRule: String?,
+            onlyRule: [String],
             onlyRules: [String],
             optInRules: [String],
             disabledRules: [String],
@@ -52,8 +52,8 @@ public extension Configuration {
 
             if enableAllRules {
                 self = .allCommandLine
-            } else if let onlyRule {
-                self = .onlyCommandLine(Set([onlyRule]))
+            } else if onlyRule.isNotEmpty {
+                self = .onlyCommandLine(Set(onlyRule))
             } else if onlyRules.isNotEmpty {
                 if disabledRules.isNotEmpty || optInRules.isNotEmpty {
                     throw Issue.genericWarning(

--- a/Source/SwiftLintCore/Extensions/Configuration+RulesMode.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+RulesMode.swift
@@ -21,16 +21,16 @@ public extension Configuration {
         /// The default rules mode, which will enable all rules that aren't defined as being opt-in
         /// (conforming to the `OptInRule` protocol), minus the rules listed in `disabled`, plus the rules listed in
         /// `optIn`.
-        case `default`(disabled: Set<String>, optIn: Set<String>)
+        case defaultConfiguration(disabled: Set<String>, optIn: Set<String>)
 
         /// Only enable the rules explicitly listed in the configuration files.
-        case only(Set<String>)
+        case onlyConfiguration(Set<String>)
 
         /// Only enable the rule explicitly listed on the command line (and it's aliases).
-        case onlyRule(Set<String>)
+        case onlyCommandLine(Set<String>)
 
         /// Enable all available rules.
-        case allEnabled
+        case allCommandLine
 
         internal init(
             enableAllRules: Bool,
@@ -51,9 +51,9 @@ public extension Configuration {
             }
 
             if enableAllRules {
-                self = .allEnabled
+                self = .allCommandLine
             } else if let onlyRule {
-                self = .onlyRule(Set([onlyRule]))
+                self = .onlyCommandLine(Set([onlyRule]))
             } else if onlyRules.isNotEmpty {
                 if disabledRules.isNotEmpty || optInRules.isNotEmpty {
                     throw Issue.genericWarning(
@@ -64,7 +64,7 @@ public extension Configuration {
                 }
 
                 warnAboutDuplicates(in: onlyRules + analyzerRules)
-                self = .only(Set(onlyRules + analyzerRules))
+                self = .onlyConfiguration(Set(onlyRules + analyzerRules))
             } else {
                 warnAboutDuplicates(in: disabledRules)
 
@@ -89,26 +89,28 @@ public extension Configuration {
                 }
 
                 warnAboutDuplicates(in: effectiveOptInRules + effectiveAnalyzerRules)
-                self = .default(disabled: Set(disabledRules), optIn: Set(effectiveOptInRules + effectiveAnalyzerRules))
+                self = .defaultConfiguration(
+                    disabled: Set(disabledRules), optIn: Set(effectiveOptInRules + effectiveAnalyzerRules)
+                )
             }
         }
 
         internal func applied(aliasResolver: (String) -> String) -> Self {
             switch self {
-            case let .default(disabled, optIn):
-                return .default(
+            case let .defaultConfiguration(disabled, optIn):
+                return .defaultConfiguration(
                     disabled: Set(disabled.map(aliasResolver)),
                     optIn: Set(optIn.map(aliasResolver))
                 )
 
-            case let .only(onlyRules):
-                return .only(Set(onlyRules.map(aliasResolver)))
+            case let .onlyConfiguration(onlyRules):
+                return .onlyConfiguration(Set(onlyRules.map(aliasResolver)))
 
-            case let .onlyRule(onlyRules):
-                return .onlyRule(Set(onlyRules.map(aliasResolver)))
+            case let .onlyCommandLine(onlyRules):
+                return .onlyCommandLine(Set(onlyRules.map(aliasResolver)))
 
-            case .allEnabled:
-                return .allEnabled
+            case .allCommandLine:
+                return .allCommandLine
             }
         }
 
@@ -116,9 +118,11 @@ public extension Configuration {
             // In the only mode, if the custom rules rule is enabled, all custom rules are also enabled implicitly
             // This method makes the implicitly explicit
             switch self {
-            case let .only(onlyRules) where onlyRules.contains { $0 == CustomRules.description.identifier }:
+            case let .onlyConfiguration(onlyRules) where onlyRules.contains {
+                $0 == CustomRules.identifier
+            }:
                 let customRulesRule = (allRulesWrapped.first { $0.rule is CustomRules })?.rule as? CustomRules
-                return .only(onlyRules.union(Set(customRulesRule?.customRuleIdentifiers ?? [])))
+                return .onlyConfiguration(onlyRules.union(Set(customRulesRule?.customRuleIdentifiers ?? [])))
 
             default:
                 return self

--- a/Source/SwiftLintCore/Extensions/Configuration+RulesMode.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+RulesMode.swift
@@ -26,6 +26,10 @@ public extension Configuration {
         /// Only enable the rules explicitly listed.
         case only(Set<String>)
 
+        /// Only enable the rule explicitly listed on the command line. The rule may have multiple identifiers,
+        /// hence why this is represented as a Set
+        case onlyRule(Set<String>)
+
         /// Enable all available rules.
         case allEnabled
 
@@ -50,7 +54,7 @@ public extension Configuration {
             if enableAllRules {
                 self = .allEnabled
             } else if let onlyRule {
-                self = .only(Set([onlyRule]))
+                self = .onlyRule(Set([onlyRule]))
             } else if onlyRules.isNotEmpty {
                 if disabledRules.isNotEmpty || optInRules.isNotEmpty {
                     throw Issue.genericWarning(
@@ -100,6 +104,9 @@ public extension Configuration {
 
             case let .only(onlyRules):
                 return .only(Set(onlyRules.map(aliasResolver)))
+
+            case let .onlyRule(onlyRules):
+                return .onlyRule(Set(onlyRules.map(aliasResolver)))
 
             case .allEnabled:
                 return .allEnabled

--- a/Source/SwiftLintCore/Extensions/Configuration+RulesMode.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+RulesMode.swift
@@ -23,11 +23,10 @@ public extension Configuration {
         /// `optIn`.
         case `default`(disabled: Set<String>, optIn: Set<String>)
 
-        /// Only enable the rules explicitly listed.
+        /// Only enable the rules explicitly listed in the configuration files.
         case only(Set<String>)
 
-        /// Only enable the rule explicitly listed on the command line. The rule may have multiple identifiers,
-        /// hence why this is represented as a Set
+        /// Only enable the rules explicitly listed on the command line.
         case onlyRule(Set<String>)
 
         /// Enable all available rules.

--- a/Source/SwiftLintCore/Extensions/Configuration+RulesMode.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+RulesMode.swift
@@ -26,7 +26,8 @@ public extension Configuration {
         /// Only enable the rules explicitly listed in the configuration files.
         case onlyConfiguration(Set<String>)
 
-        /// Only enable the rule explicitly listed on the command line (and it's aliases).
+        /// Only enable the rule(s) explicitly listed on the command line (and their aliases). `--only-rule` can be
+        /// specified multiple times to enable multiple rules.
         case onlyCommandLine(Set<String>)
 
         /// Enable all available rules.

--- a/Source/SwiftLintCore/Extensions/Configuration+RulesWrapper.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+RulesWrapper.swift
@@ -86,16 +86,7 @@ internal extension Configuration {
                 return validate(ruleIds: disabled, valid: validRuleIdentifiers, silent: true)
                     .sorted(by: <)
 
-            case let .only(onlyRules):
-                return validate(
-                    ruleIds: Set(allRulesWrapped
-                        .map { type(of: $0.rule).description.identifier }
-                        .filter { !onlyRules.contains($0) }),
-                    valid: validRuleIdentifiers,
-                    silent: true
-                ).sorted(by: <)
-
-            case let .onlyRule(onlyRules):
+            case let .only(onlyRules), let .onlyRule(onlyRules):
                 return validate(
                     ruleIds: Set(allRulesWrapped
                         .map { type(of: $0.rule).description.identifier }

--- a/Source/SwiftLintCore/Extensions/Configuration+RulesWrapper.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+RulesWrapper.swift
@@ -276,9 +276,8 @@ internal extension Configuration {
                 ))
 
             case let .onlyRule(onlyRules):
-                // .allEnabled allows rules to be disabled in the child config. For now, we'll ignore
-                // the child config
-                return .onlyRule(onlyRules)
+                // Like .allEnabled, rules can be disabled in a child config
+                return .onlyRule(onlyRules.filter { !childDisabled.contains($0) })
 
             case .allEnabled:
                 // Opt-in to every rule that isn't disabled via child config

--- a/Source/SwiftLintCore/Extensions/Configuration+RulesWrapper.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+RulesWrapper.swift
@@ -173,9 +173,13 @@ internal extension Configuration {
                 )
 
             case let .only(childOnlyRules):
-                // Always use the child only rules
-                newMode = .only(childOnlyRules)
-
+                // Use the child only rules, unless the parent is onlyRule
+                switch mode {
+                case let .onlyRule(onlyRules):
+                    newMode = .onlyRule(onlyRules)
+                default:
+                    newMode = .only(childOnlyRules)
+                }
             case let .onlyRule(onlyRules):
                 // Always use the only rule
                 newMode = .onlyRule(onlyRules)

--- a/Source/SwiftLintCore/Extensions/Configuration+RulesWrapper.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+RulesWrapper.swift
@@ -38,14 +38,7 @@ internal extension Configuration {
                 customRulesFilter = { _ in true }
                 resultingRules = allRulesWrapped.map(\.rule)
 
-            case var .only(onlyRulesRuleIdentifiers):
-                customRulesFilter = { onlyRulesRuleIdentifiers.contains($0.identifier) }
-                onlyRulesRuleIdentifiers = validate(ruleIds: onlyRulesRuleIdentifiers, valid: validRuleIdentifiers)
-                resultingRules = allRulesWrapped.filter { tuple in
-                    onlyRulesRuleIdentifiers.contains(type(of: tuple.rule).description.identifier)
-                }.map(\.rule)
-
-            case var .onlyRule(onlyRulesRuleIdentifiers):
+            case var .only(onlyRulesRuleIdentifiers), var .onlyRule(onlyRulesRuleIdentifiers):
                 customRulesFilter = { onlyRulesRuleIdentifiers.contains($0.identifier) }
                 onlyRulesRuleIdentifiers = validate(ruleIds: onlyRulesRuleIdentifiers, valid: validRuleIdentifiers)
                 resultingRules = allRulesWrapped.filter { tuple in

--- a/Source/SwiftLintCore/Extensions/Configuration+RulesWrapper.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+RulesWrapper.swift
@@ -34,18 +34,18 @@ internal extension Configuration {
             let customRulesFilter: (RegexConfiguration<CustomRules>) -> (Bool)
             var resultingRules = [any Rule]()
             switch mode {
-            case .allEnabled:
+            case .allCommandLine:
                 customRulesFilter = { _ in true }
                 resultingRules = allRulesWrapped.map(\.rule)
 
-            case let .only(onlyRulesRuleIdentifiers), let .onlyRule(onlyRulesRuleIdentifiers):
+            case let .onlyConfiguration(onlyRulesRuleIdentifiers), let .onlyCommandLine(onlyRulesRuleIdentifiers):
                 customRulesFilter = { onlyRulesRuleIdentifiers.contains($0.identifier) }
                 let onlyRulesRuleIdentifiers = validate(ruleIds: onlyRulesRuleIdentifiers, valid: validRuleIdentifiers)
                 resultingRules = allRulesWrapped.filter { tuple in
                     onlyRulesRuleIdentifiers.contains(type(of: tuple.rule).description.identifier)
                 }.map(\.rule)
 
-            case var .default(disabledRuleIdentifiers, optInRuleIdentifiers):
+            case var .defaultConfiguration(disabledRuleIdentifiers, optInRuleIdentifiers):
                 customRulesFilter = { !disabledRuleIdentifiers.contains($0.identifier) }
                 disabledRuleIdentifiers = validate(ruleIds: disabledRuleIdentifiers, valid: validRuleIdentifiers)
                 optInRuleIdentifiers = validate(optInRuleIds: optInRuleIdentifiers, valid: validRuleIdentifiers)
@@ -75,11 +75,11 @@ internal extension Configuration {
 
         lazy var disabledRuleIdentifiers: [String] = {
             switch mode {
-            case let .default(disabled, _):
+            case let .defaultConfiguration(disabled, _):
                 return validate(ruleIds: disabled, valid: validRuleIdentifiers, silent: true)
                     .sorted(by: <)
 
-            case let .only(onlyRules), let .onlyRule(onlyRules):
+            case let .onlyConfiguration(onlyRules), let .onlyCommandLine(onlyRules):
                 return validate(
                     ruleIds: Set(allRulesWrapped
                         .map { type(of: $0.rule).description.identifier }
@@ -88,7 +88,7 @@ internal extension Configuration {
                     silent: true
                 ).sorted(by: <)
 
-            case .allEnabled:
+            case .allCommandLine:
                 return []
             }
         }()
@@ -147,7 +147,7 @@ internal extension Configuration {
             let validRuleIdentifiers = self.validRuleIdentifiers.union(child.validRuleIdentifiers)
             let newMode: RulesMode
             switch child.mode {
-            case let .default(childDisabled, childOptIn):
+            case let .defaultConfiguration(childDisabled, childOptIn):
                 newMode = mergeDefaultMode(
                     newAllRulesWrapped: newAllRulesWrapped,
                     child: child,
@@ -156,21 +156,21 @@ internal extension Configuration {
                     validRuleIdentifiers: validRuleIdentifiers
                 )
 
-            case let .only(childOnlyRules):
+            case let .onlyConfiguration(childOnlyRules):
                 // Use the child only rules, unless the parent is onlyRule
                 switch mode {
-                case let .onlyRule(onlyRules):
-                    newMode = .onlyRule(onlyRules)
+                case let .onlyCommandLine(onlyRules):
+                    newMode = .onlyCommandLine(onlyRules)
                 default:
-                    newMode = .only(childOnlyRules)
+                    newMode = .onlyConfiguration(childOnlyRules)
                 }
-            case let .onlyRule(onlyRules):
+            case let .onlyCommandLine(onlyRules):
                 // Always use the only rule
-                newMode = .onlyRule(onlyRules)
+                newMode = .onlyCommandLine(onlyRules)
 
-            case .allEnabled:
+            case .allCommandLine:
                 // Always use .allEnabled mode
-                newMode = .allEnabled
+                newMode = .allCommandLine
             }
 
             // Assemble & return merged rules
@@ -233,12 +233,12 @@ internal extension Configuration {
             let childOptIn = child.validate(optInRuleIds: childOptIn, valid: validRuleIdentifiers)
 
             switch mode { // Switch parent's mode. Child is in default mode.
-            case var .default(disabled, optIn):
+            case var .defaultConfiguration(disabled, optIn):
                 disabled = validate(ruleIds: disabled, valid: validRuleIdentifiers)
                 optIn = child.validate(optInRuleIds: optIn, valid: validRuleIdentifiers)
 
                 // Only use parent disabled / optIn if child config doesn't tell the opposite
-                return .default(
+                return .defaultConfiguration(
                     disabled: Set(childDisabled).union(Set(disabled.filter { !childOptIn.contains($0) })),
                     optIn: Set(childOptIn).union(Set(optIn.filter { !childDisabled.contains($0) }))
                         .filter {
@@ -246,7 +246,7 @@ internal extension Configuration {
                         }
                 )
 
-            case var .only(onlyRules):
+            case var .onlyConfiguration(onlyRules):
                 // Also add identifiers of child custom rules iff the custom_rules rule is enabled
                 // (parent custom rules are already added)
                 if (onlyRules.contains { $0 == CustomRules.description.identifier }) {
@@ -264,17 +264,17 @@ internal extension Configuration {
 
                 // Allow parent only rules that weren't disabled via the child config
                 // & opt-ins from the child config
-                return .only(Set(
+                return .onlyConfiguration(Set(
                     childOptIn.union(onlyRules).filter { !childDisabled.contains($0) }
                 ))
 
-            case let .onlyRule(onlyRules):
+            case let .onlyCommandLine(onlyRules):
                 // Like .allEnabled, rules can be disabled in a child config
-                return .onlyRule(onlyRules.filter { !childDisabled.contains($0) })
+                return .onlyCommandLine(onlyRules.filter { !childDisabled.contains($0) })
 
-            case .allEnabled:
+            case .allCommandLine:
                 // Opt-in to every rule that isn't disabled via child config
-                return .default(
+                return .defaultConfiguration(
                     disabled: childDisabled
                         .filter {
                             !isOptInRule($0, allRulesWrapped: newAllRulesWrapped)

--- a/Source/SwiftLintCore/Extensions/Configuration+RulesWrapper.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+RulesWrapper.swift
@@ -38,9 +38,9 @@ internal extension Configuration {
                 customRulesFilter = { _ in true }
                 resultingRules = allRulesWrapped.map(\.rule)
 
-            case var .only(onlyRulesRuleIdentifiers), var .onlyRule(onlyRulesRuleIdentifiers):
+            case let .only(onlyRulesRuleIdentifiers), let .onlyRule(onlyRulesRuleIdentifiers):
                 customRulesFilter = { onlyRulesRuleIdentifiers.contains($0.identifier) }
-                onlyRulesRuleIdentifiers = validate(ruleIds: onlyRulesRuleIdentifiers, valid: validRuleIdentifiers)
+                let onlyRulesRuleIdentifiers = validate(ruleIds: onlyRulesRuleIdentifiers, valid: validRuleIdentifiers)
                 resultingRules = allRulesWrapped.filter { tuple in
                     onlyRulesRuleIdentifiers.contains(type(of: tuple.rule).description.identifier)
                 }.map(\.rule)

--- a/Source/SwiftLintCore/Models/Configuration.swift
+++ b/Source/SwiftLintCore/Models/Configuration.swift
@@ -147,7 +147,7 @@ public struct Configuration {
     /// - parameter writeBaseline:          The path to write a baseline to.
     /// - parameter checkForUpdates:        Check for updates to SwiftLint.
     package init(
-        rulesMode: RulesMode = .default(disabled: [], optIn: []),
+        rulesMode: RulesMode = .defaultConfiguration(disabled: [], optIn: []),
         allRulesWrapped: [ConfigurationRuleWrapper]? = nil,
         ruleList: RuleList = RuleRegistry.shared.list,
         fileGraph: FileGraph? = nil,
@@ -231,11 +231,11 @@ public struct Configuration {
 
         let currentWorkingDirectory = FileManager.default.currentDirectoryPath.bridge().absolutePathStandardized()
         let rulesMode: RulesMode = if enableAllRules {
-            .allEnabled
+            .allCommandLine
         } else if let onlyRule {
-            .onlyRule([onlyRule])
+            .onlyCommandLine([onlyRule])
         } else {
-            .default(disabled: [], optIn: [])
+            .defaultConfiguration(disabled: [], optIn: [])
         }
 
         // Try obtaining cached config

--- a/Source/SwiftLintCore/Models/Configuration.swift
+++ b/Source/SwiftLintCore/Models/Configuration.swift
@@ -230,6 +230,7 @@ public struct Configuration {
         defer { basedOnCustomConfigurationFiles = hasCustomConfigurationFiles }
 
         let currentWorkingDirectory = FileManager.default.currentDirectoryPath.bridge().absolutePathStandardized()
+        // Hmmmmmm
         let rulesMode: RulesMode = enableAllRules ? .allEnabled : .default(disabled: [], optIn: [])
 
         // Try obtaining cached config

--- a/Source/SwiftLintCore/Models/Configuration.swift
+++ b/Source/SwiftLintCore/Models/Configuration.swift
@@ -230,8 +230,13 @@ public struct Configuration {
         defer { basedOnCustomConfigurationFiles = hasCustomConfigurationFiles }
 
         let currentWorkingDirectory = FileManager.default.currentDirectoryPath.bridge().absolutePathStandardized()
-        // Hmmmmmm
-        let rulesMode: RulesMode = enableAllRules ? .allEnabled : .default(disabled: [], optIn: [])
+        let rulesMode: RulesMode = if enableAllRules {
+            .allEnabled
+        } else if let onlyRule {
+            .onlyRule([onlyRule])
+        } else {
+            .default(disabled: [], optIn: [])
+        }
 
         // Try obtaining cached config
         let cacheIdentifier = "\(currentWorkingDirectory) - \(configurationFiles)"

--- a/Source/SwiftLintCore/Models/Configuration.swift
+++ b/Source/SwiftLintCore/Models/Configuration.swift
@@ -210,7 +210,7 @@ public struct Configuration {
     public init(
         configurationFiles: [String], // No default value here to avoid ambiguous Configuration() initializer
         enableAllRules: Bool = false,
-        onlyRule: String? = nil,
+        onlyRule: [String] = [],
         cachePath: String? = nil,
         ignoreParentAndChildConfigs: Bool = false,
         mockedNetworkResults: [String: String] = [:],
@@ -232,8 +232,8 @@ public struct Configuration {
         let currentWorkingDirectory = FileManager.default.currentDirectoryPath.bridge().absolutePathStandardized()
         let rulesMode: RulesMode = if enableAllRules {
             .allCommandLine
-        } else if let onlyRule {
-            .onlyCommandLine([onlyRule])
+        } else if onlyRule.isNotEmpty {
+            .onlyCommandLine(Set(onlyRule))
         } else {
             .defaultConfiguration(disabled: [], optIn: [])
         }

--- a/Source/SwiftLintFramework/LintOrAnalyzeCommand.swift
+++ b/Source/SwiftLintFramework/LintOrAnalyzeCommand.swift
@@ -49,7 +49,7 @@ package struct LintOrAnalyzeOptions {
     let cachePath: String?
     let ignoreCache: Bool
     let enableAllRules: Bool
-    let onlyRule: String?
+    let onlyRule: [String]
     let autocorrect: Bool
     let format: Bool
     let compilerLogPath: String?
@@ -76,7 +76,7 @@ package struct LintOrAnalyzeOptions {
                  cachePath: String?,
                  ignoreCache: Bool,
                  enableAllRules: Bool,
-                 onlyRule: String?,
+                 onlyRule: [String],
                  autocorrect: Bool,
                  format: Bool,
                  compilerLogPath: String?,

--- a/Source/swiftlint/Commands/Analyze.swift
+++ b/Source/swiftlint/Commands/Analyze.swift
@@ -13,8 +13,11 @@ extension SwiftLint {
         var compilerLogPath: String?
         @Option(help: "The path of a compilation database to use when running AnalyzerRules.")
         var compileCommands: String?
-        @Option(help: "Run only the specified rule, ignoring `only_rules`, `opt_in_rules` and `disabled_rules`.")
-        var onlyRule: String?
+        @Option(
+            parsing: .singleValue,
+            help: "Run only the specified rule, ignoring `only_rules`, `opt_in_rules` and `disabled_rules`."
+        )
+        var onlyRule: [String]
         @Argument(help: pathsArgumentDescription(for: .analyze))
         var paths = [String]()
 

--- a/Source/swiftlint/Commands/Analyze.swift
+++ b/Source/swiftlint/Commands/Analyze.swift
@@ -15,9 +15,12 @@ extension SwiftLint {
         var compileCommands: String?
         @Option(
             parsing: .singleValue,
-            help: "Run only the specified rule, ignoring `only_rules`, `opt_in_rules` and `disabled_rules`."
+            help: """
+                    Run only the specified rule, ignoring `only_rules`, `opt_in_rules` and `disabled_rules`.
+                    Can be specified repeatedly to run multiple rules.
+                    """
         )
-        var onlyRule: [String]
+        var onlyRule: [String] = []
         @Argument(help: pathsArgumentDescription(for: .analyze))
         var paths = [String]()
 

--- a/Source/swiftlint/Commands/Lint.swift
+++ b/Source/swiftlint/Commands/Lint.swift
@@ -19,8 +19,11 @@ extension SwiftLint {
         var noCache = false
         @Flag(help: "Run all rules, even opt-in and disabled ones, ignoring `only_rules`.")
         var enableAllRules = false
-        @Option(help: "Run only the specified rule, ignoring `only_rules`, `opt_in_rules` and `disabled_rules`.")
-        var onlyRule: String?
+        @Option(
+            parsing: .singleValue,
+            help: "Run only the specified rule, ignoring `only_rules`, `opt_in_rules` and `disabled_rules`."
+        )
+        var onlyRule: [String]
         @Argument(help: pathsArgumentDescription(for: .lint))
         var paths = [String]()
 

--- a/Source/swiftlint/Commands/Lint.swift
+++ b/Source/swiftlint/Commands/Lint.swift
@@ -21,9 +21,12 @@ extension SwiftLint {
         var enableAllRules = false
         @Option(
             parsing: .singleValue,
-            help: "Run only the specified rule, ignoring `only_rules`, `opt_in_rules` and `disabled_rules`."
+            help: """
+                    Run only the specified rule, ignoring `only_rules`, `opt_in_rules` and `disabled_rules`.
+                    Can be specified repeatedly to run multiple rules.
+                    """
         )
-        var onlyRule: [String]
+        var onlyRule: [String] = []
         @Argument(help: pathsArgumentDescription(for: .lint))
         var paths = [String]()
 

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -54,7 +54,7 @@ final class IntegrationTests: SwiftLintTestCase {
     }
 
     func testDefaultConfigurations() {
-        let defaultConfig = Configuration(rulesMode: .allEnabled).rules
+        let defaultConfig = Configuration(rulesMode: .allCommandLine).rules
             .map { type(of: $0) }
             .filter { $0.identifier != "custom_rules" }
             .map {

--- a/Tests/SwiftLintFrameworkTests/CollectingRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CollectingRuleTests.swift
@@ -147,7 +147,7 @@ extension MockCollectingRule {
         RuleDescription(identifier: "test_rule", name: "", description: "", kind: .lint)
     }
     static var configuration: Configuration? {
-        Configuration(rulesMode: .only([description.identifier]), ruleList: RuleList(rules: self))
+        Configuration(rulesMode: .onlyConfiguration([identifier]), ruleList: RuleList(rules: self))
     }
 
     init(configuration _: Any) throws { self.init() }

--- a/Tests/SwiftLintFrameworkTests/CommandTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CommandTests.swift
@@ -393,7 +393,9 @@ final class CommandTests: SwiftLintTestCase {
     }
 
     func testSuperfluousDisableCommandsDisabledOnConfiguration() {
-        let rulesMode = Configuration.RulesMode.default(disabled: ["superfluous_disable_command"], optIn: [])
+        let rulesMode = Configuration.RulesMode.defaultConfiguration(
+            disabled: ["superfluous_disable_command"], optIn: []
+        )
         let configuration = Configuration(rulesMode: rulesMode)
 
         XCTAssertEqual(
@@ -456,7 +458,7 @@ final class CommandTests: SwiftLintTestCase {
 
     func testSuperfluousDisableCommandsEnabledForAnalyzer() {
         let configuration = Configuration(
-            rulesMode: .default(disabled: [], optIn: [UnusedDeclarationRule.description.identifier])
+            rulesMode: .defaultConfiguration(disabled: [], optIn: [UnusedDeclarationRule.identifier])
         )
         let violations = violations(
             Example("""

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -77,6 +77,26 @@ extension ConfigurationTests {
         XCTAssertTrue(mergedConfiguration2.contains(rule: ForceTryRule.self))
     }
 
+    func testOnlyRuleMerging() {
+        let ruleIdentifier = TodoRule.description.identifier
+        let onlyRuleConfiguration = Configuration.onlyRuleConfiguration(ruleIdentifier)
+
+        let emptyDefaultConfiguration = Configuration.emptyDefaultConfiguration()
+        let mergedConfiguration1 = onlyRuleConfiguration.merged(withChild: emptyDefaultConfiguration)
+        XCTAssertEqual(mergedConfiguration1.rules.count, 1)
+        XCTAssertTrue(mergedConfiguration1.rules[0] is TodoRule)
+
+        let disabledDefaultConfiguration = Configuration.disabledDefaultConfiguration(ruleIdentifier)
+        let mergedConfiguration2 = onlyRuleConfiguration.merged(withChild: disabledDefaultConfiguration)
+        XCTAssertEqual(mergedConfiguration2.rules.count, 1)
+        XCTAssertTrue(mergedConfiguration2.rules[0] is TodoRule)
+
+        let enabledOnlyConfiguration = Configuration.enabledOnlyConfiguration(ForceTryRule.description.identifier)
+        let mergedConfiguration3 = onlyRuleConfiguration.merged(withChild: enabledOnlyConfiguration)
+        XCTAssertEqual(mergedConfiguration3.rules.count, 1)
+        XCTAssertTrue(mergedConfiguration3.rules[0] is TodoRule)
+    }
+
     func testCustomRulesMerging() {
         let mergedConfiguration = Mock.Config._0CustomRules.merged(
             withChild: Mock.Config._2CustomRules,
@@ -653,4 +673,5 @@ private extension Configuration {
         Configuration(rulesMode: .only([ruleIdentifier]))
     }
     static func allEnabledConfiguration() -> Self { Configuration(rulesMode: .allEnabled)}
+    static func onlyRuleConfiguration(_ ruleIdentifier: String) -> Self { Configuration(rulesMode: .onlyRule([ruleIdentifier])) }
 }

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -52,7 +52,7 @@ extension ConfigurationTests {
 
     func testOnlyRulesMerging() {
         let baseConfiguration = Configuration(
-            rulesMode: .default(
+            rulesMode: .defaultConfiguration(
                 disabled: [],
                 optIn: [
                     ForceTryRule.description.identifier,
@@ -60,7 +60,7 @@ extension ConfigurationTests {
                 ]
             )
         )
-        let onlyConfiguration = Configuration(rulesMode: .only([TodoRule.description.identifier]))
+        let onlyConfiguration = Configuration(rulesMode: .onlyConfiguration([TodoRule.identifier]))
         XCTAssertTrue(baseConfiguration.contains(rule: TodoRule.self))
         XCTAssertEqual(onlyConfiguration.rules.count, 1)
         XCTAssertTrue(onlyConfiguration.rules[0] is TodoRule)
@@ -364,11 +364,11 @@ extension ConfigurationTests {
         XCTAssertTrue((ruleType as Any) is any OptInRule.Type)
         let ruleIdentifier = ruleType.description.identifier
         for testCase in testCases {
-            let parentConfiguration = Configuration(rulesMode: .default(
+            let parentConfiguration = Configuration(rulesMode: .defaultConfiguration(
                 disabled: testCase.disabledInParent ? [ruleIdentifier] : [],
                 optIn: testCase.optedInInParent ? [ruleIdentifier] : []
             ))
-            let childConfiguration = Configuration(rulesMode: .default(
+            let childConfiguration = Configuration(rulesMode: .defaultConfiguration(
                 disabled: testCase.disabledInChild ? [ruleIdentifier] : [],
                 optIn: testCase.optedInInChild ? [ruleIdentifier] : []
             ))
@@ -399,10 +399,10 @@ extension ConfigurationTests {
         let ruleIdentifier = ruleType.description.identifier
         for testCase in testCases {
             let parentConfiguration = Configuration(
-                rulesMode: .default(disabled: testCase.disabledInParent ? [ruleIdentifier] : [], optIn: [])
+                rulesMode: .defaultConfiguration(disabled: testCase.disabledInParent ? [ruleIdentifier] : [], optIn: [])
             )
             let childConfiguration = Configuration(
-                rulesMode: .default(disabled: testCase.disabledInChild ? [ruleIdentifier] : [], optIn: [])
+                rulesMode: .defaultConfiguration(disabled: testCase.disabledInChild ? [ruleIdentifier] : [], optIn: [])
             )
             let mergedConfiguration = parentConfiguration.merged(withChild: childConfiguration)
             let isEnabled = mergedConfiguration.contains(rule: ruleType)
@@ -429,9 +429,9 @@ extension ConfigurationTests {
         let ruleType = ImplicitReturnRule.self
         XCTAssertTrue((ruleType as Any) is any OptInRule.Type)
         let ruleIdentifier = ruleType.description.identifier
-        let parentConfiguration = Configuration(rulesMode: .only([ruleIdentifier]))
+        let parentConfiguration = Configuration(rulesMode: .onlyConfiguration([ruleIdentifier]))
         for testCase in testCases {
-            let childConfiguration = Configuration(rulesMode: .default(
+            let childConfiguration = Configuration(rulesMode: .defaultConfiguration(
                 disabled: testCase.disabledInChild ? [ruleIdentifier] : [],
                 optIn: testCase.optedInInChild ? [ruleIdentifier] : []
             ))
@@ -467,10 +467,10 @@ extension ConfigurationTests {
         ]
 
         let configurations = [
-            Configuration(rulesMode: .default(disabled: [], optIn: [])),
-            Configuration(rulesMode: .default(disabled: [], optIn: [ruleIdentifier])),
-            Configuration(rulesMode: .default(disabled: [ruleIdentifier], optIn: [ruleIdentifier])),
-            Configuration(rulesMode: .default(disabled: [ruleIdentifier], optIn: [])),
+            Configuration(rulesMode: .defaultConfiguration(disabled: [], optIn: [])),
+            Configuration(rulesMode: .defaultConfiguration(disabled: [], optIn: [ruleIdentifier])),
+            Configuration(rulesMode: .defaultConfiguration(disabled: [ruleIdentifier], optIn: [ruleIdentifier])),
+            Configuration(rulesMode: .defaultConfiguration(disabled: [ruleIdentifier], optIn: [])),
         ]
 
         for parentConfiguration in parentConfigurations {
@@ -485,7 +485,7 @@ extension ConfigurationTests {
         configuration: Configuration,
         ruleType: any Rule.Type
     ) {
-        guard case .default(let disabledRules, let optInRules) = configuration.rulesMode else {
+        guard case .defaultConfiguration(let disabledRules, let optInRules) = configuration.rulesMode else {
             XCTFail("Configuration rulesMode was not the default")
             return
         }
@@ -656,23 +656,23 @@ extension ConfigurationTests {
 
 private extension Configuration {
     static func emptyDefaultConfiguration() -> Self {
-        Configuration(rulesMode: .default(disabled: [], optIn: []))
+        Configuration(rulesMode: .defaultConfiguration(disabled: [], optIn: []))
     }
     static func optInDefaultConfiguration(_ ruleIdentifier: String) -> Self {
-        Configuration(rulesMode: .default(disabled: [], optIn: [ruleIdentifier]))
+        Configuration(rulesMode: .defaultConfiguration(disabled: [], optIn: [ruleIdentifier]))
     }
     static func optInDisabledDefaultConfiguration(_ ruleIdentifier: String) -> Self {
-        Configuration(rulesMode: .default(disabled: [ruleIdentifier], optIn: [ruleIdentifier]))
+        Configuration(rulesMode: .defaultConfiguration(disabled: [ruleIdentifier], optIn: [ruleIdentifier]))
     }
     static func disabledDefaultConfiguration(_ ruleIdentifier: String) -> Self {
-        Configuration(rulesMode: .default(disabled: [ruleIdentifier], optIn: []))
+        Configuration(rulesMode: .defaultConfiguration(disabled: [ruleIdentifier], optIn: []))
     }
-    static func emptyOnlyConfiguration() -> Self { Configuration(rulesMode: .only([])) }
+    static func emptyOnlyConfiguration() -> Self { Configuration(rulesMode: .onlyConfiguration([])) }
     static func enabledOnlyConfiguration(_ ruleIdentifier: String) -> Self {
-        Configuration(rulesMode: .only([ruleIdentifier]))
+        Configuration(rulesMode: .onlyConfiguration([ruleIdentifier]))
     }
-    static func allEnabledConfiguration() -> Self { Configuration(rulesMode: .allEnabled)}
+    static func allEnabledConfiguration() -> Self { Configuration(rulesMode: .allCommandLine)}
     static func onlyRuleConfiguration(_ ruleIdentifier: String) -> Self {
-        Configuration(rulesMode: .onlyRule([ruleIdentifier]))
+        Configuration(rulesMode: .onlyCommandLine([ruleIdentifier]))
     }
 }

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -88,8 +88,7 @@ extension ConfigurationTests {
 
         let disabledDefaultConfiguration = Configuration.disabledDefaultConfiguration(ruleIdentifier)
         let mergedConfiguration2 = onlyRuleConfiguration.merged(withChild: disabledDefaultConfiguration)
-        XCTAssertEqual(mergedConfiguration2.rules.count, 1)
-        XCTAssertTrue(mergedConfiguration2.rules[0] is TodoRule)
+        XCTAssertTrue(mergedConfiguration2.rules.isEmpty)
 
         let enabledOnlyConfiguration = Configuration.enabledOnlyConfiguration(ForceTryRule.description.identifier)
         let mergedConfiguration3 = onlyRuleConfiguration.merged(withChild: enabledOnlyConfiguration)

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -673,5 +673,7 @@ private extension Configuration {
         Configuration(rulesMode: .only([ruleIdentifier]))
     }
     static func allEnabledConfiguration() -> Self { Configuration(rulesMode: .allEnabled)}
-    static func onlyRuleConfiguration(_ ruleIdentifier: String) -> Self { Configuration(rulesMode: .onlyRule([ruleIdentifier])) }
+    static func onlyRuleConfiguration(_ ruleIdentifier: String) -> Self {
+        Configuration(rulesMode: .onlyRule([ruleIdentifier]))
+    }
 }

--- a/Tests/SwiftLintFrameworkTests/SourceKitCrashTests.swift
+++ b/Tests/SwiftLintFrameworkTests/SourceKitCrashTests.swift
@@ -52,7 +52,7 @@ final class SourceKitCrashTests: SwiftLintTestCase {
         file.assertHandler = {
             XCTFail("If this called, rule's SourceKitFreeRule is not properly configured")
         }
-        let configuration = Configuration(rulesMode: .only(allRuleIdentifiers))
+        let configuration = Configuration(rulesMode: .onlyConfiguration(allRuleIdentifiers))
         let storage = RuleStorage()
         _ = Linter(file: file, configuration: configuration).collect(into: storage).styleViolations(using: storage)
         file.sourcekitdFailed = false

--- a/Tests/SwiftLintTestHelpers/TestHelpers.swift
+++ b/Tests/SwiftLintTestHelpers/TestHelpers.swift
@@ -52,7 +52,7 @@ public let allRuleIdentifiers = Set(RuleRegistry.shared.list.list.keys)
 public extension Configuration {
     func applyingConfiguration(from example: Example) -> Configuration {
         guard let exampleConfiguration = example.configuration,
-           case let .only(onlyRules) = self.rulesMode,
+           case let .onlyConfiguration(onlyRules) = self.rulesMode,
            let firstRule = (onlyRules.first { $0 != "superfluous_disable_command" }),
            case let configDict: [_: any Sendable] = ["only_rules": onlyRules, firstRule: exampleConfiguration],
            let typedConfiguration = try? Configuration(dict: configDict) else { return self }
@@ -281,12 +281,12 @@ public func makeConfig(_ ruleConfiguration: Any?,
         return (try? ruleType.init(configuration: ruleConfiguration)).flatMap { configuredRule in
             let rules = skipDisableCommandTests ? [configuredRule] : [configuredRule, SuperfluousDisableCommandRule()]
             return Configuration(
-                rulesMode: .only(identifiers),
+                rulesMode: .onlyConfiguration(identifiers),
                 allRulesWrapped: rules.map { ($0, false) }
             )
         }
     }
-    return Configuration(rulesMode: .only(identifiers))
+    return Configuration(rulesMode: .onlyConfiguration(identifiers))
 }
 
 private func testCorrection(_ correction: (Example, Example),
@@ -299,7 +299,7 @@ private func testCorrection(_ correction: (Example, Example),
 #endif
     var config = configuration
     if let correctionConfiguration = correction.0.configuration,
-        case let .only(onlyRules) = configuration.rulesMode,
+        case let .onlyConfiguration(onlyRules) = configuration.rulesMode,
         let ruleToConfigure = (onlyRules.first { $0 != SuperfluousDisableCommandRule.description.identifier }),
         case let configDict: [_: any Sendable] = ["only_rules": onlyRules, ruleToConfigure: correctionConfiguration],
         let typedConfiguration = try? Configuration(dict: configDict) {


### PR DESCRIPTION
Addresses #5711, where if there was no default configuration file, `--only-rule` would be ignored.

Replaces #5725

Previously, `--only-rule some_rule` was implemented as though the configuration was:

```
only_rules:
    - some_rule
```

This did not interact well when the top level configuration was absent, or with child configurations.

This PR adds a new `RulesMode` enum -  to represent `--only-rule`: `onlyCommandLine`, and the other enums have been renamed to make it clearer whether they are derived from the configuration file or the command line.

This allows interactions with child configurations to be applied correctly. 

Like `.allCommandLine` (previously `allEnabled`), rules enabled with `--only-rule` can still be disabled in a child configuration, so if there are specific directories that the rule should not run on, that is supported. This may be useful when using `--fix` with `--only-rule`

Additionally, `--only-rule` can now be specified more than once, to enable multiple rules

