### PR TITLE
Lint PRs and show inline comments for violations

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,15 @@
+name: Lint
+
+on:
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  lint:
+    runs-on: ubuntu-24.04 # "Noble Numbat"
+    container: swift:6.0-noble
+    steps:
+      - uses: actions/checkout@v4
+      - name: Lint
+        run: swift run swiftlint --reporter github-actions-logging --strict 2> /dev/null

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -14,7 +14,11 @@ private let config: Configuration = {
 }()
 
 final class IntegrationTests: SwiftLintTestCase {
-    func testSwiftLintLints() {
+    func testSwiftLintLints() throws {
+        try XCTSkipUnless(
+            ProcessInfo.processInfo.environment["CI"] == nil,
+            "Will be covered by separate linting job"
+        )
         // This is as close as we're ever going to get to a self-hosting linter.
         let swiftFiles = config.lintableFiles(
             inPath: "",
@@ -36,7 +40,11 @@ final class IntegrationTests: SwiftLintTestCase {
         }
     }
 
-    func testSwiftLintAutoCorrects() {
+    func testSwiftLintAutoCorrects() throws {
+        try XCTSkipUnless(
+            ProcessInfo.processInfo.environment["CI"] == nil,
+            "Corrections are not verified in CI"
+        )
         let swiftFiles = config.lintableFiles(
             inPath: "",
             forceExclude: false,

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,9 @@
 trigger:
 - main
 
+variables:
+  CI: 'true'
+
 jobs:
 - job: Ubuntu
   pool:


### PR DESCRIPTION
The long-running integration tests are no longer needed (in CI). Having violations reported right in the PR is much more convenient.