### PR TITLE
Add max number if params allowed for `multiline_parameters`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,14 @@
   [SimplyDanny](https://github.com/SimplyDanny)
   [#5774](https://github.com/realm/SwiftLint/issues/5774)
 
+* Add new option `max_number_of_single_line_parameters` that allows only the specified maximum
+  number of parameters to be on one line when `allows_single_line = true`. If the limit is
+  exceeded, the rule will still trigger. Confusing option combinations like `allows_single_line = false`
+  together with `max_number_of_single_line_parameters > 1` will be reported.  
+  [kimdv](https://github.com/kimdv)
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#5781](https://github.com/realm/SwiftLint/issues/5781)
+
 * The `redundant_type_annotation` rule gains a new option,
   `ignore_properties`, that skips enforcement on members in a
   type declaration (like a `struct`). This helps the rule coexist with

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MultilineParametersConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MultilineParametersConfiguration.swift
@@ -16,20 +16,21 @@ struct MultilineParametersConfiguration: SeverityBasedRuleConfiguration {
             return
         }
         guard maxNumberOfSingleLineParameters >= 1 else {
-            throw Issue.invalidConfiguration(
+            Issue.inconsistentConfiguration(
                 ruleID: Parent.identifier,
                 message: "Option '\($maxNumberOfSingleLineParameters.key)' should be >= 1."
-            )
+            ).print()
+            return
         }
 
         if maxNumberOfSingleLineParameters > 1, !allowsSingleLine {
-            throw Issue.invalidConfiguration(
+            Issue.inconsistentConfiguration(
                 ruleID: Parent.identifier,
                 message: """
                          Option '\($maxNumberOfSingleLineParameters.key)' has no effect when \
                          '\($allowsSingleLine.key)' is false.
                          """
-            )
+            ).print()
         }
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MultilineParametersConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MultilineParametersConfiguration.swift
@@ -8,4 +8,28 @@ struct MultilineParametersConfiguration: SeverityBasedRuleConfiguration {
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "allows_single_line")
     private(set) var allowsSingleLine = true
+    @ConfigurationElement(key: "max_number_of_single_line_parameters")
+    private(set) var maxNumberOfSingleLineParameters: Int?
+
+    func validate() throws {
+        guard let maxNumberOfSingleLineParameters else {
+            return
+        }
+        guard maxNumberOfSingleLineParameters >= 1 else {
+            throw Issue.invalidConfiguration(
+                ruleID: Parent.identifier,
+                message: "Option '\($maxNumberOfSingleLineParameters.key)' should be >= 1."
+            )
+        }
+
+        if maxNumberOfSingleLineParameters > 1, !allowsSingleLine {
+            throw Issue.invalidConfiguration(
+                ruleID: Parent.identifier,
+                message: """
+                         Option '\($maxNumberOfSingleLineParameters.key)' has no effect when \
+                         '\($allowsSingleLine.key)' is false.
+                         """
+            )
+        }
+    }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/MultilineParametersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/MultilineParametersRule.swift
@@ -43,6 +43,12 @@ private extension MultilineParametersRule {
                 numberOfParameters += 1
             }
 
+            if let maxNumberOfSingleLineParameters = configuration.maxNumberOfSingleLineParameters,
+               configuration.allowsSingleLine,
+               numberOfParameters > maxNumberOfSingleLineParameters {
+                return true
+            }
+
             guard linesWithParameters.count > (configuration.allowsSingleLine ? 1 : 0),
                   numberOfParameters != linesWithParameters.count else {
                 return false

--- a/Source/SwiftLintBuiltInRules/Rules/Style/MultilineParametersRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/MultilineParametersRuleExamples.swift
@@ -197,6 +197,13 @@ internal struct MultilineParametersRuleExamples {
             ) { }
         }
         """, configuration: ["allows_single_line": false]),
+        Example("func foo(param1: Int, param2: Bool, param3: [String]) { }",
+                configuration: ["max_number_of_single_line_parameters": 3]),
+        Example("""
+        func foo(param1: Int,
+                 param2: Bool,
+                 param3: [String]) { }
+        """, configuration: ["max_number_of_single_line_parameters": 3]),
     ]
 
     static let triggeringExamples: [Example] = [
@@ -336,5 +343,12 @@ internal struct MultilineParametersRuleExamples {
                 configuration: ["allows_single_line": false]),
         Example("func ↓foo(param1: Int, param2: Bool, param3: [String]) { }",
                 configuration: ["allows_single_line": false]),
+        Example("func ↓foo(param1: Int, param2: Bool, param3: [String]) { }",
+                configuration: ["max_number_of_single_line_parameters": 2]),
+        Example("""
+        func ↓foo(param1: Int,
+                  param2: Bool, param3: [String]) { }
+        """,
+                configuration: ["max_number_of_single_line_parameters": 3]),
     ]
 }

--- a/Tests/SwiftLintFrameworkTests/MultilineParametersConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/MultilineParametersConfigurationTests.swift
@@ -8,8 +8,15 @@ final class MultilineParametersConfigurationTests: SwiftLintTestCase {
             var config = MultilineParametersConfiguration()
 
             XCTAssertEqual(
-                try Issue.captureConsole { try config.apply(configuration: ["max_number_of_single_line_parameters": maxNumberOfSingleLineParameters]) },
-                "Option \'max_number_of_single_line_parameters\' should be >= 1."
+                try Issue.captureConsole {
+                    try config.apply(
+                        configuration: ["max_number_of_single_line_parameters": maxNumberOfSingleLineParameters]
+                    )
+                },
+                """
+                warning: Inconsistent configuration for 'multiline_parameters' rule: Option \
+                'max_number_of_single_line_parameters' should be >= 1.
+                """
             )
         }
     }
@@ -18,8 +25,15 @@ final class MultilineParametersConfigurationTests: SwiftLintTestCase {
         var config = MultilineParametersConfiguration()
 
         XCTAssertEqual(
-            try Issue.captureConsole { try config.apply(configuration: ["max_number_of_single_line_parameters": 2, "allows_single_line": false]) },
-            "Option \'max_number_of_single_line_parameters\' has no effect when \'allows_single_line\' is false."
+            try Issue.captureConsole {
+                try config.apply(
+                    configuration: ["max_number_of_single_line_parameters": 2, "allows_single_line": false]
+                )
+            },
+            """
+            warning: Inconsistent configuration for 'multiline_parameters' rule: Option \
+            'max_number_of_single_line_parameters' has no effect when 'allows_single_line' is false.
+            """
         )
     }
 }

--- a/Tests/SwiftLintFrameworkTests/MultilineParametersConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/MultilineParametersConfigurationTests.swift
@@ -1,0 +1,25 @@
+@testable import SwiftLintBuiltInRules
+@testable import SwiftLintCore
+import XCTest
+
+final class MultilineParametersConfigurationTests: SwiftLintTestCase {
+    func testInvalidMaxNumberOfSingleLineParameters() throws {
+        for maxNumberOfSingleLineParameters in [0, -1] {
+            var config = MultilineParametersConfiguration()
+
+            XCTAssertEqual(
+                try Issue.captureConsole { try config.apply(configuration: ["max_number_of_single_line_parameters": maxNumberOfSingleLineParameters]) },
+                "Option \'max_number_of_single_line_parameters\' should be >= 1."
+            )
+        }
+    }
+
+    func testInvalidMaxNumberOfSingleLineParametersWithSingleLineEnabled() throws {
+        var config = MultilineParametersConfiguration()
+
+        XCTAssertEqual(
+            try Issue.captureConsole { try config.apply(configuration: ["max_number_of_single_line_parameters": 2, "allows_single_line": false]) },
+            "Option \'max_number_of_single_line_parameters\' has no effect when \'allows_single_line\' is false."
+        )
+    }
+}


### PR DESCRIPTION
This PR will configuration option for `multiline_parameters` so it's allowed to have like two params on the same line.