### PR TITLE
add support file Xcode input file lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@
   [Jordan Rose](https://github.com/jrose-signal)
   [SimplyDanny](https://github.com/SimplyDanny)
 
+* Support reading files to lint from Input File Lists provided
+  by Run Script Build Phases in Xcode using the command-line
+  argument `--use-script-input-file-lists`.  
+  [BlueVirusX](https://github.com/BlueVirusX)
+
 #### Bug Fixes
 
 * Run command plugin in whole package if no targets are defined in the

--- a/README.md
+++ b/README.md
@@ -514,6 +514,11 @@ can do so by passing the option `--use-script-input-files` and setting the
 following instance variables: `SCRIPT_INPUT_FILE_COUNT`
 and `SCRIPT_INPUT_FILE_0`, `SCRIPT_INPUT_FILE_1`, ...,
 `SCRIPT_INPUT_FILE_{SCRIPT_INPUT_FILE_COUNT - 1}`.
+Similarly, files can be read from file lists by passing
+the option `--use-script-input-file-lists` and setting the
+following instance variables: `SCRIPT_INPUT_FILE_LIST_COUNT`
+and `SCRIPT_INPUT_FILE_LIST_0`, `SCRIPT_INPUT_FILE_LIST_1`, ...,
+`SCRIPT_INPUT_FILE_LIST_{SCRIPT_INPUT_FILE_LIST_COUNT - 1}`.
 
 These are same environment variables set for input files to
 [custom Xcode script phases](http://indiestack.com/2014/12/speeding-up-custom-script-phases/).

--- a/Source/SwiftLintFramework/LintOrAnalyzeCommand.swift
+++ b/Source/SwiftLintFramework/LintOrAnalyzeCommand.swift
@@ -38,6 +38,7 @@ package struct LintOrAnalyzeOptions {
     let forceExclude: Bool
     let useExcludingByPrefix: Bool
     let useScriptInputFiles: Bool
+    let useScriptInputFileLists: Bool
     let benchmark: Bool
     let reporter: String?
     let baseline: String?
@@ -65,6 +66,7 @@ package struct LintOrAnalyzeOptions {
                  forceExclude: Bool,
                  useExcludingByPrefix: Bool,
                  useScriptInputFiles: Bool,
+                 useScriptInputFileLists: Bool,
                  benchmark: Bool,
                  reporter: String?,
                  baseline: String?,
@@ -91,6 +93,7 @@ package struct LintOrAnalyzeOptions {
         self.forceExclude = forceExclude
         self.useExcludingByPrefix = useExcludingByPrefix
         self.useScriptInputFiles = useScriptInputFiles
+        self.useScriptInputFileLists = useScriptInputFileLists
         self.benchmark = benchmark
         self.reporter = reporter
         self.baseline = baseline

--- a/Source/swiftlint/Commands/Analyze.swift
+++ b/Source/swiftlint/Commands/Analyze.swift
@@ -31,6 +31,7 @@ extension SwiftLint {
                 forceExclude: common.forceExclude,
                 useExcludingByPrefix: common.useAlternativeExcluding,
                 useScriptInputFiles: common.useScriptInputFiles,
+                useScriptInputFileLists: common.useScriptInputFileLists,
                 benchmark: common.benchmark,
                 reporter: common.reporter,
                 baseline: common.baseline,

--- a/Source/swiftlint/Commands/Lint.swift
+++ b/Source/swiftlint/Commands/Lint.swift
@@ -43,6 +43,7 @@ extension SwiftLint {
                 forceExclude: common.forceExclude,
                 useExcludingByPrefix: common.useAlternativeExcluding,
                 useScriptInputFiles: common.useScriptInputFiles,
+                useScriptInputFileLists: common.useScriptInputFileLists,
                 benchmark: common.benchmark,
                 reporter: common.reporter,
                 baseline: common.baseline,

--- a/Source/swiftlint/Common/LintOrAnalyzeArguments.swift
+++ b/Source/swiftlint/Common/LintOrAnalyzeArguments.swift
@@ -31,6 +31,8 @@ struct LintOrAnalyzeArguments: ParsableArguments {
     var useAlternativeExcluding = false
     @Flag(help: "Read SCRIPT_INPUT_FILE* environment variables as files.")
     var useScriptInputFiles = false
+    @Flag(help: "Read SCRIPT_INPUT_FILE_LIST* environment variables as file lists.")
+    var useScriptInputFileLists = false
     @Flag(exclusivity: .exclusive)
     var leniency: LeniencyOptions?
     @Flag(help: "Exclude files in config `excluded` even if their paths are explicitly specified.")


### PR DESCRIPTION
Fixes https://github.com/realm/SwiftLint/issues/5195

adds option "--use-script-input-file-lists"
adds parsing of .xcfilelist files