### PR TITLE
Fix nested disable commands

### DIFF
--- a/Source/SwiftLintCore/Extensions/SwiftLintFile+Regex.swift
+++ b/Source/SwiftLintCore/Extensions/SwiftLintFile+Regex.swift
@@ -58,44 +58,38 @@ extension SwiftLintFile {
     }
 
     public func remap(regions: [Region]) -> [Region] {
-        var remappedRegions = [Region]()
-        var startMap: [RuleIdentifier: Location] = [:]
-        var lastRegionEnd: Location?
-
         guard regions.isNotEmpty else {
             return []
         }
 
+        var remappedRegions = [Region]()
+        var startMap: [RuleIdentifier: Location] = [:]
+        var lastRegionEnd: Location?
+
         for region in regions {
-            let disabledRuleIdentifiers = startMap.keys
-            for ruleIdentifier in region.disabledRuleIdentifiers where startMap[ruleIdentifier] == nil {
-                startMap[ruleIdentifier] = region.start
-            }
-            // We've started all of our new regions - can we finish any?
-            // swiftlint:disable:next line_length
-            for ruleIdentifier in disabledRuleIdentifiers.sorted() where !region.disabledRuleIdentifiers.contains(ruleIdentifier) {
+            let ruleIdentifiers = startMap.keys.sorted()
+            for ruleIdentifier in ruleIdentifiers where !region.disabledRuleIdentifiers.contains(ruleIdentifier) {
                 if let lastRegionEnd, let start = startMap[ruleIdentifier] {
                     let newRegion = Region(start: start, end: lastRegionEnd, disabledRuleIdentifiers: [ruleIdentifier])
                     remappedRegions.append(newRegion)
                     startMap[ruleIdentifier] = nil
-                } else {
-                    print(">>>> this should not happen")
                 }
             }
-            lastRegionEnd = region.end
+            for ruleIdentifier in region.disabledRuleIdentifiers where startMap[ruleIdentifier] == nil {
+                startMap[ruleIdentifier] = region.start
+            }
             if region.disabledRuleIdentifiers.isEmpty {
                 remappedRegions.append(region)
             }
+            lastRegionEnd = region.end
         }
-        // We're at the end now, so we need to finish up any still disabled rules
+
         let end = Location(file: path, line: .max, character: .max)
         for ruleIdentifier in startMap.keys.sorted() {
             if let start = startMap[ruleIdentifier] {
                 let newRegion = Region(start: start, end: end, disabledRuleIdentifiers: [ruleIdentifier])
                 remappedRegions.append(newRegion)
                 startMap[ruleIdentifier] = nil
-            } else {
-                print(">>>> this also should not happen")
             }
         }
 

--- a/Source/SwiftLintCore/Extensions/SwiftLintFile+Regex.swift
+++ b/Source/SwiftLintCore/Extensions/SwiftLintFile+Regex.swift
@@ -73,7 +73,7 @@ extension SwiftLintFile {
             }
             // We've started all of our new regions - can we finish any?
             // swiftlint:disable:next line_length
-            for ruleIdentifier in disabledRuleIdentifiers where !region.disabledRuleIdentifiers.contains(ruleIdentifier) {
+            for ruleIdentifier in disabledRuleIdentifiers.sorted() where !region.disabledRuleIdentifiers.contains(ruleIdentifier) {
                 if let lastRegionEnd, let start = startMap[ruleIdentifier] {
                     let newRegion = Region(start: start, end: lastRegionEnd, disabledRuleIdentifiers: [ruleIdentifier])
                     remappedRegions.append(newRegion)
@@ -89,7 +89,7 @@ extension SwiftLintFile {
         }
         // We're at the end now, so we need to finish up any still disabled rules
         let end = Location(file: path, line: .max, character: .max)
-        for ruleIdentifier in startMap.keys {
+        for ruleIdentifier in startMap.keys.sorted() {
             if let start = startMap[ruleIdentifier] {
                 let newRegion = Region(start: start, end: end, disabledRuleIdentifiers: [ruleIdentifier])
                 remappedRegions.append(newRegion)

--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -19,13 +19,10 @@ private extension Rule {
     func superfluousDisableCommandViolations(regions: [Region],
                                              superfluousDisableCommandRule: SuperfluousDisableCommandRule?,
                                              allViolations: [StyleViolation]) -> [StyleViolation] {
-        guard let superfluousDisableCommandRule else {
+        guard regions.isNotEmpty, let superfluousDisableCommandRule else {
             return []
         }
-        guard regions.isNotEmpty else {
-            return []
-        }
-
+        
         let regionsDisablingSuperfluousDisableRule = regions.filter { region in
             region.isRuleDisabled(superfluousDisableCommandRule)
         }

--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -22,8 +22,7 @@ private extension Rule {
         guard let superfluousDisableCommandRule else {
             return []
         }
-        guard regions.isNotEmpty, allViolations.isNotEmpty
-        else {
+        guard regions.isNotEmpty else {
             return []
         }
 

--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -19,7 +19,11 @@ private extension Rule {
     func superfluousDisableCommandViolations(regions: [Region],
                                              superfluousDisableCommandRule: SuperfluousDisableCommandRule?,
                                              allViolations: [StyleViolation]) -> [StyleViolation] {
-        guard regions.isNotEmpty, let superfluousDisableCommandRule else {
+        guard let superfluousDisableCommandRule else {
+            return []
+        }
+        guard regions.isNotEmpty, allViolations.isNotEmpty
+        else {
             return []
         }
 
@@ -121,8 +125,9 @@ private extension Rule {
             [RuleIdentifier.all.stringRepresentation]
         let ruleIdentifiers = Set(ruleIDs.map { RuleIdentifier($0) })
 
+        let regions = regions.count > 1 ? file.regions(restrictingRuleIdentifiers: ruleIdentifiers) : regions
         let superfluousDisableCommandViolations = superfluousDisableCommandViolations(
-            regions: regions.count > 1 ? file.regions(restrictingRuleIdentifiers: ruleIdentifiers) : regions,
+            regions: file.remap(regions: regions),
             superfluousDisableCommandRule: superfluousDisableCommandRule,
             allViolations: violations
         )

--- a/Source/SwiftLintCore/Models/RuleIdentifier.swift
+++ b/Source/SwiftLintCore/Models/RuleIdentifier.swift
@@ -1,5 +1,5 @@
 /// An identifier representing a SwiftLint rule, or all rules.
-public enum RuleIdentifier: Hashable, ExpressibleByStringLiteral {
+public enum RuleIdentifier: Hashable, ExpressibleByStringLiteral, Comparable {
     // MARK: - Values
 
     /// Special identifier that should be treated as referring to 'all' SwiftLint rules. One helpful usecase is in
@@ -38,5 +38,11 @@ public enum RuleIdentifier: Hashable, ExpressibleByStringLiteral {
 
     public init(stringLiteral value: String) {
         self = Self(value)
+    }
+
+    // MARK: - Comparable Conformance
+
+    public static func < (lhs: Self, rhs: Self) -> Bool {
+        lhs.stringRepresentation < rhs.stringRepresentation
     }
 }

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -427,7 +427,7 @@ final class CustomRulesTests: SwiftLintTestCase {
         XCTAssertTrue(try violations(forExample: example, customRules: customRules).isEmpty)
     }
 
-    func testNestedCustomRuleDoNotTriggerSuperfluousDisableCommand() throws {
+    func testNestedCustomRuleDisablesDoNotTriggerSuperfluousDisableCommand() throws {
         let customRules: [String: Any] = [
             "rule1": [
                 "regex": "pattern1"
@@ -445,6 +445,34 @@ final class CustomRulesTests: SwiftLintTestCase {
                                // swiftlint:enable rule1
                                """)
         XCTAssertTrue(try violations(forExample: example, customRules: customRules).isEmpty)
+    }
+
+    func testNestedAndOverlappingCustomRuleDisables() throws {
+        let customRules: [String: Any] = [
+            "rule1": [
+                "regex": "pattern1"
+            ],
+            "rule2": [
+                "regex": "pattern2"
+            ],
+            "rule3": [
+                "regex": "pattern3"
+            ],
+        ]
+        let example = Example("""
+                              // swiftlint:disable rule1
+                              // swiftlint:disable rule2
+                              // swiftlint:disable rule3
+                              let pattern2 = ""
+                              // swiftlint:enable rule2
+                              // swiftlint:enable rule3
+                              let pattern1 = ""
+                              // swiftlint:enable rule1
+                              """)
+        let violations = try violations(forExample: example, customRules: customRules)
+
+        XCTAssertEqual(violations.count, 1)
+        XCTAssertTrue(violations[0].isSuperfluousDisableCommandViolation(for: "rule3"))
     }
 
     // MARK: - Private

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -427,6 +427,26 @@ final class CustomRulesTests: SwiftLintTestCase {
         XCTAssertTrue(try violations(forExample: example, customRules: customRules).isEmpty)
     }
 
+    func testNestedCustomRuleDoNotTriggerSuperfluousDisableCommand() throws {
+        let customRules: [String: Any] = [
+            "rule1": [
+                "regex": "pattern1"
+            ],
+            "rule2": [
+                "regex": "pattern2"
+            ],
+        ]
+        let example = Example("""
+                               // swiftlint:disable rule1
+                               // swiftlint:disable rule2
+                               let pattern2 = ""
+                               // swiftlint:enable rule2
+                               let pattern1 = ""
+                               // swiftlint:enable rule1
+                               """)
+        XCTAssertTrue(try violations(forExample: example, customRules: customRules).isEmpty)
+    }
+
     // MARK: - Private
 
     private func getCustomRules(_ extraConfig: [String: Any] = [:]) -> (Configuration, CustomRules) {

--- a/Tests/SwiftLintFrameworkTests/RegionTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RegionTests.swift
@@ -20,14 +20,18 @@ final class RegionTests: SwiftLintTestCase {
             let file = SwiftLintFile(contents: "// swiftlint:disable rule_id\n")
             let start = Location(file: nil, line: 1, character: 29)
             let end = Location(file: nil, line: .max, character: .max)
-            XCTAssertEqual(file.regions(), [Region(start: start, end: end, disabledRuleIdentifiers: ["rule_id"])])
+            let fileRegions = file.regions()
+            XCTAssertEqual(fileRegions, [Region(start: start, end: end, disabledRuleIdentifiers: ["rule_id"])])
+            XCTAssertEqual(file.remap(regions: fileRegions), fileRegions)
         }
         // enable
         do {
             let file = SwiftLintFile(contents: "// swiftlint:enable rule_id\n")
             let start = Location(file: nil, line: 1, character: 28)
             let end = Location(file: nil, line: .max, character: .max)
-            XCTAssertEqual(file.regions(), [Region(start: start, end: end, disabledRuleIdentifiers: [])])
+            let fileRegions = file.regions()
+            XCTAssertEqual(fileRegions, [Region(start: start, end: end, disabledRuleIdentifiers: [])])
+            XCTAssertEqual(file.remap(regions: fileRegions), fileRegions)
         }
     }
 
@@ -35,7 +39,8 @@ final class RegionTests: SwiftLintTestCase {
         // disable/enable
         do {
             let file = SwiftLintFile(contents: "// swiftlint:disable rule_id\n// swiftlint:enable rule_id\n")
-            XCTAssertEqual(file.regions(), [
+            let fileRegions = file.regions()
+            XCTAssertEqual(fileRegions, [
                 Region(start: Location(file: nil, line: 1, character: 29),
                        end: Location(file: nil, line: 2, character: 27),
                        disabledRuleIdentifiers: ["rule_id"]),
@@ -43,11 +48,13 @@ final class RegionTests: SwiftLintTestCase {
                        end: Location(file: nil, line: .max, character: .max),
                        disabledRuleIdentifiers: []),
             ])
+            XCTAssertEqual(file.remap(regions: fileRegions), fileRegions)
         }
         // enable/disable
         do {
             let file = SwiftLintFile(contents: "// swiftlint:enable rule_id\n// swiftlint:disable rule_id\n")
-            XCTAssertEqual(file.regions(), [
+            let fileRegions = file.regions()
+            XCTAssertEqual(fileRegions, [
                 Region(start: Location(file: nil, line: 1, character: 28),
                        end: Location(file: nil, line: 2, character: 28),
                        disabledRuleIdentifiers: []),
@@ -55,6 +62,7 @@ final class RegionTests: SwiftLintTestCase {
                        end: Location(file: nil, line: .max, character: .max),
                        disabledRuleIdentifiers: ["rule_id"]),
             ])
+            XCTAssertEqual(file.remap(regions: fileRegions), fileRegions)
         }
     }
 
@@ -62,10 +70,25 @@ final class RegionTests: SwiftLintTestCase {
         let file = SwiftLintFile(contents: "// swiftlint:disable:next 1\n" +
                                   "// swiftlint:disable:this 2\n" +
                                   "// swiftlint:disable:previous 3\n")
-        XCTAssertEqual(file.regions(), [
+        let fileRegions = file.regions()
+        XCTAssertEqual(fileRegions, [
             Region(start: Location(file: nil, line: 2, character: nil),
                    end: Location(file: nil, line: 2, character: .max - 1),
                    disabledRuleIdentifiers: ["1", "2", "3"]),
+            Region(start: Location(file: nil, line: 2, character: .max),
+                   end: Location(file: nil, line: .max, character: .max),
+                   disabledRuleIdentifiers: []),
+        ])
+        XCTAssertEqual(file.remap(regions: fileRegions), [
+            Region(start: Location(file: nil, line: 2, character: nil),
+                   end: Location(file: nil, line: 2, character: .max - 1),
+                   disabledRuleIdentifiers: ["1"]),
+            Region(start: Location(file: nil, line: 2, character: nil),
+                   end: Location(file: nil, line: 2, character: .max - 1),
+                   disabledRuleIdentifiers: ["2"]),
+            Region(start: Location(file: nil, line: 2, character: nil),
+                   end: Location(file: nil, line: 2, character: .max - 1),
+                   disabledRuleIdentifiers: ["3"]),
             Region(start: Location(file: nil, line: 2, character: .max),
                    end: Location(file: nil, line: .max, character: .max),
                    disabledRuleIdentifiers: []),
@@ -79,7 +102,8 @@ final class RegionTests: SwiftLintTestCase {
                                   "// swiftlint:enable 1\n" +
                                   "// swiftlint:enable 2\n" +
                                   "// swiftlint:enable 3\n")
-        XCTAssertEqual(file.regions(), [
+        let fileRegions = file.regions()
+        XCTAssertEqual(fileRegions, [
             Region(start: Location(file: nil, line: 1, character: 23),
                    end: Location(file: nil, line: 2, character: 22),
                    disabledRuleIdentifiers: ["1"]),
@@ -93,6 +117,20 @@ final class RegionTests: SwiftLintTestCase {
                    end: Location(file: nil, line: 5, character: 21),
                    disabledRuleIdentifiers: ["2", "3"]),
             Region(start: Location(file: nil, line: 5, character: 22),
+                   end: Location(file: nil, line: 6, character: 21),
+                   disabledRuleIdentifiers: ["3"]),
+            Region(start: Location(file: nil, line: 6, character: 22),
+                   end: Location(file: nil, line: .max, character: .max),
+                   disabledRuleIdentifiers: []),
+        ])
+        XCTAssertEqual(file.remap(regions: fileRegions), [
+            Region(start: Location(file: nil, line: 1, character: 23),
+                   end: Location(file: nil, line: 4, character: 21),
+                   disabledRuleIdentifiers: ["1"]),
+            Region(start: Location(file: nil, line: 2, character: 23),
+                   end: Location(file: nil, line: 5, character: 21),
+                   disabledRuleIdentifiers: ["2"]),
+            Region(start: Location(file: nil, line: 3, character: 23),
                    end: Location(file: nil, line: 6, character: 21),
                    disabledRuleIdentifiers: ["3"]),
             Region(start: Location(file: nil, line: 6, character: 22),

--- a/Tests/SwiftLintFrameworkTests/RegionTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RegionTests.swift
@@ -138,4 +138,48 @@ final class RegionTests: SwiftLintTestCase {
                    disabledRuleIdentifiers: []),
         ])
     }
+
+    func testOverlappingAndNestedRegions() {
+        let file = SwiftLintFile(contents: "// swiftlint:disable 1\n" +
+                                  "// swiftlint:disable 2\n" +
+                                  "// swiftlint:disable 3\n" +
+                                  "// swiftlint:enable 2\n" +
+                                  "// swiftlint:enable 3\n" +
+                                  "// swiftlint:enable 1\n")
+        let fileRegions = file.regions()
+        XCTAssertEqual(fileRegions, [
+            Region(start: Location(file: nil, line: 1, character: 23),
+                   end: Location(file: nil, line: 2, character: 22),
+                   disabledRuleIdentifiers: ["1"]),
+            Region(start: Location(file: nil, line: 2, character: 23),
+                   end: Location(file: nil, line: 3, character: 22),
+                   disabledRuleIdentifiers: ["1", "2"]),
+            Region(start: Location(file: nil, line: 3, character: 23),
+                   end: Location(file: nil, line: 4, character: 21),
+                   disabledRuleIdentifiers: ["1", "2", "3"]),
+            Region(start: Location(file: nil, line: 4, character: 22),
+                   end: Location(file: nil, line: 5, character: 21),
+                   disabledRuleIdentifiers: ["1", "3"]),
+            Region(start: Location(file: nil, line: 5, character: 22),
+                   end: Location(file: nil, line: 6, character: 21),
+                   disabledRuleIdentifiers: ["1"]),
+            Region(start: Location(file: nil, line: 6, character: 22),
+                   end: Location(file: nil, line: .max, character: .max),
+                   disabledRuleIdentifiers: []),
+        ])
+        XCTAssertEqual(file.remap(regions: fileRegions), [
+            Region(start: Location(file: nil, line: 2, character: 23),
+                   end: Location(file: nil, line: 4, character: 21),
+                   disabledRuleIdentifiers: ["2"]),
+            Region(start: Location(file: nil, line: 3, character: 23),
+                   end: Location(file: nil, line: 5, character: 21),
+                   disabledRuleIdentifiers: ["3"]),
+            Region(start: Location(file: nil, line: 1, character: 23),
+                   end: Location(file: nil, line: 6, character: 21),
+                   disabledRuleIdentifiers: ["1"]),
+            Region(start: Location(file: nil, line: 6, character: 22),
+                   end: Location(file: nil, line: .max, character: .max),
+                   disabledRuleIdentifiers: []),
+        ])
+    }
 }


### PR DESCRIPTION

Addresses #5788

The problem is that Regions are created with all of the rule identifiers that are disabled in them, with a new region being created for each `swiftlint:` command, more or less.

So an inner region may have multiple rules disabled, when disabled commands are nested, but not all of those rules might be violated within that specific region.

I guess people don't actually nest commands much in practice, at least for custom rules, or this would have created more noise.

This was not as hard to fix as I was afraid it might have been.

The basic idea is to remap the regions before passing them to `superfluousDisableCommandViolations`, so that the new regions describe the specific region that an individual rule is disabled within.

We could just calculate the regions that way in the first place, but the regions are used in multiple places, and I didn't want to interfere with any of the other call-sites right now.

Needs more tests in CustomRulesTests for sure.

Probably doesn't need to be a public method, if we're only using it for `superfluousDisableCommandViolations` - I just started with it there, and wanted it exposed right now - the RegionTests changes can probably go as well, once CustomRulesTests have more coverage, but I just wanted to make sure I'd got it right in all the existing cases and some new ones.
