### PR TITLE
Dont trigger for non-optional type casting, or for optional types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@
   [chipp](https://github.com/chipp)
   [#5791](https://github.com/realm/SwiftLint/issues/5791)
 
+* The `prefer_type_checking` rule will no longer trigger for non-optional
+  type casting (`as`), or for comparisons to optional types.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#5802](https://github.com/realm/SwiftLint/issues/5802)
+
 ## 0.57.0: Squeaky Clean Cycle
 
 #### Breaking

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferTypeCheckingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferTypeCheckingRule.swift
@@ -90,7 +90,7 @@ private extension InfixOperatorExprSyntax {
            asExpr.questionOrExclamationMark?.tokenKind == .postfixQuestionMark,
            !asExpr.type.is(OptionalTypeSyntax.self),
            self.operator.as(BinaryOperatorExprSyntax.self)?.operator.tokenKind == .binaryOperator("!="),
-           rightOperand.is(NilLiteralExprSyntax.self) || leftOperand.is(NilLiteralExprSyntax.self){
+           rightOperand.is(NilLiteralExprSyntax.self) || leftOperand.is(NilLiteralExprSyntax.self) {
             asExpr
         } else {
             nil

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferTypeCheckingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferTypeCheckingRule.swift
@@ -25,6 +25,7 @@ struct PreferTypeCheckingRule: Rule {
             }
             """),
             Example("bar as Foo? != nil"),
+            Example("bar as Foo? != nil"),
             Example("bar as? Foo? != nil"),
         ],
         triggeringExamples: [


### PR DESCRIPTION
Addresses #5802

We no longer trigger unless the type casting is optional (`as?`), or if the type is optional.

Essentially, in either case, the correction would change the resulting `true` or `false` value. See #5802 for details.

We also now check for `nil != foo as? Bar` cases
