### PR TITLE
Disable `prefer_key_path` temporarily

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -38,6 +38,7 @@ disabled_rules:
   - no_grouping_extension
   - no_magic_numbers
   - one_declaration_per_file
+  - prefer_key_path # Re-enable once we are on Swift 6.
   - prefer_nimble
   - prefixed_toplevel_constant
   - required_deinit
@@ -79,8 +80,6 @@ identifier_name:
 large_tuple: 3
 number_separator:
   minimum_length: 5
-prefer_key_path:
-  restrict_to_standard_functions: false
 redundant_type_annotation:
   consider_default_literal_types_redundant: true
 single_test_class: *unit_test_configuration


### PR DESCRIPTION
Re-enable once we require Swift 6.