### PR TITLE
Specify rule properties in attribute

### DIFF
--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/AnonymousArgumentInMultilineClosureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/AnonymousArgumentInMultilineClosureRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct AnonymousArgumentInMultilineClosureRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct AnonymousArgumentInMultilineClosureRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ConvenienceTypeRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ConvenienceTypeRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct ConvenienceTypeRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct ConvenienceTypeRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedAssertRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedAssertRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct DiscouragedAssertRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct DiscouragedAssertRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedNoneNameRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedNoneNameRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct DiscouragedNoneNameRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct DiscouragedNoneNameRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedObjectLiteralRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedObjectLiteralRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct DiscouragedObjectLiteralRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct DiscouragedObjectLiteralRule: Rule {
     var configuration = DiscouragedObjectLiteralConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedOptionalBooleanRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedOptionalBooleanRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct DiscouragedOptionalBooleanRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct DiscouragedOptionalBooleanRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedOptionalCollectionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DiscouragedOptionalCollectionRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct DiscouragedOptionalCollectionRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct DiscouragedOptionalCollectionRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitACLRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitACLRule.swift
@@ -1,8 +1,8 @@
 import SwiftLintCore
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct ExplicitACLRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct ExplicitACLRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitEnumRawValueRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitEnumRawValueRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct ExplicitEnumRawValueRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct ExplicitEnumRawValueRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitInitRule.swift
@@ -1,8 +1,8 @@
 import SwiftSyntax
 import SwiftSyntaxBuilder
 
-@SwiftSyntaxRule(explicitRewriter: true)
-struct ExplicitInitRule: OptInRule {
+@SwiftSyntaxRule(explicitRewriter: true, optIn: true)
+struct ExplicitInitRule: Rule {
     var configuration = ExplicitInitConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitTopLevelACLRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitTopLevelACLRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct ExplicitTopLevelACLRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct ExplicitTopLevelACLRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitTypeInterfaceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitTypeInterfaceRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct ExplicitTypeInterfaceRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct ExplicitTypeInterfaceRule: Rule {
     var configuration = ExplicitTypeInterfaceConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExtensionAccessModifierRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExtensionAccessModifierRule.swift
@@ -1,8 +1,8 @@
 import SwiftLintCore
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct ExtensionAccessModifierRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct ExtensionAccessModifierRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/FallthroughRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/FallthroughRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct FallthroughRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct FallthroughRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/FatalErrorMessageRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/FatalErrorMessageRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct FatalErrorMessageRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct FatalErrorMessageRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ForceUnwrappingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ForceUnwrappingRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct ForceUnwrappingRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct ForceUnwrappingRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/FunctionDefaultParameterAtEndRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/FunctionDefaultParameterAtEndRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct FunctionDefaultParameterAtEndRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct FunctionDefaultParameterAtEndRule: Rule {
     var configuration = FunctionDefaultParameterAtEndConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ImplicitlyUnwrappedOptionalRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ImplicitlyUnwrappedOptionalRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct ImplicitlyUnwrappedOptionalRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct ImplicitlyUnwrappedOptionalRule: Rule {
     var configuration = ImplicitlyUnwrappedOptionalConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/JoinedDefaultParameterRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/JoinedDefaultParameterRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule(explicitRewriter: true)
-struct JoinedDefaultParameterRule: OptInRule {
+@SwiftSyntaxRule(explicitRewriter: true, optIn: true)
+struct JoinedDefaultParameterRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyMultipleRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyMultipleRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule(foldExpressions: true)
-struct LegacyMultipleRule: OptInRule {
+@SwiftSyntaxRule(foldExpressions: true, optIn: true)
+struct LegacyMultipleRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyObjcTypeRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyObjcTypeRule.swift
@@ -28,8 +28,8 @@ private let legacyObjcTypes = [
     "NSUUID",
 ]
 
-@SwiftSyntaxRule
-struct LegacyObjcTypeRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct LegacyObjcTypeRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NimbleOperatorRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NimbleOperatorRule.swift
@@ -1,8 +1,8 @@
 import SwiftLintCore
 import SwiftSyntax
 
-@SwiftSyntaxRule(explicitRewriter: true)
-struct NimbleOperatorRule: OptInRule {
+@SwiftSyntaxRule(explicitRewriter: true, optIn: true)
+struct NimbleOperatorRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoEmptyBlockRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoEmptyBlockRule.swift
@@ -1,8 +1,8 @@
 import SwiftLintCore
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct NoEmptyBlockRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct NoEmptyBlockRule: Rule {
     var configuration = NoEmptyBlockConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoExtensionAccessModifierRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoExtensionAccessModifierRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct NoExtensionAccessModifierRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct NoExtensionAccessModifierRule: Rule {
     var configuration = SeverityConfiguration<Self>(.error)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoGroupingExtensionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoGroupingExtensionRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct NoGroupingExtensionRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct NoGroupingExtensionRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule(foldExpressions: true)
-struct NoMagicNumbersRule: OptInRule {
+@SwiftSyntaxRule(foldExpressions: true, optIn: true)
+struct NoMagicNumbersRule: Rule {
     var configuration = NoMagicNumbersConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ObjectLiteralRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ObjectLiteralRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct ObjectLiteralRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct ObjectLiteralRule: Rule {
     var configuration = ObjectLiteralConfiguration<Self>()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/OneDeclarationPerFileRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/OneDeclarationPerFileRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct OneDeclarationPerFileRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct OneDeclarationPerFileRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PatternMatchingKeywordsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PatternMatchingKeywordsRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct PatternMatchingKeywordsRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct PatternMatchingKeywordsRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferKeyPathRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferKeyPathRule.swift
@@ -1,8 +1,8 @@
 import SwiftLintCore
 import SwiftSyntax
 
-@SwiftSyntaxRule(explicitRewriter: true)
-struct PreferKeyPathRule: OptInRule {
+@SwiftSyntaxRule(explicitRewriter: true, optIn: true)
+struct PreferKeyPathRule: Rule {
     var configuration = PreferKeyPathConfiguration()
 
     private static let extendedMode = ["restrict_to_standard_functions": false]

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferNimbleRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferNimbleRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct PreferNimbleRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct PreferNimbleRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferZeroOverExplicitInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferZeroOverExplicitInitRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule(explicitRewriter: true)
-struct PreferZeroOverExplicitInitRule: OptInRule {
+@SwiftSyntaxRule(explicitRewriter: true, optIn: true)
+struct PreferZeroOverExplicitInitRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PrivateOverFilePrivateRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PrivateOverFilePrivateRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct PrivateOverFilePrivateRule: SwiftSyntaxCorrectableRule {
+@SwiftSyntaxRule(correctable: true)
+struct PrivateOverFilePrivateRule: Rule {
     var configuration = PrivateOverFilePrivateConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantNilCoalescingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantNilCoalescingRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule(explicitRewriter: true)
-struct RedundantNilCoalescingRule: OptInRule {
+@SwiftSyntaxRule(explicitRewriter: true, optIn: true)
+struct RedundantNilCoalescingRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantTypeAnnotationRule.swift
@@ -1,8 +1,8 @@
 import SwiftLintCore
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct RedundantTypeAnnotationRule: OptInRule, SwiftSyntaxCorrectableRule {
+@SwiftSyntaxRule(correctable: true, optIn: true)
+struct RedundantTypeAnnotationRule: Rule {
     var configuration = RedundantTypeAnnotationConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ReturnValueFromVoidFunctionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ReturnValueFromVoidFunctionRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule(explicitRewriter: true)
-struct ReturnValueFromVoidFunctionRule: OptInRule {
+@SwiftSyntaxRule(explicitRewriter: true, optIn: true)
+struct ReturnValueFromVoidFunctionRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ShorthandOptionalBindingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ShorthandOptionalBindingRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule(explicitRewriter: true)
-struct ShorthandOptionalBindingRule: OptInRule {
+@SwiftSyntaxRule(explicitRewriter: true, optIn: true)
+struct ShorthandOptionalBindingRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/StaticOperatorRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/StaticOperatorRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct StaticOperatorRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct StaticOperatorRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/StrictFilePrivateRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/StrictFilePrivateRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct StrictFilePrivateRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct StrictFilePrivateRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ToggleBoolRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ToggleBoolRule.swift
@@ -1,8 +1,8 @@
 import SwiftSyntax
 import SwiftSyntaxBuilder
 
-@SwiftSyntaxRule(explicitRewriter: true)
-struct ToggleBoolRule: OptInRule {
+@SwiftSyntaxRule(explicitRewriter: true, optIn: true)
+struct ToggleBoolRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnavailableFunctionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnavailableFunctionRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct UnavailableFunctionRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct UnavailableFunctionRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UntypedErrorInCatchRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UntypedErrorInCatchRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule(explicitRewriter: true)
-struct UntypedErrorInCatchRule: OptInRule {
+@SwiftSyntaxRule(explicitRewriter: true, optIn: true)
+struct UntypedErrorInCatchRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/XCTSpecificMatcherRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/XCTSpecificMatcherRule.swift
@@ -1,8 +1,8 @@
 import SwiftOperators
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct XCTSpecificMatcherRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct XCTSpecificMatcherRule: Rule {
     var configuration = XCTSpecificMatcherConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ArrayInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ArrayInitRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct ArrayInitRule: OptInRule, @unchecked Sendable {
+@SwiftSyntaxRule(optIn: true)
+struct ArrayInitRule: Rule, @unchecked Sendable {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AsyncWithoutAwaitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AsyncWithoutAwaitRule.swift
@@ -1,8 +1,8 @@
 import SwiftLintCore
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct AsyncWithoutAwaitRule: SwiftSyntaxCorrectableRule, OptInRule {
+@SwiftSyntaxRule(correctable: true, optIn: true)
+struct AsyncWithoutAwaitRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/BalancedXCTestLifecycleRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/BalancedXCTestLifecycleRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct BalancedXCTestLifecycleRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct BalancedXCTestLifecycleRule: Rule {
     var configuration = BalancedXCTestLifecycleConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/DiscardedNotificationCenterObserverRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/DiscardedNotificationCenterObserverRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct DiscardedNotificationCenterObserverRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct DiscardedNotificationCenterObserverRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/EmptyXCTestMethodRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/EmptyXCTestMethodRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct EmptyXCTestMethodRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct EmptyXCTestMethodRule: Rule {
     var configuration = EmptyXCTestMethodConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/IBInspectableInExtensionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/IBInspectableInExtensionRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct IBInspectableInExtensionRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct IBInspectableInExtensionRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/IdenticalOperandsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/IdenticalOperandsRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule(foldExpressions: true)
-struct IdenticalOperandsRule: OptInRule {
+@SwiftSyntaxRule(foldExpressions: true, optIn: true)
+struct IdenticalOperandsRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     private static let operators = ["==", "!=", "===", "!==", ">", ">=", "<", "<="]

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/LowerACLThanParentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/LowerACLThanParentRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule(explicitRewriter: true)
-struct LowerACLThanParentRule: OptInRule {
+@SwiftSyntaxRule(explicitRewriter: true, optIn: true)
+struct LowerACLThanParentRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/MarkRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/MarkRule.swift
@@ -2,7 +2,7 @@ import Foundation
 import SwiftSyntax
 
 @SwiftSyntaxRule(explicitRewriter: true)
-struct MarkRule: CorrectableRule {
+struct MarkRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/MissingDocsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/MissingDocsRule.swift
@@ -1,8 +1,8 @@
 import SwiftLintCore
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct MissingDocsRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct MissingDocsRule: Rule {
     var configuration = MissingDocsConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/NSLocalizedStringKeyRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/NSLocalizedStringKeyRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct NSLocalizedStringKeyRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct NSLocalizedStringKeyRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/NSLocalizedStringRequireBundleRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/NSLocalizedStringRequireBundleRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct NSLocalizedStringRequireBundleRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct NSLocalizedStringRequireBundleRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/OverriddenSuperCallRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/OverriddenSuperCallRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct OverriddenSuperCallRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct OverriddenSuperCallRule: Rule {
     var configuration = OverriddenSuperCallConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateActionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateActionRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct PrivateActionRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct PrivateActionRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateOutletRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateOutletRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct PrivateOutletRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct PrivateOutletRule: Rule {
     var configuration = PrivateOutletConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateSubjectRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateSubjectRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct PrivateSubjectRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct PrivateSubjectRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateSwiftUIStatePropertyRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateSwiftUIStatePropertyRule.swift
@@ -10,8 +10,8 @@ import SwiftSyntax
 ///
 /// Declare state and state objects as private to prevent setting them from a memberwise initializer,
 /// which can conflict with the storage management that SwiftUI provides:
-@SwiftSyntaxRule(explicitRewriter: true)
-struct PrivateSwiftUIStatePropertyRule: OptInRule {
+@SwiftSyntaxRule(explicitRewriter: true, optIn: true)
+struct PrivateSwiftUIStatePropertyRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ProhibitedInterfaceBuilderRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ProhibitedInterfaceBuilderRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct ProhibitedInterfaceBuilderRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct ProhibitedInterfaceBuilderRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ProhibitedSuperRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ProhibitedSuperRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct ProhibitedSuperRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct ProhibitedSuperRule: Rule {
     var configuration = ProhibitedSuperConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/QuickDiscouragedFocusedTestRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/QuickDiscouragedFocusedTestRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct QuickDiscouragedFocusedTestRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct QuickDiscouragedFocusedTestRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/QuickDiscouragedPendingTestRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/QuickDiscouragedPendingTestRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct QuickDiscouragedPendingTestRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct QuickDiscouragedPendingTestRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/RawValueForCamelCasedCodableEnumRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/RawValueForCamelCasedCodableEnumRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct RawValueForCamelCasedCodableEnumRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct RawValueForCamelCasedCodableEnumRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/RequiredDeinitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/RequiredDeinitRule.swift
@@ -6,8 +6,8 @@ import SwiftSyntax
 /// of objects and the deinit should print a message or remove its instance from a
 /// list of allocations. Even having an empty deinit method is useful to provide
 /// a place to put a breakpoint when chasing down leaks.
-@SwiftSyntaxRule
-struct RequiredDeinitRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct RequiredDeinitRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/RequiredEnumCaseRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/RequiredEnumCaseRule.swift
@@ -67,8 +67,8 @@ import SwiftSyntax
 ///     case accountCreated
 /// }
 /// ````
-@SwiftSyntaxRule
-struct RequiredEnumCaseRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct RequiredEnumCaseRule: Rule {
     var configuration = RequiredEnumCaseConfiguration()
 
     private static let exampleConfiguration = [

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/StrongIBOutletRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/StrongIBOutletRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule(explicitRewriter: true)
-struct StrongIBOutletRule: OptInRule {
+@SwiftSyntaxRule(explicitRewriter: true, optIn: true)
+struct StrongIBOutletRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/TestCaseAccessibilityRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/TestCaseAccessibilityRule.swift
@@ -1,8 +1,8 @@
 import Foundation
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct TestCaseAccessibilityRule: OptInRule, SubstitutionCorrectableRule {
+@SwiftSyntaxRule(optIn: true)
+struct TestCaseAccessibilityRule: Rule, SubstitutionCorrectableRule {
     var configuration = TestCaseAccessibilityConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnhandledThrowingTaskRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnhandledThrowingTaskRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct UnhandledThrowingTaskRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct UnhandledThrowingTaskRule: Rule {
     var configuration = SeverityConfiguration<Self>(.error)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnownedVariableCaptureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnownedVariableCaptureRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct UnownedVariableCaptureRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct UnownedVariableCaptureRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedParameterRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedParameterRule.swift
@@ -1,8 +1,8 @@
 import SwiftLintCore
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct UnusedParameterRule: SwiftSyntaxCorrectableRule, OptInRule {
+@SwiftSyntaxRule(correctable: true, optIn: true)
+struct UnusedParameterRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/WeakDelegateRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/WeakDelegateRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct WeakDelegateRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct WeakDelegateRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/YodaConditionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/YodaConditionRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct YodaConditionRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct YodaConditionRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/EnumCaseAssociatedValuesLengthRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/EnumCaseAssociatedValuesLengthRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct EnumCaseAssociatedValuesLengthRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct EnumCaseAssociatedValuesLengthRule: Rule {
     var configuration = SeverityLevelsConfiguration<Self>(warning: 5, error: 6)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverFilterCountRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverFilterCountRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct ContainsOverFilterCountRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct ContainsOverFilterCountRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverFilterIsEmptyRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverFilterIsEmptyRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct ContainsOverFilterIsEmptyRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct ContainsOverFilterIsEmptyRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverFirstNotNilRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverFirstNotNilRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule(foldExpressions: true)
-struct ContainsOverFirstNotNilRule: OptInRule {
+@SwiftSyntaxRule(foldExpressions: true, optIn: true)
+struct ContainsOverFirstNotNilRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverRangeNilComparisonRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/ContainsOverRangeNilComparisonRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule(foldExpressions: true)
-struct ContainsOverRangeNilComparisonRule: OptInRule {
+@SwiftSyntaxRule(foldExpressions: true, optIn: true)
+struct ContainsOverRangeNilComparisonRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/EmptyCollectionLiteralRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/EmptyCollectionLiteralRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct EmptyCollectionLiteralRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct EmptyCollectionLiteralRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/EmptyCountRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/EmptyCountRule.swift
@@ -1,8 +1,8 @@
 import SwiftLintCore
 import SwiftSyntax
 
-@SwiftSyntaxRule(foldExpressions: true, explicitRewriter: true)
-struct EmptyCountRule: OptInRule {
+@SwiftSyntaxRule(foldExpressions: true, explicitRewriter: true, optIn: true)
+struct EmptyCountRule: Rule {
     var configuration = EmptyCountConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/EmptyStringRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/EmptyStringRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct EmptyStringRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct EmptyStringRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/FinalTestCaseRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/FinalTestCaseRule.swift
@@ -1,8 +1,8 @@
 import SwiftLintCore
 import SwiftSyntax
 
-@SwiftSyntaxRule(explicitRewriter: true)
-struct FinalTestCaseRule: OptInRule {
+@SwiftSyntaxRule(explicitRewriter: true, optIn: true)
+struct FinalTestCaseRule: Rule {
     var configuration = FinalTestCaseConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/FirstWhereRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/FirstWhereRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct FirstWhereRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct FirstWhereRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/FlatMapOverMapReduceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/FlatMapOverMapReduceRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct FlatMapOverMapReduceRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct FlatMapOverMapReduceRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/LastWhereRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/LastWhereRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct LastWhereRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct LastWhereRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/ReduceIntoRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/ReduceIntoRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct ReduceIntoRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct ReduceIntoRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/SortedFirstLastRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/SortedFirstLastRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct SortedFirstLastRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct SortedFirstLastRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/AttributeNameSpacingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/AttributeNameSpacingRule.swift
@@ -1,8 +1,8 @@
 import SwiftLintCore
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct AttributeNameSpacingRule: SwiftSyntaxCorrectableRule {
+@SwiftSyntaxRule(correctable: true)
+struct AttributeNameSpacingRule: Rule {
     var configuration = SeverityConfiguration<Self>(.error)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct AttributesRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct AttributesRule: Rule {
     var configuration = AttributesConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ClosureSpacingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ClosureSpacingRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule(explicitRewriter: true)
-struct ClosureSpacingRule: OptInRule {
+@SwiftSyntaxRule(explicitRewriter: true, optIn: true)
+struct ClosureSpacingRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/CollectionAlignmentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/CollectionAlignmentRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct CollectionAlignmentRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct CollectionAlignmentRule: Rule {
     var configuration = CollectionAlignmentConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ConditionalReturnsOnNewlineRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ConditionalReturnsOnNewlineRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct ConditionalReturnsOnNewlineRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct ConditionalReturnsOnNewlineRule: Rule {
     var configuration = ConditionalReturnsOnNewlineConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ContrastedOpeningBraceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ContrastedOpeningBraceRule.swift
@@ -1,8 +1,8 @@
 import SwiftLintCore
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct ContrastedOpeningBraceRule: OptInRule, SwiftSyntaxCorrectableRule {
+@SwiftSyntaxRule(correctable: true, optIn: true)
+struct ContrastedOpeningBraceRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/DirectReturnRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/DirectReturnRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule(explicitRewriter: true)
-struct DirectReturnRule: OptInRule {
+@SwiftSyntaxRule(explicitRewriter: true, optIn: true)
+struct DirectReturnRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ImplicitReturnRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ImplicitReturnRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct ImplicitReturnRule: SwiftSyntaxCorrectableRule, OptInRule {
+@SwiftSyntaxRule(correctable: true, optIn: true)
+struct ImplicitReturnRule: Rule {
     var configuration = ImplicitReturnConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/LetVarWhitespaceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/LetVarWhitespaceRule.swift
@@ -1,8 +1,8 @@
 import SwiftLintCore
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct LetVarWhitespaceRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct LetVarWhitespaceRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/MultilineArgumentsBracketsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/MultilineArgumentsBracketsRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct MultilineArgumentsBracketsRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct MultilineArgumentsBracketsRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/MultilineArgumentsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/MultilineArgumentsRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct MultilineArgumentsRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct MultilineArgumentsRule: Rule {
     var configuration = MultilineArgumentsConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/MultilineLiteralBracketsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/MultilineLiteralBracketsRule.swift
@@ -1,8 +1,8 @@
 import Foundation
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct MultilineLiteralBracketsRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct MultilineLiteralBracketsRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/MultilineParametersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/MultilineParametersRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct MultilineParametersRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct MultilineParametersRule: Rule {
     var configuration = MultilineParametersConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/NonOverridableClassDeclarationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/NonOverridableClassDeclarationRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct NonOverridableClassDeclarationRule: SwiftSyntaxCorrectableRule, OptInRule {
+@SwiftSyntaxRule(correctable: true, optIn: true)
+struct NonOverridableClassDeclarationRule: Rule {
     var configuration = NonOverridableClassDeclarationConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/NumberSeparatorRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/NumberSeparatorRule.swift
@@ -1,8 +1,8 @@
 import Foundation
 import SwiftSyntax
 
-@SwiftSyntaxRule(explicitRewriter: true)
-struct NumberSeparatorRule: OptInRule {
+@SwiftSyntaxRule(explicitRewriter: true, optIn: true)
+struct NumberSeparatorRule: Rule {
     var configuration = NumberSeparatorConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/OpeningBraceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/OpeningBraceRule.swift
@@ -1,8 +1,8 @@
 import SwiftLintCore
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct OpeningBraceRule: SwiftSyntaxCorrectableRule {
+@SwiftSyntaxRule(correctable: true)
+struct OpeningBraceRule: Rule {
     var configuration = OpeningBraceConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/OptionalEnumCaseMatchingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/OptionalEnumCaseMatchingRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule(explicitRewriter: true)
-struct OptionalEnumCaseMatchingRule: OptInRule {
+@SwiftSyntaxRule(explicitRewriter: true, optIn: true)
+struct OptionalEnumCaseMatchingRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct PreferSelfInStaticReferencesRule: SwiftSyntaxCorrectableRule, OptInRule {
+@SwiftSyntaxRule(correctable: true, optIn: true)
+struct PreferSelfInStaticReferencesRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfTypeOverTypeOfSelfRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfTypeOverTypeOfSelfRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule(explicitRewriter: true)
-struct PreferSelfTypeOverTypeOfSelfRule: OptInRule {
+@SwiftSyntaxRule(explicitRewriter: true, optIn: true)
+struct PreferSelfTypeOverTypeOfSelfRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/PrefixedTopLevelConstantRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/PrefixedTopLevelConstantRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct PrefixedTopLevelConstantRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct PrefixedTopLevelConstantRule: Rule {
     var configuration = PrefixedTopLevelConstantConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/RedundantSelfInClosureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/RedundantSelfInClosureRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct RedundantSelfInClosureRule: SwiftSyntaxCorrectableRule, OptInRule {
+@SwiftSyntaxRule(correctable: true, optIn: true)
+struct RedundantSelfInClosureRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ReturnArrowWhitespaceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ReturnArrowWhitespaceRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct ReturnArrowWhitespaceRule: SwiftSyntaxCorrectableRule {
+@SwiftSyntaxRule(correctable: true)
+struct ReturnArrowWhitespaceRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SelfBindingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SelfBindingRule.swift
@@ -2,8 +2,8 @@ import SwiftSyntax
 
 // MARK: - SelfBindingRule
 
-@SwiftSyntaxRule(explicitRewriter: true)
-struct SelfBindingRule: OptInRule {
+@SwiftSyntaxRule(explicitRewriter: true, optIn: true)
+struct SelfBindingRule: Rule {
     var configuration = SelfBindingConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ShorthandArgumentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ShorthandArgumentRule.swift
@@ -1,8 +1,8 @@
 import SwiftLintCore
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct ShorthandArgumentRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct ShorthandArgumentRule: Rule {
     var configuration = ShorthandArgumentConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SortedEnumCasesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SortedEnumCasesRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct SortedEnumCasesRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct SortedEnumCasesRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SuperfluousElseRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SuperfluousElseRule.swift
@@ -1,8 +1,8 @@
 import SwiftLintCore
 import SwiftSyntax
 
-@SwiftSyntaxRule(explicitRewriter: true)
-struct SuperfluousElseRule: OptInRule {
+@SwiftSyntaxRule(explicitRewriter: true, optIn: true)
+struct SuperfluousElseRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SwitchCaseOnNewlineRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SwitchCaseOnNewlineRule.swift
@@ -8,8 +8,8 @@ private func wrapInSwitch(_ str: String, file: StaticString = #filePath, line: U
     """, file: file, line: line)
 }
 
-@SwiftSyntaxRule
-struct SwitchCaseOnNewlineRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct SwitchCaseOnNewlineRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/TrailingClosureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/TrailingClosureRule.swift
@@ -1,8 +1,8 @@
 import SwiftLintCore
 import SwiftSyntax
 
-@SwiftSyntaxRule(explicitRewriter: true)
-struct TrailingClosureRule: OptInRule {
+@SwiftSyntaxRule(explicitRewriter: true, optIn: true)
+struct TrailingClosureRule: Rule {
     var configuration = TrailingClosureConfiguration()
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/UnneededParenthesesInClosureArgumentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/UnneededParenthesesInClosureArgumentRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule(explicitRewriter: true)
-struct UnneededParenthesesInClosureArgumentRule: OptInRule {
+@SwiftSyntaxRule(explicitRewriter: true, optIn: true)
+struct UnneededParenthesesInClosureArgumentRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Style/VerticalParameterAlignmentOnCallRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/VerticalParameterAlignmentOnCallRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule
-struct VerticalParameterAlignmentOnCallRule: OptInRule {
+@SwiftSyntaxRule(optIn: true)
+struct VerticalParameterAlignmentOnCallRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintCore/Helpers/Macros.swift
+++ b/Source/SwiftLintCore/Helpers/Macros.swift
@@ -52,12 +52,18 @@ public macro MakeAcceptableByConfigurationElement() = #externalMacro(
 ///   - explicitRewriter: Set it to `true` to add a `makeRewriter(file:)` implementation which creates a rewriter
 ///                       defined in the rule struct. In this case, the rule automatically conforms to
 ///                       ``SwiftSyntaxCorrectableRule``.
+///   - correctable: Set it to `true` to make the rule conform to ``SwiftSyntaxCorrectableRule`` without an explicit
+///                  rewriter.
+///   - optIn: Set it to `true` to make the rule conform to ``OptInRule``.
 @attached(
     extension,
-    conformances: SwiftSyntaxRule, SwiftSyntaxCorrectableRule,
+    conformances: SwiftSyntaxRule, SwiftSyntaxCorrectableRule, OptInRule, Rule,
     names: named(makeVisitor(file:)), named(preprocess(file:)), named(makeRewriter(file:))
 )
-public macro SwiftSyntaxRule(foldExpressions: Bool = false, explicitRewriter: Bool = false) = #externalMacro(
+public macro SwiftSyntaxRule(foldExpressions: Bool = false,
+                             explicitRewriter: Bool = false,
+                             correctable: Bool = false,
+                             optIn: Bool = false) = #externalMacro(
     module: "SwiftLintCoreMacros",
     type: "SwiftSyntaxRule"
 )

--- a/Source/SwiftLintCoreMacros/SwiftSyntaxRule.swift
+++ b/Source/SwiftLintCoreMacros/SwiftSyntaxRule.swift
@@ -39,6 +39,18 @@ enum SwiftSyntaxRule: ExtensionMacro {
                     """
                 )
             ),
+            try (node.correctableArgument(context) && !node.explicitRewriterArgument(context)).ifTrue(
+                try ExtensionDeclSyntax("""
+                    extension \(type): SwiftSyntaxCorrectableRule {}
+                    """
+                )
+            ),
+            try node.optInArgument(context).ifTrue(
+                try ExtensionDeclSyntax("""
+                    extension \(type): OptInRule {}
+                    """
+                )
+            ),
         ].compactMap { $0 }
     }
 }
@@ -50,6 +62,14 @@ private extension AttributeSyntax {
 
     func explicitRewriterArgument(_ context: some MacroExpansionContext) -> Bool {
         findArgument(withName: "explicitRewriter", in: context)
+    }
+
+    func correctableArgument(_ context: some MacroExpansionContext) -> Bool {
+        findArgument(withName: "correctable", in: context)
+    }
+
+    func optInArgument(_ context: some MacroExpansionContext) -> Bool {
+        findArgument(withName: "optIn", in: context)
     }
 
     private func findArgument(withName name: String, in context: some MacroExpansionContext) -> Bool {


### PR DESCRIPTION
Moves more rule properties into `@SwiftSyntaxRule` attribute for more consistency, less boilerplate code and reduced chance of mistakes.