### PR TITLE
Support for running command plugin as CLI on filepaths provided as arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
   
 * Support for running command plugin as CLI on filepaths provided as arguments.  
   [DanSkeel](https://github.com/DanSkeel)
+  [#5879](https://github.com/realm/SwiftLint/pull/5879)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@
 
 * Support replacing identity expressions with `\.self` in `prefer_key_path` rule from Swift 6 on.  
   [SimplyDanny](https://github.com/SimplyDanny)
+  
+* Support for running command plugin as CLI on filepaths provided as arguments.  
+  [DanSkeel](https://github.com/DanSkeel)
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,9 +26,8 @@
 * Support replacing identity expressions with `\.self` in `prefer_key_path` rule from Swift 6 on.  
   [SimplyDanny](https://github.com/SimplyDanny)
   
-* Support for running command plugin as CLI on filepaths provided as arguments.  
+* Support linting only provided file paths with command plugins.  
   [DanSkeel](https://github.com/DanSkeel)
-  [#5879](https://github.com/realm/SwiftLint/pull/5879)
 
 #### Bug Fixes
 

--- a/Plugins/SwiftLintCommandPlugin/SwiftLintCommandPlugin.swift
+++ b/Plugins/SwiftLintCommandPlugin/SwiftLintCommandPlugin.swift
@@ -49,7 +49,7 @@ extension SwiftLintCommandPlugin {
         }
         guard !targetNames.isEmpty else {
             if let pathArgument = remainingArguments.last, FileManager.default.fileExists(atPath: pathArgument) {
-                Diagnostics.remark("No targets provided, paths from remaining arguments will be used")
+                Diagnostics.remark("No targets provided. Files provided in path arguments will be linted.")
                 try lintFiles(in: [], with: context, arguments: remainingArguments)
             } else {
                 try lintFiles(with: context, arguments: remainingArguments)

--- a/Plugins/SwiftLintCommandPlugin/SwiftLintCommandPlugin.swift
+++ b/Plugins/SwiftLintCommandPlugin/SwiftLintCommandPlugin.swift
@@ -42,8 +42,18 @@ extension SwiftLintCommandPlugin {
         var argExtractor = ArgumentExtractor(arguments)
         let targetNames = argExtractor.extractOption(named: "target")
         let remainingArguments = argExtractor.remainingArguments
-        guard !targetNames.isEmpty, commandsNotExpectingPaths.isDisjoint(with: remainingArguments) else {
+
+        if !commandsNotExpectingPaths.isDisjoint(with: remainingArguments) {
             try lintFiles(with: context, arguments: remainingArguments)
+            return
+        }
+        guard !targetNames.isEmpty else {
+            if let pathArgument = remainingArguments.last, FileManager.default.fileExists(atPath: pathArgument) {
+                Diagnostics.remark("No targets provided, paths from remaining arguments will be used")
+                try lintFiles(in: [], with: context, arguments: remainingArguments)
+            } else {
+                try lintFiles(with: context, arguments: remainingArguments)
+            }
             return
         }
         for target in try context.targets(named: targetNames) {


### PR DESCRIPTION
# Why?

There is no way to use SwiftLintCommandPlugin to lint just several given files.

This is can be useful if you develop SPM framework with [SwiftLintPlugins](https://github.com/dshikulin-mwb/SwiftLintPlugins) and want to lint only changed files in pre-commit git-hook without installing swiftlint via Homebrew or Mint.

# Solution

When targets are not provided check if last argument is a path for existing file, and if it is run linting with provided arguments without any additional paths.

Similar PR below was by mistake opened in SwiftLintPlugins and can be deleted.
https://github.com/SimplyDanny/SwiftLintPlugins/pull/1#issue-2470521858
