### PR TITLE
Added `lenient` command line option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   by Run Script Build Phases in Xcode using the command-line
   argument `--use-script-input-file-lists`.  
   [BlueVirusX](https://github.com/BlueVirusX)
+
 * Adds a `lenient` configuration file setting, equivalent to the `--lenient`
   command line option.  
   [Martin Redington](https://github.com/mildm8nnered)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
   by Run Script Build Phases in Xcode using the command-line
   argument `--use-script-input-file-lists`.  
   [BlueVirusX](https://github.com/BlueVirusX)
+* Adds a `lenient` configuration file setting, equivalent to the `--lenient`
+  command line option.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#5801](https://github.com/realm/SwiftLint/issues/5801)
 
 #### Bug Fixes
 

--- a/README.md
+++ b/README.md
@@ -723,6 +723,9 @@ allow_zero_lintable_files: false
 # If true, SwiftLint will treat all warnings as errors.
 strict: false
 
+# If true, SwiftLint will treat all errors as warnings.
+lenient: false
+
 # The path to a baseline file, which will be used to filter out detected violations.
 baseline: Baseline.json
 

--- a/Source/SwiftLintCore/Extensions/Configuration+Merging.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Merging.swift
@@ -26,6 +26,7 @@ extension Configuration {
             cachePath: cachePath,
             allowZeroLintableFiles: childConfiguration.allowZeroLintableFiles,
             strict: childConfiguration.strict,
+            lenient: childConfiguration.lenient,
             baseline: childConfiguration.baseline,
             writeBaseline: childConfiguration.writeBaseline,
             checkForUpdates: childConfiguration.checkForUpdates

--- a/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
@@ -15,6 +15,7 @@ extension Configuration {
         case analyzerRules = "analyzer_rules"
         case allowZeroLintableFiles = "allow_zero_lintable_files"
         case strict = "strict"
+        case lenient = "lenient"
         case baseline = "baseline"
         case writeBaseline = "write_baseline"
         case checkForUpdates = "check_for_updates"
@@ -103,6 +104,7 @@ extension Configuration {
             pinnedVersion: dict[Key.swiftlintVersion.rawValue].map { ($0 as? String) ?? String(describing: $0) },
             allowZeroLintableFiles: dict[Key.allowZeroLintableFiles.rawValue] as? Bool ?? false,
             strict: dict[Key.strict.rawValue] as? Bool ?? false,
+            lenient: dict[Key.lenient.rawValue] as? Bool ?? false,
             baseline: dict[Key.baseline.rawValue] as? String,
             writeBaseline: dict[Key.writeBaseline.rawValue] as? String,
             checkForUpdates: dict[Key.checkForUpdates.rawValue] as? Bool ?? false

--- a/Source/SwiftLintCore/Models/Configuration.swift
+++ b/Source/SwiftLintCore/Models/Configuration.swift
@@ -38,6 +38,9 @@ public struct Configuration {
     /// Treat warnings as errors.
     public let strict: Bool
 
+    /// Treat errors as warnings.
+    public let lenient: Bool
+
     /// The path to read a baseline from.
     public let baseline: String?
 
@@ -83,6 +86,7 @@ public struct Configuration {
         cachePath: String?,
         allowZeroLintableFiles: Bool,
         strict: Bool,
+        lenient: Bool,
         baseline: String?,
         writeBaseline: String?,
         checkForUpdates: Bool
@@ -97,6 +101,7 @@ public struct Configuration {
         self.cachePath = cachePath
         self.allowZeroLintableFiles = allowZeroLintableFiles
         self.strict = strict
+        self.lenient = lenient
         self.baseline = baseline
         self.writeBaseline = writeBaseline
         self.checkForUpdates = checkForUpdates
@@ -117,6 +122,7 @@ public struct Configuration {
         cachePath = configuration.cachePath
         allowZeroLintableFiles = configuration.allowZeroLintableFiles
         strict = configuration.strict
+        lenient = configuration.lenient
         baseline = configuration.baseline
         writeBaseline = configuration.writeBaseline
         checkForUpdates = configuration.checkForUpdates
@@ -143,6 +149,7 @@ public struct Configuration {
     /// - parameter allowZeroLintableFiles: Allow SwiftLint to exit successfully when passed ignored or unlintable
     ///                                     files.
     /// - parameter strict:                 Treat warnings as errors.
+    /// - parameter lenient:                Treat errors as warnings.
     /// - parameter baseline:               The path to read a baseline from.
     /// - parameter writeBaseline:          The path to write a baseline to.
     /// - parameter checkForUpdates:        Check for updates to SwiftLint.
@@ -160,6 +167,7 @@ public struct Configuration {
         pinnedVersion: String? = nil,
         allowZeroLintableFiles: Bool = false,
         strict: Bool = false,
+        lenient: Bool = false,
         baseline: String? = nil,
         writeBaseline: String? = nil,
         checkForUpdates: Bool = false
@@ -189,6 +197,7 @@ public struct Configuration {
             cachePath: cachePath,
             allowZeroLintableFiles: allowZeroLintableFiles,
             strict: strict,
+            lenient: lenient,
             baseline: baseline,
             writeBaseline: writeBaseline,
             checkForUpdates: checkForUpdates
@@ -304,6 +313,7 @@ extension Configuration: Hashable {
         hasher.combine(reporter)
         hasher.combine(allowZeroLintableFiles)
         hasher.combine(strict)
+        hasher.combine(lenient)
         hasher.combine(baseline)
         hasher.combine(writeBaseline)
         hasher.combine(checkForUpdates)
@@ -325,6 +335,7 @@ extension Configuration: Hashable {
             lhs.fileGraph == rhs.fileGraph &&
             lhs.allowZeroLintableFiles == rhs.allowZeroLintableFiles &&
             lhs.strict == rhs.strict &&
+            lhs.lenient == rhs.lenient &&
             lhs.baseline == rhs.baseline &&
             lhs.writeBaseline == rhs.writeBaseline &&
             lhs.checkForUpdates == rhs.checkForUpdates &&

--- a/Source/SwiftLintFramework/LintOrAnalyzeCommand.swift
+++ b/Source/SwiftLintFramework/LintOrAnalyzeCommand.swift
@@ -417,8 +417,8 @@ extension LintOrAnalyzeOptions {
 
     // config file settings can be overridden by either `--strict` or `--lenient` command line options.
     func leniency(strict commandLineStrict: Bool, lenient commandLineLenient: Bool) -> (Bool, Bool) {
-        let strict = (commandLineStrict && !self.lenient) || self.strict
-        let lenient = (commandLineLenient && !self.strict) || self.lenient
+        let strict = commandLineStrict || self.strict
+        let lenient = commandLineLenient || self.lenient
         return (strict, lenient)
     }
 }

--- a/Source/SwiftLintFramework/LintOrAnalyzeCommand.swift
+++ b/Source/SwiftLintFramework/LintOrAnalyzeCommand.swift
@@ -278,9 +278,9 @@ package struct LintOrAnalyzeCommand {
         lenient: Bool,
         violations: [StyleViolation]
     ) -> [StyleViolation] {
-        let (strict, lenient) = options.leniency(strict: strict, lenient: lenient)
+        let leniency = options.leniency(strict: strict, lenient: lenient)
 
-        switch (strict, lenient) {
+        switch leniency {
         case (false, false):
             return violations
 
@@ -415,11 +415,13 @@ extension LintOrAnalyzeOptions {
         }
     }
 
-    // config file settings can be overridden by either `--strict` or `--lenient` command line options.
-    func leniency(strict commandLineStrict: Bool, lenient commandLineLenient: Bool) -> (Bool, Bool) {
-        let strict = commandLineStrict || self.strict
+    typealias Leniency = (strict: Bool, lenient: Bool)
+
+    // Config file settings can be overridden by either `--strict` or `--lenient` command line options.
+    func leniency(strict commandLineStrict: Bool, lenient commandLineLenient: Bool) -> Leniency {
+        let strict = commandLineStrict || (self.strict && !commandLineLenient)
         let lenient = commandLineLenient || (self.lenient && !commandLineStrict)
-        return (strict, lenient)
+        return Leniency(strict: strict, lenient: lenient)
     }
 }
 

--- a/Source/SwiftLintFramework/LintOrAnalyzeCommand.swift
+++ b/Source/SwiftLintFramework/LintOrAnalyzeCommand.swift
@@ -418,9 +418,9 @@ extension LintOrAnalyzeOptions {
     typealias Leniency = (strict: Bool, lenient: Bool)
 
     // Config file settings can be overridden by either `--strict` or `--lenient` command line options.
-    func leniency(strict commandLineStrict: Bool, lenient commandLineLenient: Bool) -> Leniency {
-        let strict = commandLineStrict || (self.strict && !commandLineLenient)
-        let lenient = commandLineLenient || (self.lenient && !commandLineStrict)
+    func leniency(strict configurationStrict: Bool, lenient configurationLenient: Bool) -> Leniency {
+        let strict = self.strict || (configurationStrict && !self.lenient)
+        let lenient = self.lenient || (configurationLenient && !self.strict)
         return Leniency(strict: strict, lenient: lenient)
     }
 }

--- a/Source/SwiftLintFramework/LintOrAnalyzeCommand.swift
+++ b/Source/SwiftLintFramework/LintOrAnalyzeCommand.swift
@@ -418,7 +418,7 @@ extension LintOrAnalyzeOptions {
     // config file settings can be overridden by either `--strict` or `--lenient` command line options.
     func leniency(strict commandLineStrict: Bool, lenient commandLineLenient: Bool) -> (Bool, Bool) {
         let strict = commandLineStrict || self.strict
-        let lenient = commandLineLenient || self.lenient
+        let lenient = commandLineLenient || (self.lenient && !commandLineStrict)
         return (strict, lenient)
     }
 }

--- a/Source/SwiftLintFramework/LintOrAnalyzeCommand.swift
+++ b/Source/SwiftLintFramework/LintOrAnalyzeCommand.swift
@@ -169,6 +169,7 @@ package struct LintOrAnalyzeCommand {
                 currentViolations = applyLeniency(
                     options: options,
                     strict: builder.configuration.strict,
+                    lenient: builder.configuration.lenient,
                     violations: violationsBeforeLeniency
                 )
                 visitorMutationQueue.sync {
@@ -179,6 +180,7 @@ package struct LintOrAnalyzeCommand {
                 currentViolations = applyLeniency(
                     options: options,
                     strict: builder.configuration.strict,
+                    lenient: builder.configuration.lenient,
                     violations: linter.styleViolations(using: builder.storage)
                 )
             }
@@ -273,11 +275,14 @@ package struct LintOrAnalyzeCommand {
     private static func applyLeniency(
         options: LintOrAnalyzeOptions,
         strict: Bool,
+        lenient: Bool,
         violations: [StyleViolation]
     ) -> [StyleViolation] {
+        // config file settings can be overridden by either `--strict` or `--lenient` command line options
         let strict = (strict && !options.lenient) || options.strict
+        let lenient = (lenient && !options.strict) || options.lenient
 
-        switch (options.lenient, strict) {
+        switch (lenient, strict) {
         case (false, false):
             return violations
 
@@ -298,7 +303,7 @@ package struct LintOrAnalyzeCommand {
             }
 
         case (true, true):
-            queuedFatalError("Invalid command line options: 'lenient' and 'strict' are mutually exclusive.")
+            queuedFatalError("Invalid command line or config options: 'lenient' and 'strict' are mutually exclusive.")
         }
     }
 

--- a/Source/SwiftLintFramework/LintOrAnalyzeCommand.swift
+++ b/Source/SwiftLintFramework/LintOrAnalyzeCommand.swift
@@ -416,9 +416,9 @@ extension LintOrAnalyzeOptions {
     }
 
     // config file settings can be overridden by either `--strict` or `--lenient` command line options.
-    func leniency(strict: Bool, lenient: Bool) -> (Bool, Bool) {
-        let strict = (strict && !self.lenient) || self.strict
-        let lenient = (lenient && !self.strict) || self.lenient
+    func leniency(strict commandLineStrict: Bool, lenient commandLineLenient: Bool) -> (Bool, Bool) {
+        let strict = (commandLineStrict && !self.lenient) || self.strict
+        let lenient = (commandLineLenient && !self.strict) || self.lenient
         return (strict, lenient)
     }
 }

--- a/Source/SwiftLintFramework/LintOrAnalyzeCommand.swift
+++ b/Source/SwiftLintFramework/LintOrAnalyzeCommand.swift
@@ -415,8 +415,8 @@ extension LintOrAnalyzeOptions {
         }
     }
 
-    // config file settings can be overridden by either `--strict` or `--lenient` command line options
-    func leniency(strict: Bool, lenient: Bool) -> (Bool , Bool) {
+    // config file settings can be overridden by either `--strict` or `--lenient` command line options.
+    func leniency(strict: Bool, lenient: Bool) -> (Bool, Bool) {
         let strict = (strict && !self.lenient) || self.strict
         let lenient = (lenient && !self.strict) || self.lenient
         return (strict, lenient)

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -56,6 +56,7 @@ final class ConfigurationTests: SwiftLintTestCase {
         XCTAssertEqual(reporterFrom(identifier: config.reporter).identifier, "xcode")
         XCTAssertFalse(config.allowZeroLintableFiles)
         XCTAssertFalse(config.strict)
+        XCTAssertFalse(config.lenient)
         XCTAssertNil(config.baseline)
         XCTAssertNil(config.writeBaseline)
         XCTAssertFalse(config.checkForUpdates)
@@ -456,6 +457,11 @@ final class ConfigurationTests: SwiftLintTestCase {
     func testStrict() throws {
         let configuration = try Configuration(dict: ["strict": true])
         XCTAssertTrue(configuration.strict)
+    }
+
+    func testLenient() throws {
+        let configuration = try Configuration(dict: ["lenient": true])
+        XCTAssertTrue(configuration.lenient)
     }
 
     func testBaseline() throws {

--- a/Tests/SwiftLintFrameworkTests/LintOrAnalyzeOptionsTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LintOrAnalyzeOptionsTests.swift
@@ -1,9 +1,9 @@
 @testable import SwiftLintFramework
 import XCTest
 
-internal typealias Leniency = (strict: Bool, lenient: Bool)
-
 final class LintOrAnalyzeOptionsTests: XCTestCase {
+    typealias Leniency = LintOrAnalyzeOptions.Leniency
+
     func testLeniency() {
         let bothFalse = Leniency(strict: false, lenient: false)
         let bothTrue = Leniency(strict: true, lenient: true)
@@ -14,7 +14,7 @@ final class LintOrAnalyzeOptionsTests: XCTestCase {
         for configuration in parameters {
             for commandLine in parameters {
                 let options = LintOrAnalyzeOptions(leniency: configuration)
-                let leniency: Leniency = options.leniency(strict: commandLine.strict, lenient: commandLine.lenient)
+                let leniency = options.leniency(strict: commandLine.strict, lenient: commandLine.lenient)
                 if commandLine.strict {
                     // Command line takes precedence.
                     XCTAssertTrue(leniency.strict)

--- a/Tests/SwiftLintFrameworkTests/LintOrAnalyzeOptionsTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LintOrAnalyzeOptionsTests.swift
@@ -1,4 +1,3 @@
-
 @testable import SwiftLintFramework
 import XCTest
 

--- a/Tests/SwiftLintFrameworkTests/LintOrAnalyzeOptionsTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LintOrAnalyzeOptionsTests.swift
@@ -16,9 +16,17 @@ final class LintOrAnalyzeOptionsTests: XCTestCase {
                 let options = LintOrAnalyzeOptions(leniency: configuration)
                 let leniency: Leniency = options.leniency(strict: commandLine.strict, lenient: commandLine.lenient)
                 if commandLine.strict {
+                    // Command line takes precedence.
                     XCTAssertTrue(leniency.strict)
+                    if !commandLine.lenient {
+                        // `--strict` should disable configuration lenience.
+                        XCTAssertFalse(leniency.lenient)
+                    }
                 } else if commandLine.lenient {
+                    // Command line takes precendence, and should override
+                    // `strict` in the configuration.
                     XCTAssertTrue(leniency.lenient)
+                    XCTAssertFalse(leniency.strict)
                 } else if configuration.strict {
                     XCTAssertTrue(leniency.strict)
                 } else if configuration.lenient {

--- a/Tests/SwiftLintFrameworkTests/LintOrAnalyzeOptionsTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LintOrAnalyzeOptionsTests.swift
@@ -14,27 +14,19 @@ final class LintOrAnalyzeOptionsTests: XCTestCase {
 
         for configuration in parameters {
             for commandLine in parameters {
-                let expected: Leniency = if configuration == bothFalse {
-                    commandLine
-                } else if configuration == bothTrue {
-                    bothTrue // This is an error
-                } else if configuration == strict {
-                    strict // Hmmm. We should be able to override strict with lenient on the command line
-                } else { // configuration = lenient. Can be overridden from the command line
-                    commandLine.strict ? strict : lenient
+                let options = LintOrAnalyzeOptions(leniency: configuration)
+                let leniency: Leniency = options.leniency(strict: commandLine.strict, lenient: commandLine.lenient)
+                if commandLine.strict {
+                    XCTAssertTrue(leniency.strict)
+                } else if commandLine.lenient {
+                    XCTAssertTrue(leniency.lenient)
+                } else if configuration.strict {
+                    XCTAssertTrue(leniency.strict)
+                } else if configuration.lenient {
+                    XCTAssertTrue(leniency.lenient)
                 }
-                testLeniency(configuration: bothTrue, commandLine: lenient, expected: expected)
             }
         }
-
-        testLeniency(configuration: strict, commandLine: lenient, expected: lenient)
-    }
-
-    private func testLeniency(configuration: Leniency, commandLine: Leniency, expected: Leniency) {
-        let options = LintOrAnalyzeOptions(leniency: configuration)
-        let leniency = options.leniency(strict: commandLine.strict, lenient: commandLine.lenient)
-        XCTAssertEqual(leniency.0, expected.strict)
-        XCTAssertEqual(leniency.1, expected.lenient)
     }
 }
 

--- a/Tests/SwiftLintFrameworkTests/LintOrAnalyzeOptionsTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LintOrAnalyzeOptionsTests.swift
@@ -2,14 +2,15 @@
 import XCTest
 
 final class LintOrAnalyzeOptionsTests: XCTestCase {
-    typealias Leniency = LintOrAnalyzeOptions.Leniency
+    private typealias Leniency = LintOrAnalyzeOptions.Leniency
 
     func testLeniency() {
-        let bothFalse = Leniency(strict: false, lenient: false)
-        let bothTrue = Leniency(strict: true, lenient: true)
-        let strict = Leniency(strict: true, lenient: false)
-        let lenient = Leniency(strict: true, lenient: false)
-        let parameters = [ bothFalse, bothTrue, strict, lenient ]
+        let parameters = [
+            Leniency(strict: false, lenient: false),
+            Leniency(strict: true, lenient: true),
+            Leniency(strict: true, lenient: false),
+            Leniency(strict: false, lenient: true),
+        ]
 
         for configuration in parameters {
             for commandLine in parameters {
@@ -23,7 +24,7 @@ final class LintOrAnalyzeOptionsTests: XCTestCase {
                         XCTAssertFalse(leniency.lenient)
                     }
                 } else if commandLine.lenient {
-                    // Command line takes precendence, and should override
+                    // Command line takes precedence, and should override
                     // `strict` in the configuration.
                     XCTAssertTrue(leniency.lenient)
                     XCTAssertFalse(leniency.strict)

--- a/Tests/SwiftLintFrameworkTests/LintOrAnalyzeOptionsTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LintOrAnalyzeOptionsTests.swift
@@ -1,0 +1,72 @@
+
+@testable import SwiftLintFramework
+import XCTest
+
+internal typealias Leniency = (strict: Bool, lenient: Bool)
+
+final class LintOrAnalyzeOptionsTests: XCTestCase {
+    func testLeniency() {
+        let bothFalse = Leniency(strict: false, lenient: false)
+        let bothTrue = Leniency(strict: true, lenient: true)
+        let strict = Leniency(strict: true, lenient: false)
+        let lenient = Leniency(strict: true, lenient: false)
+        let parameters = [ bothFalse, bothTrue, strict, lenient ]
+
+        for configuration in parameters {
+            for commandLine in parameters {
+                let expected: Leniency = if configuration == bothFalse {
+                    commandLine
+                } else if configuration == bothTrue {
+                    bothTrue // This is an error
+                } else if configuration == strict {
+                    strict // Hmmm. We should be able to override strict with lenient on the command line
+                } else { // configuration = lenient. Can be overridden from the command line
+                    commandLine.strict ? strict : lenient
+                }
+                testLeniency(configuration: bothTrue, commandLine: lenient, expected: expected)
+            }
+        }
+
+        testLeniency(configuration: strict, commandLine: lenient, expected: lenient)
+    }
+
+    private func testLeniency(configuration: Leniency, commandLine: Leniency, expected: Leniency) {
+        let options = LintOrAnalyzeOptions(leniency: configuration)
+        let leniency = options.leniency(strict: commandLine.strict, lenient: commandLine.lenient)
+        XCTAssertEqual(leniency.0, expected.strict)
+        XCTAssertEqual(leniency.1, expected.lenient)
+    }
+}
+
+private extension LintOrAnalyzeOptions {
+    init(leniency: Leniency) {
+        self.init(mode: .lint,
+                  paths: [],
+                  useSTDIN: true,
+                  configurationFiles: [],
+                  strict: leniency.strict,
+                  lenient: leniency.lenient,
+                  forceExclude: false,
+                  useExcludingByPrefix: false,
+                  useScriptInputFiles: false,
+                  useScriptInputFileLists: false,
+                  benchmark: false,
+                  reporter: nil,
+                  baseline: nil,
+                  writeBaseline: nil,
+                  workingDirectory: nil,
+                  quiet: false,
+                  output: nil,
+                  progress: false,
+                  cachePath: nil,
+                  ignoreCache: false,
+                  enableAllRules: false,
+                  onlyRule: [],
+                  autocorrect: false,
+                  format: false,
+                  compilerLogPath: nil,
+                  compileCommands: nil,
+                  checkForUpdates: false
+        )
+    }
+}

--- a/Tests/SwiftLintFrameworkTests/LintOrAnalyzeOptionsTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LintOrAnalyzeOptionsTests.swift
@@ -12,10 +12,10 @@ final class LintOrAnalyzeOptionsTests: XCTestCase {
             Leniency(strict: false, lenient: true),
         ]
 
-        for configuration in parameters {
-            for commandLine in parameters {
-                let options = LintOrAnalyzeOptions(leniency: configuration)
-                let leniency = options.leniency(strict: commandLine.strict, lenient: commandLine.lenient)
+        for commandLine in parameters {
+            let options = LintOrAnalyzeOptions(leniency: commandLine)
+            for configuration in parameters {
+                let leniency = options.leniency(strict: configuration.strict, lenient: configuration.lenient)
                 if commandLine.strict {
                     // Command line takes precedence.
                     XCTAssertTrue(leniency.strict)


### PR DESCRIPTION
Addresses #5779 

So I basically just copied #5226 (which I wrote).

If you have `strict` and `lenient` as true in the config file, a `fatalError` will be thrown, but either can be overridden by the `--strict` or `--lenient` command line options, and they will also override the opposite setting in the config file.

For example, if you have 

`lenient: true` in your config file, but you specify `--strict` on the command line, you will get the `strict` behaviour, and your config file setting will be ignored.

I tested this manually - it was hard to do a unit test, because we `fatalError` instead of throwing an error right now.

As before, `--strict` and `--lenient` on the command line will also fatal error.