### PR TITLE
Replace `description.identifier` with `identifier`

### DIFF
--- a/Source/SwiftLintBuiltInRules/Rules/Lint/CaptureVariableRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/CaptureVariableRule.swift
@@ -264,7 +264,7 @@ private extension SwiftLintFile {
             let path = self.path,
             let response = try? Request.index(file: path, arguments: compilerArguments).sendIfNotDisabled()
         else {
-            Issue.indexingError(path: path, ruleID: CaptureVariableRule.description.identifier).print()
+            Issue.indexingError(path: path, ruleID: CaptureVariableRule.identifier).print()
             return nil
         }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/InertDeferRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/InertDeferRule.swift
@@ -2,7 +2,7 @@ import SwiftSyntax
 
 // TODO: [12/23/2024] Remove deprecation warning after ~2 years.
 private let warnDeprecatedOnceImpl: Void = {
-    Issue.ruleDeprecated(ruleID: InertDeferRule.description.identifier).print()
+    Issue.ruleDeprecated(ruleID: InertDeferRule.identifier).print()
 }()
 
 private func warnDeprecatedOnce() {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/TypesafeArrayInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/TypesafeArrayInitRule.swift
@@ -67,7 +67,7 @@ struct TypesafeArrayInitRule: AnalyzerRule {
             return []
         }
         guard compilerArguments.isNotEmpty else {
-            Issue.missingCompilerArguments(path: file.path, ruleID: Self.description.identifier).print()
+            Issue.missingCompilerArguments(path: file.path, ruleID: Self.identifier).print()
             return []
         }
         return Self.parentRule.validate(file: file)

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedCaptureListRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedCaptureListRule.swift
@@ -2,7 +2,7 @@ import SwiftSyntax
 
 // TODO: [12/22/2024] Remove deprecation warning after ~2 years.
 private let warnDeprecatedOnceImpl: Void = {
-    Issue.ruleDeprecated(ruleID: UnusedCaptureListRule.description.identifier).print()
+    Issue.ruleDeprecated(ruleID: UnusedCaptureListRule.identifier).print()
 }()
 
 private func warnDeprecatedOnce() {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedDeclarationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedDeclarationRule.swift
@@ -30,18 +30,18 @@ struct UnusedDeclarationRule: AnalyzerRule, CollectingRule {
 
     func collectInfo(for file: SwiftLintFile, compilerArguments: [String]) -> Self.FileUSRs {
         guard compilerArguments.isNotEmpty else {
-            Issue.missingCompilerArguments(path: file.path, ruleID: Self.description.identifier).print()
+            Issue.missingCompilerArguments(path: file.path, ruleID: Self.identifier).print()
             return .empty
         }
 
         guard let index = file.index(compilerArguments: compilerArguments), index.value.isNotEmpty else {
-            Issue.indexingError(path: file.path, ruleID: Self.description.identifier).print()
+            Issue.indexingError(path: file.path, ruleID: Self.identifier).print()
             return .empty
         }
 
         guard let editorOpen = (try? Request.editorOpen(file: file.file).sendIfNotDisabled())
                 .map(SourceKittenDictionary.init) else {
-            Issue.fileNotReadable(path: file.path, ruleID: Self.description.identifier).print()
+            Issue.fileNotReadable(path: file.path, ruleID: Self.identifier).print()
             return .empty
         }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedImportRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedImportRule.swift
@@ -84,7 +84,7 @@ struct UnusedImportRule: CorrectableRule, AnalyzerRule {
 
     private func importUsage(in file: SwiftLintFile, compilerArguments: [String]) -> [ImportUsage] {
         guard compilerArguments.isNotEmpty else {
-            Issue.missingCompilerArguments(path: file.path, ruleID: Self.description.identifier).print()
+            Issue.missingCompilerArguments(path: file.path, ruleID: Self.identifier).print()
             return []
         }
 
@@ -162,7 +162,7 @@ private extension SwiftLintFile {
                 file: path!, offset: token.offset, arguments: compilerArguments
             )
             guard let cursorInfo = (try? cursorInfoRequest.sendIfNotDisabled()).map(SourceKittenDictionary.init) else {
-                Issue.missingCursorInfo(path: path, ruleID: UnusedImportRule.description.identifier).print()
+                Issue.missingCursorInfo(path: path, ruleID: UnusedImportRule.identifier).print()
                 continue
             }
             if nextIsModuleImport {
@@ -197,7 +197,7 @@ private extension SwiftLintFile {
     func operatorImports(arguments: [String], processedTokenOffsets: Set<ByteCount>) -> Set<String> {
         guard let index = (try? Request.index(file: path!, arguments: arguments).sendIfNotDisabled())
             .map(SourceKittenDictionary.init) else {
-            Issue.indexingError(path: path, ruleID: UnusedImportRule.description.identifier).print()
+            Issue.indexingError(path: path, ruleID: UnusedImportRule.identifier).print()
             return []
         }
 
@@ -220,7 +220,7 @@ private extension SwiftLintFile {
                 )
                 guard let cursorInfo = (try? cursorInfoRequest.sendIfNotDisabled())
                     .map(SourceKittenDictionary.init) else {
-                    Issue.missingCursorInfo(path: path, ruleID: UnusedImportRule.description.identifier).print()
+                    Issue.missingCursorInfo(path: path, ruleID: UnusedImportRule.identifier).print()
                     continue
                 }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ExplicitSelfRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ExplicitSelfRule.swift
@@ -42,7 +42,7 @@ struct ExplicitSelfRule: CorrectableRule, AnalyzerRule {
 
     private func violationRanges(in file: SwiftLintFile, compilerArguments: [String]) -> [NSRange] {
         guard compilerArguments.isNotEmpty else {
-            Issue.missingCompilerArguments(path: file.path, ruleID: Self.description.identifier).print()
+            Issue.missingCompilerArguments(path: file.path, ruleID: Self.identifier).print()
             return []
         }
 
@@ -69,7 +69,7 @@ struct ExplicitSelfRule: CorrectableRule, AnalyzerRule {
 
         return cursorsMissingExplicitSelf.compactMap { cursorInfo in
             guard let byteOffset = (cursorInfo["swiftlint.offset"] as? Int64).flatMap(ByteCount.init) else {
-                Issue.genericWarning("Cannot convert offsets in '\(Self.description.identifier)' rule.").print()
+                Issue.genericWarning("Cannot convert offsets in '\(Self.identifier)' rule.").print()
                 return nil
             }
 

--- a/Source/SwiftLintCore/Documentation/RuleDocumentation.swift
+++ b/Source/SwiftLintCore/Documentation/RuleDocumentation.swift
@@ -31,10 +31,10 @@ struct RuleDocumentation {
     var ruleName: String { ruleType.description.name }
 
     /// The identifier of the documented rule.
-    var ruleIdentifier: String { ruleType.description.identifier }
+    var ruleIdentifier: String { ruleType.identifier }
 
     /// The name of the file on disk for this rule documentation.
-    var fileName: String { "\(ruleType.description.identifier).md" }
+    var fileName: String { "\(ruleType.identifier).md" }
 
     /// The contents of the file for this rule documentation.
     var fileContents: String {
@@ -81,7 +81,7 @@ private func h2(_ text: String) -> String { "## \(text)" }
 
 private func detailsSummary(_ rule: some Rule) -> String {
     let ruleDescription = """
-        * **Identifier:** `\(type(of: rule).description.identifier)`
+        * **Identifier:** `\(type(of: rule).identifier)`
         * **Enabled by default:** \(rule is any OptInRule ? "No" : "Yes")
         * **Supports autocorrection:** \(rule is any CorrectableRule ? "Yes" : "No")
         * **Kind:** \(type(of: rule).description.kind)

--- a/Source/SwiftLintCore/Extensions/Configuration+Cache.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Cache.swift
@@ -60,7 +60,7 @@ extension Configuration {
         }
 
         let cacheRulesDescriptions = rules
-            .map { rule in [type(of: rule).description.identifier, rule.cacheDescription] }
+            .map { rule in [type(of: rule).identifier, rule.cacheDescription] }
             .sorted { $0[0] < $1[0] }
         let jsonObject: [Any] = [rootDirectory, cacheRulesDescriptions]
         if let jsonData = try? JSONSerialization.data(withJSONObject: jsonObject) {

--- a/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+Parsing.swift
@@ -66,7 +66,7 @@ extension Configuration {
             allRulesWrapped = try ruleList.allRulesWrapped(configurationDict: dict)
         } catch let RuleListError.duplicatedConfigurations(ruleType) {
             let aliases = ruleType.description.deprecatedAliases.map { "'\($0)'" }.joined(separator: ", ")
-            let identifier = ruleType.description.identifier
+            let identifier = ruleType.identifier
             throw Issue.genericWarning(
                 "Multiple configurations found for '\(identifier)'. Check for any aliases: \(aliases)."
             )

--- a/Source/SwiftLintCore/Extensions/Configuration+RulesMode.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+RulesMode.swift
@@ -6,7 +6,7 @@ public extension Configuration {
     /// - returns: The rule for the specified ID, if configured in this configuration.
     func configuredRule(forID ruleID: String) -> (any Rule)? {
         rules.first { rule in
-            if type(of: rule).description.identifier == ruleID {
+            if type(of: rule).identifier == ruleID {
                 if let customRules = rule as? CustomRules {
                     return customRules.configuration.customRuleConfigurations.isNotEmpty
                 }

--- a/Source/SwiftLintCore/Extensions/Configuration+RulesWrapper.swift
+++ b/Source/SwiftLintCore/Extensions/Configuration+RulesWrapper.swift
@@ -11,7 +11,7 @@ internal extension Configuration {
 
         private var invalidRuleIdsWarnedAbout: Set<String> = []
         private var validRuleIdentifiers: Set<String> {
-            let regularRuleIdentifiers = allRulesWrapped.map { type(of: $0.rule).description.identifier }
+            let regularRuleIdentifiers = allRulesWrapped.map { type(of: $0.rule).identifier }
             let configurationCustomRulesIdentifiers =
                 (allRulesWrapped.first { $0.rule is CustomRules }?.rule as? CustomRules)?.customRuleIdentifiers ?? []
             return Set(regularRuleIdentifiers + configurationCustomRulesIdentifiers)
@@ -42,7 +42,7 @@ internal extension Configuration {
                 customRulesFilter = { onlyRulesRuleIdentifiers.contains($0.identifier) }
                 let onlyRulesRuleIdentifiers = validate(ruleIds: onlyRulesRuleIdentifiers, valid: validRuleIdentifiers)
                 resultingRules = allRulesWrapped.filter { tuple in
-                    onlyRulesRuleIdentifiers.contains(type(of: tuple.rule).description.identifier)
+                    onlyRulesRuleIdentifiers.contains(type(of: tuple.rule).identifier)
                 }.map(\.rule)
 
             case var .defaultConfiguration(disabledRuleIdentifiers, optInRuleIdentifiers):
@@ -50,7 +50,7 @@ internal extension Configuration {
                 disabledRuleIdentifiers = validate(ruleIds: disabledRuleIdentifiers, valid: validRuleIdentifiers)
                 optInRuleIdentifiers = validate(optInRuleIds: optInRuleIdentifiers, valid: validRuleIdentifiers)
                 resultingRules = allRulesWrapped.filter { tuple in
-                    let id = type(of: tuple.rule).description.identifier
+                    let id = type(of: tuple.rule).identifier
                     return !disabledRuleIdentifiers.contains(id)
                         && (!(tuple.rule is any OptInRule) || optInRuleIdentifiers.contains(id))
                 }.map(\.rule)
@@ -65,7 +65,7 @@ internal extension Configuration {
 
             // Sort by name
             resultingRules = resultingRules.sorted {
-                type(of: $0).description.identifier < type(of: $1).description.identifier
+                type(of: $0).identifier < type(of: $1).identifier
             }
 
             // Store & return
@@ -82,7 +82,7 @@ internal extension Configuration {
             case let .onlyConfiguration(onlyRules), let .onlyCommandLine(onlyRules):
                 return validate(
                     ruleIds: Set(allRulesWrapped
-                        .map { type(of: $0.rule).description.identifier }
+                        .map { type(of: $0.rule).identifier }
                         .filter { !onlyRules.contains($0) }),
                     valid: validRuleIdentifiers,
                     silent: true
@@ -249,7 +249,7 @@ internal extension Configuration {
             case var .onlyConfiguration(onlyRules):
                 // Also add identifiers of child custom rules iff the custom_rules rule is enabled
                 // (parent custom rules are already added)
-                if (onlyRules.contains { $0 == CustomRules.description.identifier }) {
+                if (onlyRules.contains { $0 == CustomRules.identifier }) {
                     if let childCustomRulesRule = (child.allRulesWrapped.first { $0.rule is CustomRules })?.rule
                         as? CustomRules {
                         onlyRules = onlyRules.union(
@@ -279,7 +279,7 @@ internal extension Configuration {
                         .filter {
                             !isOptInRule($0, allRulesWrapped: newAllRulesWrapped)
                         },
-                    optIn: Set(newAllRulesWrapped.map { type(of: $0.rule).description.identifier }
+                    optIn: Set(newAllRulesWrapped.map { type(of: $0.rule).identifier }
                         .filter {
                             !childDisabled.contains($0)
                             && isOptInRule($0, allRulesWrapped: newAllRulesWrapped)
@@ -298,7 +298,7 @@ internal extension Configuration {
             }
 
             let isOptInRule = allRulesWrapped
-                .first { type(of: $0.rule).description.identifier == identifier }?.rule is any OptInRule
+                .first { type(of: $0.rule).identifier == identifier }?.rule is any OptInRule
             Self.isOptInRuleCache[identifier] = isOptInRule
             return isOptInRule
         }

--- a/Source/SwiftLintCore/Models/ChildOptionSeverityConfiguration.swift
+++ b/Source/SwiftLintCore/Models/ChildOptionSeverityConfiguration.swift
@@ -23,7 +23,7 @@ public struct ChildOptionSeverityConfiguration<Parent: Rule>: RuleConfiguration,
     public mutating func apply(configuration: Any) throws {
         guard let configString = configuration as? String,
             let optionSeverity = ChildOptionSeverity(rawValue: configString.lowercased()) else {
-            throw Issue.invalidConfiguration(ruleID: Parent.description.identifier)
+            throw Issue.invalidConfiguration(ruleID: Parent.identifier)
         }
         self.optionSeverity = optionSeverity
     }

--- a/Source/SwiftLintCore/Models/Configuration.swift
+++ b/Source/SwiftLintCore/Models/Configuration.swift
@@ -309,7 +309,7 @@ extension Configuration: Hashable {
         hasher.combine(checkForUpdates)
         hasher.combine(basedOnCustomConfigurationFiles)
         hasher.combine(cachePath)
-        hasher.combine(rules.map { type(of: $0).description.identifier })
+        hasher.combine(rules.map { type(of: $0).identifier })
         hasher.combine(fileGraph)
     }
 
@@ -344,6 +344,6 @@ extension Configuration: CustomStringConvertible {
             + "- Reporter: \(reporter ?? "default")\n"
             + "- Cache Path: \(cachePath as Optional)\n"
             + "- Computed Cache Description: \(computedCacheDescription as Optional)\n"
-            + "- Rules: \(rules.map { type(of: $0).description.identifier })"
+            + "- Rules: \(rules.map { type(of: $0).identifier })"
     }
 }

--- a/Source/SwiftLintCore/Models/HashableConfigurationRuleWrapperWrapper.swift
+++ b/Source/SwiftLintCore/Models/HashableConfigurationRuleWrapperWrapper.swift
@@ -5,11 +5,11 @@ internal struct HashableConfigurationRuleWrapperWrapper: Hashable {
         lhs: Self, rhs: Self
     ) -> Bool {
         // Only use identifier for equality check (not taking config into account)
-        type(of: lhs.configurationRuleWrapper.rule).description.identifier
-            == type(of: rhs.configurationRuleWrapper.rule).description.identifier
+        type(of: lhs.configurationRuleWrapper.rule).identifier
+            == type(of: rhs.configurationRuleWrapper.rule).identifier
     }
 
     func hash(into hasher: inout Hasher) {
-        hasher.combine(type(of: configurationRuleWrapper.rule).description.identifier)
+        hasher.combine(type(of: configurationRuleWrapper.rule).identifier)
     }
 }

--- a/Source/SwiftLintCore/Models/Linter.swift
+++ b/Source/SwiftLintCore/Models/Linter.swift
@@ -89,7 +89,7 @@ private extension Rule {
             return nil
         }
 
-        let ruleID = Self.description.identifier
+        let ruleID = Self.identifier
 
         let violations: [StyleViolation]
         let ruleTime: (String, Double)?
@@ -351,7 +351,7 @@ public struct CollectedLinter {
             let totalTime = -start.timeIntervalSinceNow
             let fractionedTime = totalTime / TimeInterval(rules.count)
             ruleTimes = rules.compactMap { rule in
-                let id = type(of: rule).description.identifier
+                let id = type(of: rule).identifier
                 return (id, fractionedTime)
             }
         }
@@ -414,7 +414,7 @@ public struct CollectedLinter {
             .configuration.customRuleConfigurations.map { RuleIdentifier($0.identifier) } ?? []
         let allRuleIdentifiers = RuleRegistry.shared.list.allValidIdentifiers().map { RuleIdentifier($0) }
         let allValidIdentifiers = Set(allCustomIdentifiers + allRuleIdentifiers + [.all])
-        let superfluousRuleIdentifier = RuleIdentifier(SuperfluousDisableCommandRule.description.identifier)
+        let superfluousRuleIdentifier = RuleIdentifier(SuperfluousDisableCommandRule.identifier)
 
         return regions.flatMap { region in
             region.disabledRuleIdentifiers.filter({

--- a/Source/SwiftLintCore/Models/RuleList.swift
+++ b/Source/SwiftLintCore/Models/RuleList.swift
@@ -27,7 +27,7 @@ public struct RuleList {
         var tmpAliases = [String: String]()
 
         for rule in rules {
-            let identifier = rule.description.identifier
+            let identifier = rule.identifier
             tmpList[identifier] = rule
             for alias in rule.description.deprecatedAliases {
                 tmpAliases[alias] = identifier

--- a/Source/SwiftLintCore/Protocols/Rule.swift
+++ b/Source/SwiftLintCore/Protocols/Rule.swift
@@ -147,7 +147,7 @@ public extension Rule {
 }
 
 public extension Rule {
-    /// The rule's unique identifier which is the same as `Rule.description.identifier`.
+    /// The rule's unique identifier which is the same as `Rule.identifier`.
     static var identifier: String { description.identifier }
 }
 

--- a/Source/SwiftLintCore/Protocols/Rule.swift
+++ b/Source/SwiftLintCore/Protocols/Rule.swift
@@ -147,7 +147,7 @@ public extension Rule {
 }
 
 public extension Rule {
-    /// The rule's unique identifier which is the same as `Rule.identifier`.
+    /// The rule's unique identifier which is the same as `Rule.description.identifier`.
     static var identifier: String { description.identifier }
 }
 

--- a/Source/SwiftLintCore/RuleConfigurations/RegexConfiguration.swift
+++ b/Source/SwiftLintCore/RuleConfigurations/RegexConfiguration.swift
@@ -60,7 +60,7 @@ public struct RegexConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration, 
     public mutating func apply(configuration: Any) throws {
         guard let configurationDict = configuration as? [String: Any],
               let regexString = configurationDict[$regex.key] as? String else {
-            throw Issue.invalidConfiguration(ruleID: Parent.description.identifier)
+            throw Issue.invalidConfiguration(ruleID: Parent.identifier)
         }
 
         regex = try RegularExpression(pattern: regexString)
@@ -92,7 +92,7 @@ public struct RegexConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration, 
         }
         if let captureGroup = configurationDict["capture_group"] as? Int {
             guard (0 ... regex.numberOfCaptureGroups).contains(captureGroup) else {
-                throw Issue.invalidConfiguration(ruleID: Parent.description.identifier)
+                throw Issue.invalidConfiguration(ruleID: Parent.identifier)
             }
             self.captureGroup = captureGroup
         }
@@ -142,7 +142,7 @@ public struct RegexConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration, 
             if let kind = SyntaxKind(shortName: $0) {
                 return kind
             }
-            throw Issue.invalidConfiguration(ruleID: Parent.description.identifier)
+            throw Issue.invalidConfiguration(ruleID: Parent.identifier)
         }
         return Set(kinds)
     }

--- a/Source/SwiftLintCore/Rules/CustomRules.swift
+++ b/Source/SwiftLintCore/Rules/CustomRules.swift
@@ -90,7 +90,7 @@ struct CustomRules: Rule, CacheDescriptionProvider {
     func canBeDisabled(violation: StyleViolation, by ruleID: RuleIdentifier) -> Bool {
         switch ruleID {
         case let .single(identifier: id):
-            id == Self.description.identifier
+            id == Self.identifier
                 ? customRuleIdentifiers.contains(violation.ruleIdentifier)
                 : customRuleIdentifiers.contains(id) && violation.ruleIdentifier == id
         default:
@@ -101,10 +101,10 @@ struct CustomRules: Rule, CacheDescriptionProvider {
     func isEnabled(in region: Region, for ruleID: String) -> Bool {
         if !Self.description.allIdentifiers.contains(ruleID),
            !customRuleIdentifiers.contains(ruleID),
-           Self.description.identifier != ruleID {
+           Self.identifier != ruleID {
             return true
         }
-        return !region.disabledRuleIdentifiers.contains(RuleIdentifier(Self.description.identifier))
+        return !region.disabledRuleIdentifiers.contains(RuleIdentifier(Self.identifier))
             && !region.disabledRuleIdentifiers.contains(RuleIdentifier(ruleID))
             && !region.disabledRuleIdentifiers.contains(.all)
     }

--- a/Source/SwiftLintFramework/RulesFilter.swift
+++ b/Source/SwiftLintFramework/RulesFilter.swift
@@ -26,7 +26,7 @@ package final class RulesFilter {
 
         let filtered: [any Rule.Type] = allRules.list.compactMap { ruleID, ruleType in
             let enabledRule = enabledRules.first { rule in
-                type(of: rule).description.identifier == ruleID
+                type(of: rule).identifier == ruleID
             }
             let isRuleEnabled = enabledRule != nil
 

--- a/Tests/CLITests/RulesFilterTests.swift
+++ b/Tests/CLITests/RulesFilterTests.swift
@@ -23,7 +23,7 @@ final class RulesFilterTests: XCTestCase {
 
         XCTAssertEqual(
             Set(filteredRules.list.keys),
-            Set([RuleMock2.description.identifier])
+            Set([RuleMock2.identifier])
         )
     }
 
@@ -48,7 +48,7 @@ final class RulesFilterTests: XCTestCase {
 
         XCTAssertEqual(
             Set(filteredRules.list.keys),
-            Set([RuleMock1.description.identifier, CorrectableRuleMock.description.identifier])
+            Set([RuleMock1.identifier, CorrectableRuleMock.identifier])
         )
     }
 
@@ -73,7 +73,7 @@ final class RulesFilterTests: XCTestCase {
 
         XCTAssertEqual(
             Set(filteredRules.list.keys),
-            Set([CorrectableRuleMock.description.identifier])
+            Set([CorrectableRuleMock.identifier])
         )
     }
 
@@ -98,7 +98,7 @@ final class RulesFilterTests: XCTestCase {
 
         XCTAssertEqual(
             Set(filteredRules.list.keys),
-            Set([CorrectableRuleMock.description.identifier])
+            Set([CorrectableRuleMock.identifier])
         )
     }
 
@@ -122,7 +122,7 @@ final class RulesFilterTests: XCTestCase {
 
         XCTAssertEqual(
             Set(filteredRules.list.keys),
-            Set([CorrectableRuleMock.description.identifier])
+            Set([CorrectableRuleMock.identifier])
         )
     }
 }

--- a/Tests/SwiftLintFrameworkTests/CompilerProtocolInitRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CompilerProtocolInitRuleTests.swift
@@ -2,7 +2,7 @@
 import XCTest
 
 final class CompilerProtocolInitRuleTests: SwiftLintTestCase {
-    private let ruleID = CompilerProtocolInitRule.description.identifier
+    private let ruleID = CompilerProtocolInitRule.identifier
 
     func testViolationMessageForExpressibleByIntegerLiteral() throws {
         let config = try XCTUnwrap(makeConfig(nil, ruleID))

--- a/Tests/SwiftLintFrameworkTests/ComputedAccessorsOrderRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ComputedAccessorsOrderRuleTests.swift
@@ -120,7 +120,7 @@ final class ComputedAccessorsOrderRuleTests: SwiftLintTestCase {
     }
 
     private func ruleViolations(_ example: Example, ruleConfiguration: Any? = nil) -> [StyleViolation] {
-        guard let config = makeConfig(ruleConfiguration, ComputedAccessorsOrderRule.description.identifier) else {
+        guard let config = makeConfig(ruleConfiguration, ComputedAccessorsOrderRule.identifier) else {
             return []
         }
 

--- a/Tests/SwiftLintFrameworkTests/ConfigurationAliasesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationAliasesTests.swift
@@ -28,7 +28,7 @@ final class ConfigurationAliasesTests: SwiftLintTestCase {
         // swiftlint:disable:next force_try
         let configuration = try! Configuration(dict: ["only_rules": ["mock"]], ruleList: testRuleList)
         let configuredIdentifiers = configuration.rules.map {
-            type(of: $0).description.identifier
+            type(of: $0).identifier
         }
         XCTAssertEqual(configuredIdentifiers, ["severity_level_mock"])
     }

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests+MultipleConfigs.swift
@@ -55,8 +55,8 @@ extension ConfigurationTests {
             rulesMode: .defaultConfiguration(
                 disabled: [],
                 optIn: [
-                    ForceTryRule.description.identifier,
-                    ForceCastRule.description.identifier,
+                    ForceTryRule.identifier,
+                    ForceCastRule.identifier,
                 ]
             )
         )
@@ -78,7 +78,7 @@ extension ConfigurationTests {
     }
 
     func testOnlyRuleMerging() {
-        let ruleIdentifier = TodoRule.description.identifier
+        let ruleIdentifier = TodoRule.identifier
         let onlyRuleConfiguration = Configuration.onlyRuleConfiguration(ruleIdentifier)
 
         let emptyDefaultConfiguration = Configuration.emptyDefaultConfiguration()
@@ -90,7 +90,7 @@ extension ConfigurationTests {
         let mergedConfiguration2 = onlyRuleConfiguration.merged(withChild: disabledDefaultConfiguration)
         XCTAssertTrue(mergedConfiguration2.rules.isEmpty)
 
-        let enabledOnlyConfiguration = Configuration.enabledOnlyConfiguration(ForceTryRule.description.identifier)
+        let enabledOnlyConfiguration = Configuration.enabledOnlyConfiguration(ForceTryRule.identifier)
         let mergedConfiguration3 = onlyRuleConfiguration.merged(withChild: enabledOnlyConfiguration)
         XCTAssertEqual(mergedConfiguration3.rules.count, 1)
         XCTAssertTrue(mergedConfiguration3.rules[0] is TodoRule)
@@ -362,7 +362,7 @@ extension ConfigurationTests {
         XCTAssertEqual(testCases.unique.count, 4 * 4)
         let ruleType = ImplicitReturnRule.self
         XCTAssertTrue((ruleType as Any) is any OptInRule.Type)
-        let ruleIdentifier = ruleType.description.identifier
+        let ruleIdentifier = ruleType.identifier
         for testCase in testCases {
             let parentConfiguration = Configuration(rulesMode: .defaultConfiguration(
                 disabled: testCase.disabledInParent ? [ruleIdentifier] : [],
@@ -396,7 +396,7 @@ extension ConfigurationTests {
         XCTAssertEqual(testCases.unique.count, 2 * 2)
         let ruleType = BlanketDisableCommandRule.self
         XCTAssertFalse(ruleType is any OptInRule.Type)
-        let ruleIdentifier = ruleType.description.identifier
+        let ruleIdentifier = ruleType.identifier
         for testCase in testCases {
             let parentConfiguration = Configuration(
                 rulesMode: .defaultConfiguration(disabled: testCase.disabledInParent ? [ruleIdentifier] : [], optIn: [])
@@ -428,7 +428,7 @@ extension ConfigurationTests {
         XCTAssertEqual(testCases.unique.count, 2 * 2)
         let ruleType = ImplicitReturnRule.self
         XCTAssertTrue((ruleType as Any) is any OptInRule.Type)
-        let ruleIdentifier = ruleType.description.identifier
+        let ruleIdentifier = ruleType.identifier
         let parentConfiguration = Configuration(rulesMode: .onlyConfiguration([ruleIdentifier]))
         for testCase in testCases {
             let childConfiguration = Configuration(rulesMode: .defaultConfiguration(
@@ -635,8 +635,8 @@ extension ConfigurationTests {
         )
 
         XCTAssertEqual(
-            configuration1.rules.map { type(of: $0).description.identifier },
-            configuration2.rules.map { type(of: $0).description.identifier }
+            configuration1.rules.map { type(of: $0).identifier },
+            configuration2.rules.map { type(of: $0).identifier }
         )
 
         XCTAssertEqual(

--- a/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ConfigurationTests.swift
@@ -116,7 +116,7 @@ final class ConfigurationTests: SwiftLintTestCase {
 
         let config = try Configuration(dict: ["only_rules": only])
         let configuredIdentifiers = config.rules.map {
-            type(of: $0).description.identifier
+            type(of: $0).identifier
         }.sorted()
         XCTAssertEqual(only, configuredIdentifiers)
     }
@@ -178,7 +178,7 @@ final class ConfigurationTests: SwiftLintTestCase {
         let expectedIdentifiers = Set(RuleRegistry.shared.list.list.keys
             .filter({ !(["nesting", "todo"] + optInRules).contains($0) }))
         let configuredIdentifiers = Set(disabledConfig.rules.map {
-            type(of: $0).description.identifier
+            type(of: $0).identifier
         })
         XCTAssertEqual(expectedIdentifiers, configuredIdentifiers)
     }
@@ -205,7 +205,7 @@ final class ConfigurationTests: SwiftLintTestCase {
 
         let duplicateConfig2 = try? Configuration(dict: ["opt_in_rules": [optInRules.first!, optInRules.first!]])
         XCTAssertEqual(
-            duplicateConfig2?.rules.filter { type(of: $0).description.identifier == optInRules.first! }.count, 1,
+            duplicateConfig2?.rules.filter { type(of: $0).identifier == optInRules.first! }.count, 1,
             "duplicate rules should be removed when initializing Configuration"
         )
 
@@ -435,14 +435,14 @@ final class ConfigurationTests: SwiftLintTestCase {
 
     func testConfiguresCorrectlyFromDict() throws {
         let ruleConfiguration = [1, 2]
-        let config = [RuleWithLevelsMock.description.identifier: ruleConfiguration]
+        let config = [RuleWithLevelsMock.identifier: ruleConfiguration]
         let rules = try testRuleList.allRulesWrapped(configurationDict: config).map(\.rule)
         // swiftlint:disable:next xct_specific_matcher
         XCTAssertTrue(rules == [try RuleWithLevelsMock(configuration: ruleConfiguration)])
     }
 
     func testConfigureFallsBackCorrectly() throws {
-        let config = [RuleWithLevelsMock.description.identifier: ["a", "b"]]
+        let config = [RuleWithLevelsMock.identifier: ["a", "b"]]
         let rules = try testRuleList.allRulesWrapped(configurationDict: config).map(\.rule)
         // swiftlint:disable:next xct_specific_matcher
         XCTAssertTrue(rules == [RuleWithLevelsMock()])

--- a/Tests/SwiftLintFrameworkTests/ContainsOverFirstNotNilRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ContainsOverFirstNotNilRuleTests.swift
@@ -21,7 +21,7 @@ final class ContainsOverFirstNotNilRuleTests: SwiftLintTestCase {
     // MARK: - Private
 
     private func violations(_ example: Example, config: Any? = nil) -> [StyleViolation] {
-        guard let config = makeConfig(config, ContainsOverFirstNotNilRule.description.identifier) else {
+        guard let config = makeConfig(config, ContainsOverFirstNotNilRule.identifier) else {
             return []
         }
 

--- a/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CustomRulesTests.swift
@@ -66,7 +66,7 @@ final class CustomRulesTests: SwiftLintTestCase {
     func testCustomRuleConfigurationThrows() {
         let config = 17
         var customRulesConfig = CustomRulesConfiguration()
-        checkError(Issue.invalidConfiguration(ruleID: CustomRules.description.identifier)) {
+        checkError(Issue.invalidConfiguration(ruleID: CustomRules.identifier)) {
             try customRulesConfig.apply(configuration: config)
         }
     }
@@ -106,7 +106,7 @@ final class CustomRulesTests: SwiftLintTestCase {
 
         XCTAssertEqual(customRulesConfig.customRuleConfigurations.count, 1)
 
-        let identifier = customRulesConfig.customRuleConfigurations.first?.description.identifier
+        let identifier = customRulesConfig.customRuleConfigurations.first?.identifier
         XCTAssertEqual(identifier, "my_custom_rule")
     }
 
@@ -570,7 +570,7 @@ final class CustomRulesTests: SwiftLintTestCase {
 
 private extension StyleViolation {
     func isSuperfluousDisableCommandViolation(for ruleIdentifier: String) -> Bool {
-        self.ruleIdentifier == SuperfluousDisableCommandRule.description.identifier &&
+        self.ruleIdentifier == SuperfluousDisableCommandRule.identifier &&
             reason.contains("SwiftLint rule '\(ruleIdentifier)' did not trigger a violation")
     }
 }

--- a/Tests/SwiftLintFrameworkTests/CyclomaticComplexityConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/CyclomaticComplexityConfigurationTests.swift
@@ -71,7 +71,7 @@ final class CyclomaticComplexityConfigurationTests: SwiftLintTestCase {
             var configuration = CyclomaticComplexityConfiguration(
                 length: SeverityLevelsConfiguration<CyclomaticComplexityRule>(warning: 100, error: 150)
             )
-            checkError(Issue.invalidConfiguration(ruleID: CyclomaticComplexityRule.description.identifier)) {
+            checkError(Issue.invalidConfiguration(ruleID: CyclomaticComplexityRule.identifier)) {
                 try configuration.apply(configuration: badConfig)
             }
         }

--- a/Tests/SwiftLintFrameworkTests/DeploymentTargetConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/DeploymentTargetConfigurationTests.swift
@@ -139,7 +139,7 @@ final class DeploymentTargetConfigurationTests: SwiftLintTestCase {
 
         for badConfig in badConfigs {
             var configuration = DeploymentTargetConfiguration()
-            checkError(Issue.invalidConfiguration(ruleID: DeploymentTargetRule.description.identifier)) {
+            checkError(Issue.invalidConfiguration(ruleID: DeploymentTargetRule.identifier)) {
                 try configuration.apply(configuration: badConfig)
             }
         }

--- a/Tests/SwiftLintFrameworkTests/DeploymentTargetRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/DeploymentTargetRuleTests.swift
@@ -35,7 +35,7 @@ final class DeploymentTargetRuleTests: SwiftLintTestCase {
     }
 
     private func violations(_ example: Example, config: Any?) -> [StyleViolation] {
-        guard let config = makeConfig(config, DeploymentTargetRule.description.identifier) else {
+        guard let config = makeConfig(config, DeploymentTargetRule.identifier) else {
             return []
         }
 

--- a/Tests/SwiftLintFrameworkTests/ExpiringTodoRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExpiringTodoRuleTests.swift
@@ -191,7 +191,7 @@ final class ExpiringTodoRuleTests: SwiftLintTestCase {
             ]
         }
 
-        return makeConfig(serializedConfig, ExpiringTodoRule.description.identifier)!
+        return makeConfig(serializedConfig, ExpiringTodoRule.identifier)!
     }
 }
 

--- a/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ExplicitTypeInterfaceConfigurationTests.swift
@@ -33,14 +33,14 @@ final class ExplicitTypeInterfaceConfigurationTests: SwiftLintTestCase {
 
     func testInvalidTypeOfCustomConfiguration() {
         var config = ExplicitTypeInterfaceConfiguration()
-        checkError(Issue.invalidConfiguration(ruleID: ExplicitTypeInterfaceRule.description.identifier)) {
+        checkError(Issue.invalidConfiguration(ruleID: ExplicitTypeInterfaceRule.identifier)) {
             try config.apply(configuration: "invalidKey")
         }
     }
 
     func testInvalidTypeOfValueInCustomConfiguration() {
         var config = ExplicitTypeInterfaceConfiguration()
-        checkError(Issue.invalidConfiguration(ruleID: ExplicitTypeInterfaceRule.description.identifier)) {
+        checkError(Issue.invalidConfiguration(ruleID: ExplicitTypeInterfaceRule.identifier)) {
             try config.apply(configuration: ["severity": "foo"])
         }
     }

--- a/Tests/SwiftLintFrameworkTests/FunctionBodyLengthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FunctionBodyLengthRuleTests.swift
@@ -101,7 +101,7 @@ final class FunctionBodyLengthRuleTests: SwiftLintTestCase {
     }
 
     private func violations(_ example: Example, configuration: Any? = nil) -> [StyleViolation] {
-        let config = makeConfig(configuration, FunctionBodyLengthRule.description.identifier)!
+        let config = makeConfig(configuration, FunctionBodyLengthRule.identifier)!
         return SwiftLintFrameworkTests.violations(example, config: config)
     }
 }

--- a/Tests/SwiftLintFrameworkTests/ImplicitGetterRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ImplicitGetterRuleTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 final class ImplicitGetterRuleTests: SwiftLintTestCase {
     func testPropertyReason() throws {
-        let config = try XCTUnwrap(makeConfig(nil, ImplicitGetterRule.description.identifier))
+        let config = try XCTUnwrap(makeConfig(nil, ImplicitGetterRule.identifier))
         let example = Example("""
         class Foo {
             var foo: Int {
@@ -20,7 +20,7 @@ final class ImplicitGetterRuleTests: SwiftLintTestCase {
     }
 
     func testSubscriptReason() throws {
-        let config = try XCTUnwrap(makeConfig(nil, ImplicitGetterRule.description.identifier))
+        let config = try XCTUnwrap(makeConfig(nil, ImplicitGetterRule.identifier))
         let example = Example("""
         class Foo {
             subscript(i: Int) -> Int {

--- a/Tests/SwiftLintFrameworkTests/ImplicitReturnConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ImplicitReturnConfigurationTests.swift
@@ -31,7 +31,7 @@ final class ImplicitReturnConfigurationTests: SwiftLintTestCase {
         var configuration = ImplicitReturnConfiguration()
         let config = ["included": ["foreach"]] as [String: any Sendable]
 
-        checkError(Issue.invalidConfiguration(ruleID: ImplicitReturnRule.description.identifier)) {
+        checkError(Issue.invalidConfiguration(ruleID: ImplicitReturnRule.identifier)) {
             try configuration.apply(configuration: config)
         }
     }

--- a/Tests/SwiftLintFrameworkTests/ImplicitlyUnwrappedOptionalConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ImplicitlyUnwrappedOptionalConfigurationTests.swift
@@ -39,7 +39,7 @@ final class ImplicitlyUnwrappedOptionalConfigurationTests: SwiftLintTestCase {
                 mode: .allExceptIBOutlets
             )
 
-            checkError(Issue.invalidConfiguration(ruleID: ImplicitlyUnwrappedOptionalRule.description.identifier)) {
+            checkError(Issue.invalidConfiguration(ruleID: ImplicitlyUnwrappedOptionalRule.identifier)) {
                 try configuration.apply(configuration: badConfig)
             }
         }

--- a/Tests/SwiftLintFrameworkTests/IndentationWidthRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/IndentationWidthRuleTests.swift
@@ -282,7 +282,7 @@ final class IndentationWidthRuleTests: SwiftLintTestCase {
         configDict["include_compiler_directives"] = includeCompilerDirectives
         configDict["include_multiline_strings"] = includeMultilineStrings
 
-        guard let config = makeConfig(configDict, IndentationWidthRule.description.identifier) else {
+        guard let config = makeConfig(configDict, IndentationWidthRule.identifier) else {
             XCTFail("Unable to create rule configuration.", file: (file), line: line)
             return 0
         }

--- a/Tests/SwiftLintFrameworkTests/LineLengthConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/LineLengthConfigurationTests.swift
@@ -71,7 +71,7 @@ final class LineLengthConfigurationTests: SwiftLintTestCase {
     func testLineLengthConfigurationThrowsOnBadConfig() {
         let config = ["warning": "unknown"]
         var configuration = LineLengthConfiguration(length: severityLevels)
-        checkError(Issue.invalidConfiguration(ruleID: LineLengthRule.description.identifier)) {
+        checkError(Issue.invalidConfiguration(ruleID: LineLengthRule.identifier)) {
             try configuration.apply(configuration: config)
         }
     }
@@ -84,7 +84,7 @@ final class LineLengthConfigurationTests: SwiftLintTestCase {
 
         for badConfig in badConfigs {
             var configuration = LineLengthConfiguration(length: severityLevels)
-            checkError(Issue.invalidConfiguration(ruleID: LineLengthRule.description.identifier)) {
+            checkError(Issue.invalidConfiguration(ruleID: LineLengthRule.identifier)) {
                 try configuration.apply(configuration: badConfig)
             }
         }

--- a/Tests/SwiftLintFrameworkTests/ModifierOrderTests.swift
+++ b/Tests/SwiftLintFrameworkTests/ModifierOrderTests.swift
@@ -383,7 +383,7 @@ final class ModifierOrderTests: SwiftLintTestCase {
     }
 
     func testViolationMessage() {
-        let ruleID = ModifierOrderRule.description.identifier
+        let ruleID = ModifierOrderRule.identifier
         guard let config = makeConfig(["preferred_modifier_order": ["acl", "final"]], ruleID) else {
             XCTFail("Failed to create configuration")
             return

--- a/Tests/SwiftLintFrameworkTests/NameConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/NameConfigurationTests.swift
@@ -67,7 +67,7 @@ final class NameConfigurationTests: SwiftLintTestCase {
                                     minLengthError: 0,
                                     maxLengthWarning: 0,
                                     maxLengthError: 0)
-        checkError(Issue.invalidConfiguration(ruleID: RuleMock.description.identifier)) {
+        checkError(Issue.invalidConfiguration(ruleID: RuleMock.identifier)) {
             try nameConfig.apply(configuration: config)
         }
     }

--- a/Tests/SwiftLintFrameworkTests/NestingRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/NestingRuleTests.swift
@@ -200,7 +200,7 @@ final class NestingRuleTests: SwiftLintTestCase {
         })
 
         let description = RuleDescription(
-            identifier: NestingRule.description.identifier,
+            identifier: NestingRule.identifier,
             name: NestingRule.description.name,
             description: NestingRule.description.description,
             kind: .metrics,
@@ -499,7 +499,7 @@ final class NestingRuleTests: SwiftLintTestCase {
         ])
 
         let description = RuleDescription(
-            identifier: NestingRule.description.identifier,
+            identifier: NestingRule.identifier,
             name: NestingRule.description.name,
             description: NestingRule.description.description,
             kind: .metrics,

--- a/Tests/SwiftLintFrameworkTests/NoEmptyBlockConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/NoEmptyBlockConfigurationTests.swift
@@ -31,14 +31,14 @@ final class NoEmptyBlockConfigurationTests: SwiftLintTestCase {
 
     func testInvalidTypeOfCustomConfiguration() {
         var config = NoEmptyBlockConfiguration()
-        checkError(Issue.invalidConfiguration(ruleID: NoEmptyBlockRule.description.identifier)) {
+        checkError(Issue.invalidConfiguration(ruleID: NoEmptyBlockRule.identifier)) {
             try config.apply(configuration: "invalidKey")
         }
     }
 
     func testInvalidTypeOfValueInCustomConfiguration() {
         var config = NoEmptyBlockConfiguration()
-        checkError(Issue.invalidConfiguration(ruleID: NoEmptyBlockRule.description.identifier)) {
+        checkError(Issue.invalidConfiguration(ruleID: NoEmptyBlockRule.identifier)) {
             try config.apply(configuration: ["severity": "foo"])
         }
     }

--- a/Tests/SwiftLintFrameworkTests/RuleConfigurationTests.swift
+++ b/Tests/SwiftLintFrameworkTests/RuleConfigurationTests.swift
@@ -37,7 +37,7 @@ final class RuleConfigurationTests: SwiftLintTestCase {
     func testNestingConfigurationThrowsOnBadConfig() {
         let config = 17
         var nestingConfig = defaultNestingConfiguration
-        checkError(Issue.invalidConfiguration(ruleID: NestingRule.description.identifier)) {
+        checkError(Issue.invalidConfiguration(ruleID: NestingRule.identifier)) {
             try nestingConfig.apply(configuration: config)
         }
     }
@@ -117,7 +117,7 @@ final class RuleConfigurationTests: SwiftLintTestCase {
     func testRegexConfigurationThrows() {
         let config = 17
         var regexConfig = RegexConfiguration<RuleMock>(identifier: "")
-        checkError(Issue.invalidConfiguration(ruleID: RuleMock.description.identifier)) {
+        checkError(Issue.invalidConfiguration(ruleID: RuleMock.identifier)) {
             try regexConfig.apply(configuration: config)
         }
     }
@@ -137,7 +137,7 @@ final class RuleConfigurationTests: SwiftLintTestCase {
         let config = "unknown"
         var configuration = TrailingWhitespaceConfiguration(ignoresEmptyLines: false,
                                                             ignoresComments: true)
-        checkError(Issue.invalidConfiguration(ruleID: TrailingWhitespaceRule.description.identifier)) {
+        checkError(Issue.invalidConfiguration(ruleID: TrailingWhitespaceRule.identifier)) {
             try configuration.apply(configuration: config)
         }
     }
@@ -321,7 +321,7 @@ final class RuleConfigurationTests: SwiftLintTestCase {
         var configuration = ModifierOrderConfiguration()
         let config = ["severity": "warning", "preferred_modifier_order": ["specialize"]]  as [String: any Sendable]
 
-        checkError(Issue.invalidConfiguration(ruleID: ModifierOrderRule.description.identifier)) {
+        checkError(Issue.invalidConfiguration(ruleID: ModifierOrderRule.identifier)) {
             try configuration.apply(configuration: config)
         }
     }
@@ -329,7 +329,7 @@ final class RuleConfigurationTests: SwiftLintTestCase {
     func testModifierOrderConfigurationThrowsOnNonModifiableGroup() {
         var configuration = ModifierOrderConfiguration()
         let config = ["severity": "warning", "preferred_modifier_order": ["atPrefixed"]]  as [String: any Sendable]
-        checkError(Issue.invalidConfiguration(ruleID: ModifierOrderRule.description.identifier)) {
+        checkError(Issue.invalidConfiguration(ruleID: ModifierOrderRule.identifier)) {
             try configuration.apply(configuration: config)
         }
     }

--- a/Tests/SwiftLintFrameworkTests/TodoRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TodoRuleTests.swift
@@ -41,7 +41,7 @@ final class TodoRuleTests: SwiftLintTestCase {
     }
 
     private func violations(_ example: Example, config: Any? = nil) -> [StyleViolation] {
-        let config = makeConfig(config, TodoRule.description.identifier)!
+        let config = makeConfig(config, TodoRule.identifier)!
         return SwiftLintFrameworkTests.violations(example, config: config)
     }
 }

--- a/Tests/SwiftLintFrameworkTests/TrailingCommaRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/TrailingCommaRuleTests.swift
@@ -69,7 +69,7 @@ final class TrailingCommaRuleTests: SwiftLintTestCase {
     }
 
     private func trailingCommaViolations(_ example: Example, ruleConfiguration: Any? = nil) -> [StyleViolation] {
-        let config = makeConfig(ruleConfiguration, TrailingCommaRule.description.identifier)!
+        let config = makeConfig(ruleConfiguration, TrailingCommaRule.identifier)!
         return violations(example, config: config)
     }
 }

--- a/Tests/SwiftLintFrameworkTests/VerticalWhitespaceRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/VerticalWhitespaceRuleTests.swift
@@ -2,7 +2,7 @@
 import XCTest
 
 final class VerticalWhitespaceRuleTests: SwiftLintTestCase {
-    private let ruleID = VerticalWhitespaceRule.description.identifier
+    private let ruleID = VerticalWhitespaceRule.identifier
 
     func testAttributesWithMaxEmptyLines() {
         // Test with custom `max_empty_lines`

--- a/Tests/SwiftLintFrameworkTests/XCTSpecificMatcherRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/XCTSpecificMatcherRuleTests.swift
@@ -181,7 +181,7 @@ final class XCTSpecificMatcherRuleTests: SwiftLintTestCase {
     }
 
     private func violations(_ example: Example) -> [StyleViolation] {
-        guard let config = makeConfig(nil, XCTSpecificMatcherRule.description.identifier) else { return [] }
+        guard let config = makeConfig(nil, XCTSpecificMatcherRule.identifier) else { return [] }
         return SwiftLintFrameworkTests.violations(example, config: config)
     }
 

--- a/Tests/SwiftLintTestHelpers/TestHelpers.swift
+++ b/Tests/SwiftLintTestHelpers/TestHelpers.swift
@@ -272,7 +272,7 @@ private extension String {
 public func makeConfig(_ ruleConfiguration: Any?,
                        _ identifier: String,
                        skipDisableCommandTests: Bool = false) -> Configuration? {
-    let superfluousDisableCommandRuleIdentifier = SuperfluousDisableCommandRule.description.identifier
+    let superfluousDisableCommandRuleIdentifier = SuperfluousDisableCommandRule.identifier
     let identifiers: Set<String> = skipDisableCommandTests ? [identifier]
         : [identifier, superfluousDisableCommandRuleIdentifier]
 
@@ -300,7 +300,7 @@ private func testCorrection(_ correction: (Example, Example),
     var config = configuration
     if let correctionConfiguration = correction.0.configuration,
         case let .onlyConfiguration(onlyRules) = configuration.rulesMode,
-        let ruleToConfigure = (onlyRules.first { $0 != SuperfluousDisableCommandRule.description.identifier }),
+        let ruleToConfigure = (onlyRules.first { $0 != SuperfluousDisableCommandRule.identifier }),
         case let configDict: [_: any Sendable] = ["only_rules": onlyRules, ruleToConfigure: correctionConfiguration],
         let typedConfiguration = try? Configuration(dict: configDict) {
         config = configuration.merged(withChild: typedConfiguration, rootDirectory: configuration.rootDirectory)
@@ -425,7 +425,7 @@ public extension XCTestCase {
 
             for trigger in disabledTriggers {
                 let violationsPartitionedByType = makeViolations(trigger)
-                    .partitioned { $0.ruleIdentifier == SuperfluousDisableCommandRule.description.identifier }
+                    .partitioned { $0.ruleIdentifier == SuperfluousDisableCommandRule.identifier }
 
                 XCTAssert(violationsPartitionedByType.first.isEmpty,
                           "Violation(s) still triggered although rule was disabled",


### PR DESCRIPTION

```
public extension Rule {
    /// The rule's unique identifier which is the same as `Rule.identifier`.
    static var identifier: String { description.identifier }
}
```

was defined a while ago, but only used in a few places. This PR replaces all occurrences of `Rule.description.identifier` with `Rule.identifier`
