### PR TITLE
Update `file_name` rule to match fully-qualified names of nested types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@
 
 * Fixes `file_name` rule to match fully-qualified names of nested types.
   Additionally adds a `require_fully_qualified_names` boolean option to enforce 
-  that file names match nested types only using their fully-qualified name.
+  that file names match nested types only using their fully-qualified name.  
   [fraioli](https://github.com/fraioli)
   [#5840](https://github.com/realm/SwiftLint/issues/5840)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,12 @@
   [Martin Redington](https://github.com/mildm8nnered)
   [#5711](https://github.com/realm/SwiftLint/issues/5711)
 
+* Fixes `file_name` rule to match fully-qualified names of nested types.
+  Additionally adds a `fully_qualified` boolean option to enforce that
+  file names match nested types only using their fully-qualified name.
+  [fraioli](https://github.com/fraioli)
+  [#issue_number](https://github.com/realm/SwiftLint/issues/issue_number)
+
 ## 0.57.0: Squeaky Clean Cycle
 
 #### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,10 +64,10 @@
   [#5711](https://github.com/realm/SwiftLint/issues/5711)
 
 * Fixes `file_name` rule to match fully-qualified names of nested types.
-  Additionally adds a `fully_qualified` boolean option to enforce that
-  file names match nested types only using their fully-qualified name.
+  Additionally adds a `require_fully_qualified_names` boolean option to enforce 
+  that file names match nested types only using their fully-qualified name.
   [fraioli](https://github.com/fraioli)
-  [#issue_number](https://github.com/realm/SwiftLint/issues/issue_number)
+  [#5840](https://github.com/realm/SwiftLint/issues/5840)
 
 ## 0.57.0: Squeaky Clean Cycle
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileNameConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileNameConfiguration.swift
@@ -14,6 +14,6 @@ struct FileNameConfiguration: SeverityBasedRuleConfiguration {
     private(set) var suffixPattern = "\\+.*"
     @ConfigurationElement(key: "nested_type_separator")
     private(set) var nestedTypeSeparator = "."
-    @ConfigurationElement(key: "fully_qualified")
-    private(set) var fullyQualified = false
+    @ConfigurationElement(key: "require_fully_qualified_names")
+    private(set) var requireFullyQualifiedNames = false
 }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileNameConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FileNameConfiguration.swift
@@ -14,4 +14,6 @@ struct FileNameConfiguration: SeverityBasedRuleConfiguration {
     private(set) var suffixPattern = "\\+.*"
     @ConfigurationElement(key: "nested_type_separator")
     private(set) var nestedTypeSeparator = "."
+    @ConfigurationElement(key: "fully_qualified")
+    private(set) var fullyQualified = false
 }

--- a/Tests/IntegrationTests/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/default_rule_configurations.yml
@@ -177,6 +177,7 @@ file_name:
   prefix_pattern: ""
   suffix_pattern: "\+.*"
   nested_type_separator: "."
+  fully_qualified: false
 file_name_no_space:
   severity: warning
   excluded: []

--- a/Tests/IntegrationTests/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/default_rule_configurations.yml
@@ -177,7 +177,7 @@ file_name:
   prefix_pattern: ""
   suffix_pattern: "\+.*"
   nested_type_separator: "."
-  fully_qualified: false
+  require_fully_qualified_names: false
 file_name_no_space:
   severity: warning
   excluded: []

--- a/Tests/SwiftLintFrameworkTests/FileNameRuleTests.swift
+++ b/Tests/SwiftLintFrameworkTests/FileNameRuleTests.swift
@@ -9,7 +9,7 @@ final class FileNameRuleTests: SwiftLintTestCase {
                           prefixPattern: String? = nil,
                           suffixPattern: String? = nil,
                           nestedTypeSeparator: String? = nil,
-                          fullyQualified: Bool = false) throws -> [StyleViolation] {
+                          requireFullyQualifiedNames: Bool = false) throws -> [StyleViolation] {
         let file = SwiftLintFile(path: fixturesDirectory.stringByAppendingPathComponent(fileName))!
 
         var configuration = [String: Any]()
@@ -26,8 +26,8 @@ final class FileNameRuleTests: SwiftLintTestCase {
         if let nestedTypeSeparator {
             configuration["nested_type_separator"] = nestedTypeSeparator
         }
-        if fullyQualified {
-            configuration["fully_qualified"] = fullyQualified
+        if requireFullyQualifiedNames {
+            configuration["require_fully_qualified_names"] = requireFullyQualifiedNames
         }
 
         let rule = try FileNameRule(configuration: configuration)
@@ -72,7 +72,7 @@ final class FileNameRuleTests: SwiftLintTestCase {
     }
 
     func testNestedTypeNotFullyQualifiedDoesTriggerWithOverride() {
-        XCTAssert(try !validate(fileName: "MyType.swift", fullyQualified: true).isEmpty)
+        XCTAssert(try validate(fileName: "MyType.swift", requireFullyQualifiedNames: true).isNotEmpty)
     }
 
     func testNestedTypeSeparatorDoesntTrigger() {
@@ -81,8 +81,8 @@ final class FileNameRuleTests: SwiftLintTestCase {
     }
 
     func testWrongNestedTypeSeparatorDoesTrigger() {
-        XCTAssert(try !validate(fileName: "Notification__Name+Extension.swift", nestedTypeSeparator: ".").isEmpty)
-        XCTAssert(try !validate(fileName: "NotificationName+Extension.swift", nestedTypeSeparator: "__").isEmpty)
+        XCTAssert(try validate(fileName: "Notification__Name+Extension.swift", nestedTypeSeparator: ".").isNotEmpty)
+        XCTAssert(try validate(fileName: "NotificationName+Extension.swift", nestedTypeSeparator: "__").isNotEmpty)
     }
 
     func testMisspelledNameDoesTrigger() {

--- a/Tests/SwiftLintFrameworkTests/Resources/FileNameRuleFixtures/Multiple.Levels.Deeply.Nested.MyType.swift
+++ b/Tests/SwiftLintFrameworkTests/Resources/FileNameRuleFixtures/Multiple.Levels.Deeply.Nested.MyType.swift
@@ -1,0 +1,9 @@
+extension Multiple {
+    enum Levels {
+        class Deeply {
+            struct Nested {
+                actor MyType {}
+            }
+        }
+    }
+}

--- a/Tests/SwiftLintFrameworkTests/Resources/FileNameRuleFixtures/MyType.swift
+++ b/Tests/SwiftLintFrameworkTests/Resources/FileNameRuleFixtures/MyType.swift
@@ -1,0 +1,3 @@
+enum Nested {
+    struct MyType {}
+}

--- a/Tests/SwiftLintFrameworkTests/Resources/FileNameRuleFixtures/Nested.MyType.swift
+++ b/Tests/SwiftLintFrameworkTests/Resources/FileNameRuleFixtures/Nested.MyType.swift
@@ -1,0 +1,4 @@
+enum Nested {
+    struct MyType {
+    }
+}


### PR DESCRIPTION
This PR is aimed to address Issue #5840. It does the following:

1. Allows the `file_name` rule to match nested types when using fully-qualified names, meaning naming the following file `Nested.MyType.swift` is no longer a violation:

```
// Nested.MyType.swift

enum Nested {
    struct MyType {
    }
}
```

2. Introduces a new option `fully_qualified` to have the `file_name` rule enforce using fully-qualified names, meaning naming the above file `MyType.swift` instead of `Nested.MyType.swift` would become a violation where it wasn't before (naming the file `Nested.swift` would still not be a violation).