### PR TITLE
Enable strict concurrency checks in test code

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -124,14 +124,14 @@ let package = Package(
             exclude: [
                 "Resources",
             ],
-            swiftSettings: swiftFeatures
+            swiftSettings: swiftFeatures + strictConcurrency
         ),
         .testTarget(
             name: "CLITests",
             dependencies: [
                 "SwiftLintFramework",
             ],
-            swiftSettings: swiftFeatures
+            swiftSettings: swiftFeatures + strictConcurrency
         ),
         .testTarget(
             name: "ExtraRulesTests",
@@ -139,7 +139,7 @@ let package = Package(
                 "SwiftLintFramework",
                 "TestHelpers",
             ],
-            swiftSettings: swiftFeatures
+            swiftSettings: swiftFeatures + strictConcurrency
         ),
         .testTarget(
             name: "FrameworkTests",
@@ -151,7 +151,7 @@ let package = Package(
             exclude: [
                 "Resources",
             ],
-            swiftSettings: swiftFeatures
+            swiftSettings: swiftFeatures + strictConcurrency
         ),
         .testTarget(
             name: "GeneratedTests",
@@ -159,7 +159,7 @@ let package = Package(
                 "SwiftLintFramework",
                 "TestHelpers",
             ],
-            swiftSettings: swiftFeatures
+            swiftSettings: swiftFeatures + strictConcurrency
         ),
         .testTarget(
             name: "IntegrationTests",
@@ -170,7 +170,7 @@ let package = Package(
             exclude: [
                 "default_rule_configurations.yml"
             ],
-            swiftSettings: swiftFeatures
+            swiftSettings: swiftFeatures + targetedConcurrency // Set to strict once SwiftLintFramework is updated
         ),
         .testTarget(
             name: "MacroTests",
@@ -178,7 +178,7 @@ let package = Package(
                 "SwiftLintCoreMacros",
                 .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
             ],
-            swiftSettings: swiftFeatures
+            swiftSettings: swiftFeatures + strictConcurrency
         ),
         .target(
             name: "TestHelpers",
@@ -186,7 +186,7 @@ let package = Package(
                 "SwiftLintFramework"
             ],
             path: "Tests/TestHelpers",
-            swiftSettings: swiftFeatures
+            swiftSettings: swiftFeatures + strictConcurrency
         ),
     ]
 )

