### PR TITLE
RedundantTypeAnnotation: add 'ignore_type_interfaces' option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@
   command line option.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#5801](https://github.com/realm/SwiftLint/issues/5801)
+* The `redundant_type_annotation` rule gains a new option,
+  `ignore_type_interfaces`, that skips enforcement on members in a
+  type declaration (like a `struct`). This helps the rule coexist with
+  the `explicit_type_interface` rule that requires such redundancy.
+  [jaredgrubb](https://github.com/jaredgrubb)
+  [#3750](https://github.com/realm/SwiftLint/issues/3750)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,11 @@
   command line option.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#5801](https://github.com/realm/SwiftLint/issues/5801)
+
 * The `redundant_type_annotation` rule gains a new option,
-  `ignore_type_interfaces`, that skips enforcement on members in a
+  `ignore_properties`, that skips enforcement on members in a
   type declaration (like a `struct`). This helps the rule coexist with
-  the `explicit_type_interface` rule that requires such redundancy.
+  the `explicit_type_interface` rule that requires such redundancy.  
   [jaredgrubb](https://github.com/jaredgrubb)
   [#3750](https://github.com/realm/SwiftLint/issues/3750)
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -62,7 +62,7 @@ struct RedundantTypeAnnotationRule: OptInRule, SwiftSyntaxCorrectableRule {
                 var url: URL = URL()
                 let myVar: Int? = 0, s: String = ""
             }
-            """, configuration: ["ignore_type_interfaces": true]),
+            """, configuration: ["ignore_properties": true]),
         ],
         triggeringExamples: [
             Example("var url↓:URL=URL()"),
@@ -100,7 +100,7 @@ struct RedundantTypeAnnotationRule: OptInRule, SwiftSyntaxCorrectableRule {
                 let myVar↓: Int = Int(5)
               }
             }
-            """, configuration: ["ignore_type_interfaces": true]),
+            """, configuration: ["ignore_properties": true]),
             Example("let a↓: [Int] = [Int]()"),
             Example("let a↓: A.B = A.B()"),
             Example("""
@@ -280,11 +280,7 @@ extension RedundantTypeAnnotationConfiguration {
         if ignoreAttributes.contains(where: { varDecl.attributes.contains(attributeNamed: $0) }) {
             return true
         }
-        if ignoreTypeInterfaces,
-           let parentNode = varDecl.parent,
-           parentNode.as(CodeBlockItemSyntax.self) == nil {
-            return true
-        }
-        return false
+
+        return ignoreProperties && varDecl.parent?.is(MemberBlockItemSyntax.self) == true
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -57,6 +57,12 @@ struct RedundantTypeAnnotationRule: OptInRule, SwiftSyntaxCorrectableRule {
             Example("var dbl: Double = 0.0"),
             Example("var int: Int = 0"),
             Example("var str: String = \"str\""),
+            Example("""
+            struct Foo {
+                var url: URL = URL()
+                let myVar: Int? = 0, s: String = ""
+            }
+            """, configuration: ["ignore_type_interfaces": true]),
         ],
         triggeringExamples: [
             Example("var url↓:URL=URL()"),
@@ -88,6 +94,13 @@ struct RedundantTypeAnnotationRule: OptInRule, SwiftSyntaxCorrectableRule {
               }
             }
             """),
+            Example("""
+            class ViewController: UIViewController {
+              func someMethod() {
+                let myVar↓: Int = Int(5)
+              }
+            }
+            """, configuration: ["ignore_type_interfaces": true]),
             Example("let a↓: [Int] = [Int]()"),
             Example("let a↓: A.B = A.B()"),
             Example("""
@@ -183,7 +196,7 @@ private extension RedundantTypeAnnotationRule {
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: PatternBindingSyntax) {
             if let varDecl = node.parent?.parent?.as(VariableDeclSyntax.self),
-               configuration.ignoreAttributes.allSatisfy({ !varDecl.attributes.contains(attributeNamed: $0) }),
+               !configuration.shouldSkipRuleCheck(for: varDecl),
                let typeAnnotation = node.typeAnnotation,
                let initializer = node.initializer?.value {
                 collectViolation(forType: typeAnnotation, withInitializer: initializer)
@@ -259,5 +272,19 @@ private extension SyntaxKind {
         default:
             nil
         }
+    }
+}
+
+extension RedundantTypeAnnotationConfiguration {
+    func shouldSkipRuleCheck(for varDecl: VariableDeclSyntax) -> Bool {
+        if ignoreAttributes.contains(where: { varDecl.attributes.contains(attributeNamed: $0) }) {
+            return true
+        }
+        if ignoreTypeInterfaces,
+           let parentNode = varDecl.parent,
+           parentNode.as(CodeBlockItemSyntax.self) == nil {
+            return true
+        }
+        return false
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/RedundantTypeAnnotationConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/RedundantTypeAnnotationConfiguration.swift
@@ -8,8 +8,8 @@ struct RedundantTypeAnnotationConfiguration: SeverityBasedRuleConfiguration {
     var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "ignore_attributes")
     var ignoreAttributes = Set<String>(["IBInspectable"])
-    @ConfigurationElement(key: "ignore_type_interfaces")
-    private(set) var ignoreTypeInterfaces = false
+    @ConfigurationElement(key: "ignore_properties")
+    private(set) var ignoreProperties = false
     @ConfigurationElement(key: "consider_default_literal_types_redundant")
     private(set) var considerDefaultLiteralTypesRedundant = false
 }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/RedundantTypeAnnotationConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/RedundantTypeAnnotationConfiguration.swift
@@ -8,6 +8,8 @@ struct RedundantTypeAnnotationConfiguration: SeverityBasedRuleConfiguration {
     var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "ignore_attributes")
     var ignoreAttributes = Set<String>(["IBInspectable"])
+    @ConfigurationElement(key: "ignore_type_interfaces")
+    private(set) var ignoreTypeInterfaces = false
     @ConfigurationElement(key: "consider_default_literal_types_redundant")
     private(set) var considerDefaultLiteralTypesRedundant = false
 }

--- a/Tests/IntegrationTests/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/default_rule_configurations.yml
@@ -473,7 +473,7 @@ redundant_string_enum_value:
 redundant_type_annotation:
   severity: warning
   ignore_attributes: ["IBInspectable"]
-  ignore_type_interfaces: false
+  ignore_properties: false
   consider_default_literal_types_redundant: false
 redundant_void_return:
   severity: warning

--- a/Tests/IntegrationTests/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/default_rule_configurations.yml
@@ -473,6 +473,7 @@ redundant_string_enum_value:
 redundant_type_annotation:
   severity: warning
   ignore_attributes: ["IBInspectable"]
+  ignore_type_interfaces: false
   consider_default_literal_types_redundant: false
 redundant_void_return:
   severity: warning


### PR DESCRIPTION
The `redundant_type_annotation` and `explicit_type_interface` rules conflict. For users that want to have an explicit type interface, but still be able to write simple code inside the bodies of functions, I want to add an option to `redundant_type_annotation` that has it ignore "type interfaces".

For example, this allows:
```
struct Foo {
    var bar: Bar = Bar() // OK: ignore this! I want explicit types on interfaces.
    func baz() {
       let bar: Bar = Bar() // WARN: redundant_type_annotation kicks in here though.
    }
}
```

I suggest that this addresses the complaint made in Issue #3750.