### PR TITLE
Allow inherited isolation parameter to be first in function signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@
   [jaredgrubb](https://github.com/jaredgrubb)
   [#3750](https://github.com/realm/SwiftLint/issues/3750)
 
+* Allow inherited isolation parameter to be first in function signatures
+  depending on the new option `ignore_first_isolation_inheritance_parameter`
+  which is `true` by default.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#5793](https://github.com/realm/SwiftLint/issues/5793)
+
 #### Bug Fixes
 
 * Run command plugin in whole package if no targets are defined in the

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FunctionDefaultParameterAtEndConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FunctionDefaultParameterAtEndConfiguration.swift
@@ -1,0 +1,13 @@
+import SwiftLintCore
+
+@AutoConfigParser
+struct FunctionDefaultParameterAtEndConfiguration: SeverityBasedRuleConfiguration {
+    // swiftlint:disable:previous type_name
+
+    typealias Parent = FunctionDefaultParameterAtEndRule
+
+    @ConfigurationElement(key: "severity")
+    private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement(key: "ignore_first_isolation_inheritance_parameter")
+    private(set) var ignoreFirstIsolationInheritanceParameter = true
+}

--- a/Tests/IntegrationTests/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/default_rule_configurations.yml
@@ -204,6 +204,7 @@ function_body_length:
   error: 100
 function_default_parameter_at_end:
   severity: warning
+  ignore_first_isolation_inheritance_parameter: true
 function_parameter_count:
   warning: 5
   error: 8


### PR DESCRIPTION
Fixes #5793.