### PR TITLE
Build with warnings as errors excluding SourceKitten

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -26,6 +26,7 @@ config_setting(
 )
 
 copts = [
+    "-warnings-as-errors",
     "-enable-upcoming-feature",
     "ExistentialAny",
     "-enable-upcoming-feature",
@@ -90,13 +91,23 @@ swift_library(
         "@SwiftSyntax//:SwiftParserDiagnostics_opt",
         "@SwiftSyntax//:SwiftSyntaxBuilder_opt",
         "@SwiftSyntax//:SwiftSyntax_opt",
-        "@com_github_jpsim_sourcekitten//:SourceKittenFramework",
+        ":SourceKittenFramework.wrapper",
         "@sourcekitten_com_github_jpsim_yams//:Yams",
         "@swiftlint_com_github_scottrhoyt_swifty_text_table//:SwiftyTextTable",
     ] + select({
         "@platforms//os:linux": ["@com_github_krzyzanowskim_cryptoswift//:CryptoSwift"],
         "//conditions:default": [":DyldWarningWorkaround"],
     }),
+)
+
+swift_library(
+    name = "SourceKittenFramework.wrapper",
+    srcs = ["Source/SourceKittenFrameworkWrapper/Empty.swift"],
+    module_name = "SourceKittenFrameworkWrapper",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_jpsim_sourcekitten//:SourceKittenFramework",
+    ],
 )
 
 swift_library(


### PR DESCRIPTION
With https://github.com/jpsim/SourceKitten/pull/822 merged and released, the SourceKitten exception can be reverted.