### PR TITLE
Add option to disable `redundant_discardable_let` in SwiftUI view bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@
   [dk-talks](https://github.com/dk-talks)
   [SimplyDanny](https://github.com/SimplyDanny)
 
+* Add option to disable `redundant_discardable_let` rule in SwiftUI view bodies.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#3855](https://github.com/realm/SwiftLint/issues/3855)
+
 * Add new `redundant_sendable` rule that triggers on `Sendable` conformances of
   types that are implicitly already `Sendable` due to being actor-isolated. It
   is enabled by default.  

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/RedundantDiscardableLetConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/RedundantDiscardableLetConfiguration.swift
@@ -1,0 +1,11 @@
+import SwiftLintCore
+
+@AutoConfigParser
+struct RedundantDiscardableLetConfiguration: SeverityBasedRuleConfiguration {
+    typealias Parent = RedundantDiscardableLetRule
+
+    @ConfigurationElement(key: "severity")
+    private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement(key: "ignore_swiftui_view_bodies")
+    private(set) var ignoreSwiftUIViewBodies = false
+}

--- a/Tests/IntegrationTests/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/default_rule_configurations.yml
@@ -795,6 +795,7 @@ reduce_into:
     opt-in: true
 redundant_discardable_let:
   severity: warning
+  ignore_swiftui_view_bodies: false
   meta:
     opt-in: false
 redundant_nil_coalescing:


### PR DESCRIPTION
Resolves #3855.