--- a/Source/SwiftLintCore/Models/Issue.swift
+++ b/Source/SwiftLintCore/Models/Issue.swift
@@ -94,7 +94,7 @@ public enum Issue: LocalizedError, Equatable {
     ///
     /// - returns: The collected messages produced while running the code in the runner.
     @MainActor
-    static func captureConsole(runner: () throws -> Void) async rethrows -> String {
+    static func captureConsole(runner: @Sendable () throws -> Void) async rethrows -> String {
         actor Console {
             static var content = ""
         }

--- a/Tests/BUILD
+++ b/Tests/BUILD
@@ -3,6 +3,7 @@ load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library", "swift_test")
 exports_files(["BUILD"])
 
 copts = [
+    "-warnings-as-errors",
     "-enable-upcoming-feature",
     "ExistentialAny",
     "-enable-upcoming-feature",
@@ -13,6 +14,15 @@ copts = [
     "ForwardTrailingClosures",
     "-enable-upcoming-feature",
     "ImplicitOpenExistentials",
+]
+
+strict_concurrency_copts = [
+    "-Xfrontend",
+    "-strict-concurrency=complete",
+]
+targeted_concurrency_copts = [
+    "-Xfrontend",
+    "-strict-concurrency=targeted",
 ]
 
 # CLITests
@@ -26,7 +36,7 @@ swift_library(
     deps = [
         "//:SwiftLintFramework",
     ],
-    copts = copts,
+    copts = copts + strict_concurrency_copts,
 )
 
 swift_test(
@@ -46,7 +56,7 @@ swift_library(
         "//:SwiftLintCoreMacrosLib",
         "@SwiftSyntax//:SwiftSyntaxMacrosTestSupport_opt",
     ],
-    copts = copts,
+    copts = copts + strict_concurrency_copts,
 )
 
 swift_test(
@@ -66,7 +76,7 @@ swift_library(
     deps = [
         "//:SwiftLintFramework",
     ],
-    copts = copts,
+    copts = copts + strict_concurrency_copts,
 )
 
 # BuiltInRulesTests
@@ -87,7 +97,7 @@ swift_library(
     deps = [
         ":TestHelpers",
     ],
-    copts = copts,
+    copts = copts + strict_concurrency_copts,
 )
 
 swift_test(
@@ -117,7 +127,7 @@ swift_library(
     deps = [
         ":TestHelpers",
     ],
-    copts = copts,
+    copts = copts + strict_concurrency_copts,
 )
 
 swift_test(
@@ -140,7 +150,7 @@ swift_library(
     deps = [
         ":TestHelpers",
     ],
-    copts = copts,
+    copts = copts + strict_concurrency_copts,
 )
 
 swift_test(
@@ -169,7 +179,7 @@ swift_library(
     deps = [
         ":TestHelpers",
     ],
-    copts = copts,
+    copts = copts + targeted_concurrency_copts, # Set to strict once SwiftLintFramework is updated
 )
 
 swift_test(
@@ -208,7 +218,7 @@ swift_library(
     deps = [
         ":TestHelpers",
     ],
-    copts = copts,
+    copts = copts + strict_concurrency_copts,
 )
 
 swift_test(

--- a/Tests/BuiltInRulesTests/ExplicitTypeInterfaceConfigurationTests.swift
+++ b/Tests/BuiltInRulesTests/ExplicitTypeInterfaceConfigurationTests.swift
@@ -24,11 +24,12 @@ final class ExplicitTypeInterfaceConfigurationTests: SwiftLintTestCase {
         XCTAssertTrue(config.allowRedundancy)
     }
 
-    @MainActor
     func testInvalidKeyInCustomConfiguration() async throws {
-        var config = ExplicitTypeInterfaceConfiguration()
         try await AsyncAssertEqual(
-            try await Issue.captureConsole { try config.apply(configuration: ["invalidKey": "error"]) },
+            try await Issue.captureConsole {
+                var config = ExplicitTypeInterfaceConfiguration()
+                try config.apply(configuration: ["invalidKey": "error"])
+            },
             "warning: Configuration for 'explicit_type_interface' rule contains the invalid key(s) 'invalidKey'."
         )
     }

--- a/Tests/BuiltInRulesTests/IndentationWidthRuleTests.swift
+++ b/Tests/BuiltInRulesTests/IndentationWidthRuleTests.swift
@@ -4,18 +4,20 @@ import TestHelpers
 import XCTest
 
 final class IndentationWidthRuleTests: SwiftLintTestCase {
-    @MainActor
     func testInvalidIndentation() async throws {
-        var testee = IndentationWidthConfiguration()
-        let defaultValue = testee.indentationWidth
+        let defaultValue = IndentationWidthConfiguration().indentationWidth
 
         for indentation in [0, -1, -5] {
             try await AsyncAssertEqual(
-                try await Issue.captureConsole { try testee.apply(configuration: ["indentation_width": indentation]) },
+                try await Issue.captureConsole {
+                    var testee = IndentationWidthConfiguration()
+                    try testee.apply(configuration: ["indentation_width": indentation])
+
+                    // Value remains the default.
+                    XCTAssertEqual(testee.indentationWidth, defaultValue)
+                },
                 "warning: Invalid configuration for 'indentation_width' rule. Falling back to default."
             )
-            // Value remains the default.
-            XCTAssertEqual(testee.indentationWidth, defaultValue)
         }
     }
 

--- a/Tests/BuiltInRulesTests/MultilineParametersConfigurationTests.swift
+++ b/Tests/BuiltInRulesTests/MultilineParametersConfigurationTests.swift
@@ -6,10 +6,9 @@ import XCTest
 final class MultilineParametersConfigurationTests: SwiftLintTestCase {
     func testInvalidMaxNumberOfSingleLineParameters() async throws {
         for maxNumberOfSingleLineParameters in [0, -1] {
-            var config = MultilineParametersConfiguration()
-
             try await AsyncAssertEqual(
                 try await Issue.captureConsole {
+                    var config = MultilineParametersConfiguration()
                     try config.apply(
                         configuration: ["max_number_of_single_line_parameters": maxNumberOfSingleLineParameters]
                     )
@@ -23,10 +22,9 @@ final class MultilineParametersConfigurationTests: SwiftLintTestCase {
     }
 
     func testInvalidMaxNumberOfSingleLineParametersWithSingleLineEnabled() async throws {
-        var config = MultilineParametersConfiguration()
-
         try await AsyncAssertEqual(
             try await Issue.captureConsole {
+                var config = MultilineParametersConfiguration()
                 try config.apply(
                     configuration: ["max_number_of_single_line_parameters": 2, "allows_single_line": false]
                 )

--- a/Tests/BuiltInRulesTests/NoEmptyBlockConfigurationTests.swift
+++ b/Tests/BuiltInRulesTests/NoEmptyBlockConfigurationTests.swift
@@ -22,11 +22,12 @@ final class NoEmptyBlockConfigurationTests: SwiftLintTestCase {
         XCTAssertEqual(config.enabledBlockTypes, Set([.initializerBodies, .statementBlocks, .closureBlocks]))
     }
 
-    @MainActor
     func testInvalidKeyInCustomConfiguration() async throws {
-        var config = NoEmptyBlockConfiguration()
         try await AsyncAssertEqual(
-            try await Issue.captureConsole { try config.apply(configuration: ["invalidKey": "error"]) },
+            try await Issue.captureConsole {
+                var config = NoEmptyBlockConfiguration()
+                try config.apply(configuration: ["invalidKey": "error"])
+            },
             "warning: Configuration for 'no_empty_block' rule contains the invalid key(s) 'invalidKey'."
         )
     }

--- a/Tests/FrameworkTests/BaselineTests.swift
+++ b/Tests/FrameworkTests/BaselineTests.swift
@@ -47,7 +47,9 @@ final class BaselineTests: XCTestCase {
         DirectReturnRule.description,
     ]
 
-    private static var currentDirectoryPath: String?
+    private actor CurrentDirectoryHolder {
+        static var currentDirectoryPath: String?
+    }
 
     private static func violations(for filePath: String?) -> [StyleViolation] {
         ruleDescriptions.violations(for: filePath)
@@ -59,14 +61,14 @@ final class BaselineTests: XCTestCase {
 
     override static func setUp() {
         super.setUp()
-        currentDirectoryPath = FileManager.default.currentDirectoryPath
+        CurrentDirectoryHolder.currentDirectoryPath = FileManager.default.currentDirectoryPath
         XCTAssertTrue(FileManager.default.changeCurrentDirectoryPath(temporaryDirectoryPath))
     }
 
     override static func tearDown() {
-        if let currentDirectoryPath {
+        if let currentDirectoryPath = CurrentDirectoryHolder.currentDirectoryPath {
             XCTAssertTrue(FileManager.default.changeCurrentDirectoryPath(currentDirectoryPath))
-            self.currentDirectoryPath = nil
+            CurrentDirectoryHolder.currentDirectoryPath = nil
         }
         super.tearDown()
     }

--- a/Tests/FrameworkTests/RuleConfigurationDescriptionTests.swift
+++ b/Tests/FrameworkTests/RuleConfigurationDescriptionTests.swift
@@ -490,31 +490,29 @@ final class RuleConfigurationDescriptionTests: SwiftLintTestCase {
         XCTAssertEqual(configuration.nestedSeverityLevels, SeverityLevelsConfiguration(warning: 6, error: 7))
     }
 
-    @MainActor
     func testDeprecationWarning() async throws {
-        var configuration = TestConfiguration()
-
         try await AsyncAssertEqual(
-            try await Issue.captureConsole { try configuration.apply(configuration: ["set": [6, 7]]) },
+            try await Issue.captureConsole {
+                var configuration = TestConfiguration()
+                try configuration.apply(configuration: ["set": [6, 7]])
+            },
             "warning: Configuration option 'set' in 'my_rule' rule is deprecated. Use the option 'other_opt' instead."
         )
     }
 
-    @MainActor
     func testNoDeprecationWarningIfNoDeprecatedPropertySet() async throws {
-        var configuration = TestConfiguration()
-
         try await AsyncAssertTrue(
-            try await Issue.captureConsole { try configuration.apply(configuration: ["flag": false]) }.isEmpty
+            try await Issue.captureConsole {
+                var configuration = TestConfiguration()
+                try configuration.apply(configuration: ["flag": false])
+            }.isEmpty
         )
     }
 
-    @MainActor
     func testInvalidKeys() async throws {
-        var configuration = TestConfiguration()
-
         try await AsyncAssertEqual(
             try await Issue.captureConsole {
+                var configuration = TestConfiguration()
                 try configuration.apply(configuration: [
                     "severity": "error",
                     "warning": 3,


### PR DESCRIPTION
`IntegrationTests` requires `SwiftLintFramework` to comply with complete strict concurrency checks.