### PR TITLE
Remove tracking of correction positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Breaking
 
-* None.
+* Remove tracking of correction positions. Print the number of corrections applied instead.  
+  [SimplyDanny](https://github.com/SimplyDanny)
 
 ### Experimental
 

--- a/Source/SwiftLintBuiltInRules/Helpers/LegacyFunctionRuleHelper.swift
+++ b/Source/SwiftLintBuiltInRules/Helpers/LegacyFunctionRuleHelper.swift
@@ -52,12 +52,9 @@ enum LegacyFunctionRuleHelper {
                   let funcName = node.calledExpression.as(DeclReferenceExprSyntax.self)?.baseName.text else {
                 return super.visit(node)
             }
-
-            correctionPositions.append(node.positionAfterSkippingLeadingTrivia)
-
+            numberOfCorrections += 1
             let trimmedArguments = node.arguments.map { $0.trimmingTrailingComma() }
             let rewriteStrategy = legacyFunctions[funcName]
-
             let expr: ExprSyntax
             switch rewriteStrategy {
             case .equal:

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DuplicateImportsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DuplicateImportsRule.swift
@@ -178,8 +178,7 @@ private extension DuplicateImportsRule {
             if itemsToRemove.isEmpty {
                 return super.visit(node)
             }
-            correctionPositions.append(contentsOf: itemsToRemove.map(\.absolutePosition))
-
+            numberOfCorrections += itemsToRemove.count
             var copy = node
             for indexInParent in itemsToRemove.map(\.indexInParent).reversed() {
                 let currentIndex = copy.index(copy.startIndex, offsetBy: indexInParent)
@@ -190,7 +189,6 @@ private extension DuplicateImportsRule {
                 }
                 copy.remove(at: currentIndex)
             }
-
             return super.visit(copy)
         }
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ExplicitInitRule.swift
@@ -204,11 +204,11 @@ private extension ExplicitInitRule {
     final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: FunctionCallExprSyntax) -> ExprSyntax {
             guard let calledExpression = node.calledExpression.as(MemberAccessExprSyntax.self),
-                  let violationPosition = calledExpression.explicitInitPosition,
+                  calledExpression.explicitInitPosition != nil,
                   let calledBase = calledExpression.base else {
                 return super.visit(node)
             }
-            correctionPositions.append(violationPosition)
+            numberOfCorrections += 1
             let newNode = node.with(\.calledExpression, calledBase)
             return super.visit(newNode)
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/JoinedDefaultParameterRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/JoinedDefaultParameterRule.swift
@@ -49,10 +49,10 @@ private extension JoinedDefaultParameterRule {
 
     final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: FunctionCallExprSyntax) -> ExprSyntax {
-            guard let violationPosition = node.violationPosition else {
+            guard node.violationPosition != nil else {
                 return super.visit(node)
             }
-            correctionPositions.append(violationPosition)
+            numberOfCorrections += 1
             let newNode = node.with(\.arguments, [])
             return super.visit(newNode)
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyConstantRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyConstantRule.swift
@@ -36,7 +36,7 @@ private extension LegacyConstantRule {
             guard let correction = LegacyConstantRuleExamples.patterns[node.baseName.text] else {
                 return super.visit(node)
             }
-            correctionPositions.append(node.positionAfterSkippingLeadingTrivia)
+            numberOfCorrections += 1
             return ("\(raw: correction)" as ExprSyntax)
                 .with(\.leadingTrivia, node.leadingTrivia)
                 .with(\.trailingTrivia, node.trailingTrivia)
@@ -47,7 +47,7 @@ private extension LegacyConstantRule {
                   let calledExpression = node.calledExpression.as(DeclReferenceExprSyntax.self) else {
                 return super.visit(node)
             }
-            correctionPositions.append(node.positionAfterSkippingLeadingTrivia)
+            numberOfCorrections += 1
             return ("\(raw: calledExpression.baseName.text).pi" as ExprSyntax)
                 .with(\.leadingTrivia, node.leadingTrivia)
                 .with(\.trailingTrivia, node.trailingTrivia)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyConstructorRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyConstructorRule.swift
@@ -146,9 +146,7 @@ private extension LegacyConstructorRule {
                   let args = constructorsToArguments[identifier] else {
                 return super.visit(node)
             }
-
-            correctionPositions.append(node.positionAfterSkippingLeadingTrivia)
-
+            numberOfCorrections += 1
             let arguments = LabeledExprListSyntax(node.arguments.enumerated().map { index, elem in
                 elem
                     .with(\.label, .identifier(args[index]))

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NimbleOperatorRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NimbleOperatorRule.swift
@@ -88,9 +88,7 @@ private extension NimbleOperatorRule {
                   let expectedValueExpr = expectation.expectedValueExpr(for: predicate) else {
                 return super.visit(node)
             }
-
-            correctionPositions.append(node.positionAfterSkippingLeadingTrivia)
-
+            numberOfCorrections += 1
             let elements = ExprListSyntax([
                 expectation.baseExpr.with(\.trailingTrivia, .space),
                 operatorExpr.with(\.trailingTrivia, .space),

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferKeyPathRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferKeyPathRule.swift
@@ -110,7 +110,7 @@ private extension PreferKeyPathRule {
                   let calleeName = node.calleeName else {
                 return super.visit(node)
             }
-            correctionPositions.append(closure.positionAfterSkippingLeadingTrivia)
+            numberOfCorrections += 1
             var node = node.with(\.calledExpression, node.calledExpression.with(\.trailingTrivia, []))
             if node.leftParen == nil {
                 node = node.with(\.leftParen, .leftParenToken())
@@ -137,7 +137,7 @@ private extension PreferKeyPathRule {
             if let expr = node.onlyExprStmt,
                expr.accesses(identifier: node.onlyParameter) == true,
                let replacement = expr.asKeyPath {
-                correctionPositions.append(node.positionAfterSkippingLeadingTrivia)
+                numberOfCorrections += 1
                 let node = replacement
                     .with(\.leadingTrivia, node.leadingTrivia)
                     .with(\.trailingTrivia, node.trailingTrivia)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferTypeCheckingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferTypeCheckingRule.swift
@@ -71,12 +71,9 @@ private extension PreferTypeCheckingRule {
             guard let asExpr = node.asExprWithOptionalTypeChecking else {
                 return super.visit(node)
             }
-
-            correctionPositions.append(asExpr.asKeyword.positionAfterSkippingLeadingTrivia)
-
+            numberOfCorrections += 1
             let expression = asExpr.expression.trimmed
             let type = asExpr.type.trimmed
-
             return ExprSyntax(stringLiteral: "\(expression) is \(type)")
                 .with(\.leadingTrivia, node.leadingTrivia)
                 .with(\.trailingTrivia, node.trailingTrivia)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferZeroOverExplicitInitRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferZeroOverExplicitInitRule.swift
@@ -50,16 +50,12 @@ private extension PreferZeroOverExplicitInitRule {
             guard node.hasViolation, let name = node.name else {
                 return super.visit(node)
             }
-
-            correctionPositions.append(node.positionAfterSkippingLeadingTrivia)
-
+            numberOfCorrections += 1
             let newNode = MemberAccessExprSyntax(name: "zero")
                 .with(\.base, "\(raw: name)")
-            return super.visit(
-                newNode
-                    .with(\.leadingTrivia, node.leadingTrivia)
-                    .with(\.trailingTrivia, node.trailingTrivia)
-            )
+                .with(\.leadingTrivia, node.leadingTrivia)
+                .with(\.trailingTrivia, node.trailingTrivia)
+            return super.visit(newNode)
         }
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantNilCoalescingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantNilCoalescingRule.swift
@@ -44,9 +44,8 @@ private extension RedundantNilCoalescingRule {
             else {
                 return super.visit(node)
             }
-
+            numberOfCorrections += 1
             let newNode = ExprListSyntax(node.dropLast(2)).with(\.trailingTrivia, [])
-            correctionPositions.append(secondToLastExpression.operator.positionAfterSkippingLeadingTrivia)
             return super.visit(newNode)
         }
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantOptionalInitializationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantOptionalInitializationRule.swift
@@ -138,9 +138,7 @@ private extension RedundantOptionalInitializationRule {
             guard violations.isNotEmpty else {
                 return super.visit(node)
             }
-
-            correctionPositions.append(contentsOf: violations.map(\.0))
-
+            numberOfCorrections += violations.count
             let violatingBindings = violations.map(\.1)
             let newBindings = PatternBindingListSyntax(node.bindings.map { binding in
                 guard violatingBindings.contains(binding) else {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantVoidReturnRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantVoidReturnRule.swift
@@ -88,25 +88,23 @@ private extension RedundantVoidReturnRule {
         override func visit(_ node: ClosureSignatureSyntax) -> ClosureSignatureSyntax {
             guard configuration.includeClosures,
                   let output = node.returnClause,
-                  let tokenBeforeOutput = output.previousToken(viewMode: .sourceAccurate),
+                  output.previousToken(viewMode: .sourceAccurate) != nil,
                   output.containsRedundantVoidViolation
             else {
                 return super.visit(node)
             }
-
-            correctionPositions.append(tokenBeforeOutput.endPositionBeforeTrailingTrivia)
+            numberOfCorrections += 1
             return super.visit(node.with(\.returnClause, nil).removingTrailingSpaceIfNeeded())
         }
 
         override func visit(_ node: FunctionSignatureSyntax) -> FunctionSignatureSyntax {
             guard let output = node.returnClause,
-                  let tokenBeforeOutput = output.previousToken(viewMode: .sourceAccurate),
+                  output.previousToken(viewMode: .sourceAccurate) != nil,
                   output.containsRedundantVoidViolation
             else {
                 return super.visit(node)
             }
-
-            correctionPositions.append(tokenBeforeOutput.endPositionBeforeTrailingTrivia)
+            numberOfCorrections += 1
             return super.visit(node.with(\.returnClause, nil).removingTrailingSpaceIfNeeded())
         }
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ReturnValueFromVoidFunctionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ReturnValueFromVoidFunctionRule.swift
@@ -33,7 +33,7 @@ private extension ReturnValueFromVoidFunctionRule {
                   Syntax(statements).enclosingFunction()?.returnsVoid == true else {
                 return super.visit(statements)
             }
-            correctionPositions.append(returnStmt.positionAfterSkippingLeadingTrivia)
+            numberOfCorrections += 1
             let newStmtList = Array(statements.dropLast()) + [
                 CodeBlockItemSyntax(item: .expr(expr))
                     .with(\.leadingTrivia, returnStmt.leadingTrivia),

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ShorthandOptionalBindingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ShorthandOptionalBindingRule.swift
@@ -95,8 +95,7 @@ private extension ShorthandOptionalBindingRule {
             guard node.isShadowingOptionalBinding else {
                 return super.visit(node)
             }
-
-            correctionPositions.append(node.positionAfterSkippingLeadingTrivia)
+            numberOfCorrections += 1
             let newNode = node
                 .with(\.initializer, nil)
                 .with(\.pattern, node.pattern.with(\.trailingTrivia, node.trailingTrivia))

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/SyntacticSugarRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/SyntacticSugarRule.swift
@@ -31,16 +31,14 @@ struct SyntacticSugarRule: CorrectableRule, SourceKitFreeRule {
         violations.flatMap { [$0] + flattenViolations($0.children) }
     }
 
-    func correct(file: SwiftLintFile) -> [Correction] {
+    func correct(file: SwiftLintFile) -> Int {
         let visitor = SyntacticSugarRuleVisitor(viewMode: .sourceAccurate)
         return visitor.walk(file: file) { visitor in
             var context = CorrectingContext(rule: self, file: file, contents: file.contents)
             context.correctViolations(visitor.violations)
-
             file.write(context.contents)
-
-            return context.corrections
-        }
+            return [context.numberOfCorrections]
+        }.reduce(0, +)
     }
 }
 
@@ -261,7 +259,7 @@ private struct CorrectingContext<R: Rule> {
     let rule: R
     let file: SwiftLintFile
     var contents: String
-    var corrections: [Correction] = []
+    var numberOfCorrections = 0
 
     mutating func correctViolations(_ violations: [SyntacticSugarRuleViolation]) {
         let sortedVolations = violations.sorted(by: { $0.correction.typeStart > $1.correction.typeStart })
@@ -311,9 +309,7 @@ private struct CorrectingContext<R: Rule> {
             correctViolations(violation.children)
             replaceCharacters(in: leftRange, with: "")
         }
-
-        let location = Location(file: file, byteOffset: ByteCount(correction.typeStart))
-        corrections.append(Correction(ruleDescription: type(of: rule).description, location: location))
+        numberOfCorrections += 1
     }
 
     private func typeIsOpaqueOrExistential(correction: SyntacticSugarRuleViolation.Correction) -> Bool {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ToggleBoolRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/ToggleBoolRule.swift
@@ -45,7 +45,7 @@ private extension ToggleBoolRule {
             guard node.hasToggleBoolViolation, let firstExpr = node.first, let index = node.index(of: firstExpr) else {
                 return super.visit(node)
             }
-            correctionPositions.append(node.positionAfterSkippingLeadingTrivia)
+            numberOfCorrections += 1
             let elements = node
                 .with(
                     \.[index],

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/TrailingSemicolonRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/TrailingSemicolonRule.swift
@@ -40,8 +40,7 @@ private extension TrailingSemicolonRule {
             guard node.isTrailingSemicolon else {
                 return super.visit(node)
             }
-
-            correctionPositions.append(node.positionAfterSkippingLeadingTrivia)
+            numberOfCorrections += 1
             return .unknown("").with(\.trailingTrivia, node.trailingTrivia)
         }
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededBreakInSwitchRule.swift
@@ -95,7 +95,6 @@ private extension UnneededBreakInSwitchRule {
             guard let statement = node.unneededBreak else {
                 return
             }
-
             violations.append(statement.item.positionAfterSkippingLeadingTrivia)
         }
     }
@@ -103,22 +102,17 @@ private extension UnneededBreakInSwitchRule {
     final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: SwitchCaseSyntax) -> SwitchCaseSyntax {
             let stmts = CodeBlockItemListSyntax(node.statements.dropLast())
-
             guard let breakStatement = node.unneededBreak, let secondLast = stmts.last else {
                 return super.visit(node)
             }
-
-            correctionPositions.append(breakStatement.item.positionAfterSkippingLeadingTrivia)
-
+            numberOfCorrections += 1
             let trivia = breakStatement.item.leadingTrivia + breakStatement.item.trailingTrivia
-
             let newNode = node
                 .with(\.statements, stmts)
                 .with(\.statements.trailingTrivia, secondLast.item.trailingTrivia + trivia)
                 .trimmed { !$0.isComment }
                 .formatted()
                 .as(SwitchCaseSyntax.self)!
-
             return super.visit(newNode)
         }
     }
@@ -131,7 +125,6 @@ private extension SwitchCaseSyntax {
               breakStatement.label == nil else {
             return nil
         }
-
         return statements.last
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededSynthesizedInitializerRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnneededSynthesizedInitializerRule.swift
@@ -60,7 +60,7 @@ private extension UnneededSynthesizedInitializerRule {
 
         override func visit(_ node: InitializerDeclSyntax) -> DeclSyntax {
             if unneededInitializers.contains(node) {
-                correctionPositions.append(node.positionAfterSkippingLeadingTrivia)
+                numberOfCorrections += 1
                 let expr: DeclSyntax = ""
                 return expr
                     .with(\.leadingTrivia, node.leadingTrivia)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UntypedErrorInCatchRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UntypedErrorInCatchRule.swift
@@ -124,8 +124,7 @@ private extension UntypedErrorInCatchRule {
             guard let item = node.catchItems.onlyElement, item.isIdentifierPattern else {
                 return super.visit(node)
             }
-
-            correctionPositions.append(node.catchKeyword.positionAfterSkippingLeadingTrivia)
+            numberOfCorrections += 1
             return super.visit(
                 node
                     .with(\.catchKeyword, node.catchKeyword.with(\.trailingTrivia, .spaces(1)))

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/LowerACLThanParentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/LowerACLThanParentRule.swift
@@ -96,8 +96,7 @@ private extension LowerACLThanParentRule {
             guard node.isHigherACLThanParent else {
                 return super.visit(node)
             }
-
-            correctionPositions.append(node.positionAfterSkippingLeadingTrivia)
+            numberOfCorrections += 1
             let newNode: DeclModifierSyntax
             if node.name.tokenKind == .keyword(.open) {
                 newNode = DeclModifierSyntax(

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/MarkRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/MarkRule.swift
@@ -29,9 +29,7 @@ private extension MarkRule {
         override func visit(_ token: TokenSyntax) -> TokenSyntax {
             var pieces = token.leadingTrivia.pieces
             for result in token.violationResults() {
-                // caution: `correctionPositions` records the positions before the mutations.
-                // https://github.com/realm/SwiftLint/pull/4297
-                correctionPositions.append(result.position)
+                numberOfCorrections += 1
                 result.correct(&pieces)
             }
             return super.visit(token.with(\.leadingTrivia, Trivia(pieces: pieces)))

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateSwiftUIStatePropertyRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateSwiftUIStatePropertyRule.swift
@@ -117,7 +117,7 @@ private extension PrivateSwiftUIStatePropertyRule {
                 return DeclSyntax(node)
             }
 
-            correctionPositions.append(node.bindingSpecifier.positionAfterSkippingLeadingTrivia)
+            numberOfCorrections += 1
 
             // If there are no modifiers present on the current syntax node,
             // then we should retain the binding specifier's leading trivia

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateUnitTestRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/PrivateUnitTestRule.swift
@@ -153,8 +153,7 @@ private extension PrivateUnitTestRule {
             guard node.isPrivate, node.isXCTestCase(configuration.testParentClasses) else {
                 return super.visit(node)
             }
-
-            correctionPositions.append(node.positionAfterSkippingLeadingTrivia)
+            numberOfCorrections += 1
             let (modifiers, declKeyword) = withoutPrivate(modifiers: node.modifiers, declKeyword: node.classKeyword)
             return super.visit(node.with(\.modifiers, modifiers).with(\.classKeyword, declKeyword))
         }
@@ -163,8 +162,7 @@ private extension PrivateUnitTestRule {
             guard node.isTestMethod, node.isPrivate else {
                 return super.visit(node)
             }
-
-            correctionPositions.append(node.positionAfterSkippingLeadingTrivia)
+            numberOfCorrections += 1
             let (modifiers, declKeyword) = withoutPrivate(modifiers: node.modifiers, declKeyword: node.funcKeyword)
             return super.visit(node.with(\.modifiers, modifiers).with(\.funcKeyword, declKeyword))
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/RedundantSendableRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/RedundantSendableRule.swift
@@ -73,7 +73,7 @@ private extension RedundantSendableRule {
     final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: ActorDeclSyntax) -> DeclSyntax {
             if node.conformsToSendable {
-                correctionPositions.append(node.name.positionAfterSkippingLeadingTrivia)
+                numberOfCorrections += 1
                 return super.visit(node.withoutSendable)
             }
             return super.visit(node)
@@ -93,7 +93,7 @@ private extension RedundantSendableRule {
 
         private func removeRedundantSendable<T: DeclGroupSyntax & NamedDeclSyntax>(from decl: T) -> T {
             if decl.conformsToSendable, decl.isIsolatedToActor(actors: configuration.globalActors) {
-                correctionPositions.append(decl.name.positionAfterSkippingLeadingTrivia)
+                numberOfCorrections += 1
                 return decl.withoutSendable
             }
             return decl

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/StrongIBOutletRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/StrongIBOutletRule.swift
@@ -40,15 +40,14 @@ private extension StrongIBOutletRule {
 
     final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: VariableDeclSyntax) -> DeclSyntax {
-            guard let violationPosition = node.violationPosition,
+            guard node.violationPosition != nil,
                   let weakOrUnownedModifier = node.weakOrUnownedModifier,
                   case let modifiers = node.modifiers else {
                 return super.visit(node)
             }
-
             let newModifiers = modifiers.filter { $0 != weakOrUnownedModifier }
             let newNode = node.with(\.modifiers, newModifiers)
-            correctionPositions.append(violationPosition)
+            numberOfCorrections += 1
             return super.visit(newNode)
         }
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnneededOverrideRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnneededOverrideRule.swift
@@ -49,7 +49,7 @@ private extension UnneededOverrideRule {
         }
 
         private func visitUnneededOverride(_ node: some DeclSyntaxProtocol) -> DeclSyntax {
-            correctionPositions.append(node.positionAfterSkippingLeadingTrivia)
+            numberOfCorrections += 1
             let expr: DeclSyntax = ""
             return expr
                 .with(\.leadingTrivia, node.leadingTrivia)

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedClosureParameterRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedClosureParameterRule.swift
@@ -56,7 +56,7 @@ private extension UnusedClosureParameterRule {
                           let index = params.parameters.index(of: param) else {
                         continue
                     }
-                    correctionPositions.append(name.positionAfterSkippingLeadingTrivia)
+                    numberOfCorrections += 1
                     let newParameterList = newParams.parameters.with(
                         \.[index],
                         param.with(\.firstName, name.with(\.tokenKind, .wildcard))
@@ -74,7 +74,7 @@ private extension UnusedClosureParameterRule {
                       let index = params.index(of: param) else {
                     continue
                 }
-                correctionPositions.append(param.name.positionAfterSkippingLeadingTrivia)
+                numberOfCorrections += 1
                 newParams = newParams.with(
                     \.[index],
                     param.with(\.name, param.name.with(\.tokenKind, .wildcard))

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedControlFlowLabelRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedControlFlowLabelRule.swift
@@ -96,10 +96,10 @@ private extension UnusedControlFlowLabelRule {
 
     final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: LabeledStmtSyntax) -> StmtSyntax {
-            guard let violationPosition = node.violationPosition else {
+            guard node.violationPosition != nil else {
                 return super.visit(node)
             }
-            correctionPositions.append(violationPosition)
+            numberOfCorrections += 1
             return visit(node.statement.with(\.leadingTrivia, node.leadingTrivia))
         }
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/EmptyCountRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/EmptyCountRule.swift
@@ -112,15 +112,17 @@ private extension EmptyCountRule {
                 return super.visit(node)
             }
 
-            if let (count, position) = node.countNodeAndPosition(onlyAfterDot: configuration.onlyAfterDot) {
+            if let (count, _) = node.countNodeAndPosition(onlyAfterDot: configuration.onlyAfterDot) {
                 let newNode =
                     if let count = count.as(MemberAccessExprSyntax.self) {
                         ExprSyntax(count.with(\.declName.baseName, "isEmpty").trimmed)
                     } else {
                         ExprSyntax(count.as(DeclReferenceExprSyntax.self)?.with(\.baseName, "isEmpty").trimmed)
                     }
-                guard let newNode else { return super.visit(node) }
-                correctionPositions.append(position)
+                guard let newNode else {
+                    return super.visit(node)
+                }
+                numberOfCorrections += 1
                 return
                     if ["!=", "<", ">"].contains(binaryOperator) {
                         newNode.negated

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/FinalTestCaseRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/FinalTestCaseRule.swift
@@ -44,7 +44,7 @@ private extension FinalTestCaseRule {
         override func visit(_ node: ClassDeclSyntax) -> DeclSyntax {
             var newNode = node
             if node.isNonFinalTestClass(parentClasses: configuration.testParentClasses) {
-                correctionPositions.append(node.name.positionAfterSkippingLeadingTrivia)
+                numberOfCorrections += 1
                 let finalModifier = DeclModifierSyntax(name: .keyword(.final))
                 newNode =
                     if node.modifiers.isEmpty {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ClosingBraceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ClosingBraceRule.swift
@@ -37,7 +37,7 @@ private extension ClosingBraceRule {
             guard node.hasClosingBraceViolation else {
                 return super.visit(node)
             }
-            correctionPositions.append(node.positionAfterSkippingLeadingTrivia)
+            numberOfCorrections += 1
             return super.visit(node.with(\.trailingTrivia, Trivia()))
         }
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ClosureEndIndentationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ClosureEndIndentationRule.swift
@@ -35,7 +35,7 @@ struct ClosureEndIndentationRule: Rule, OptInRule {
 }
 
 extension ClosureEndIndentationRule: CorrectableRule {
-    func correct(file: SwiftLintFile) -> [Correction] {
+    func correct(file: SwiftLintFile) -> Int {
         let allViolations = violations(in: file).reversed().filter { violation in
             guard let nsRange = file.stringView.byteRangeToNSRange(violation.range) else {
                 return false
@@ -45,7 +45,7 @@ extension ClosureEndIndentationRule: CorrectableRule {
         }
 
         guard allViolations.isNotEmpty else {
-            return []
+            return 0
         }
 
         var correctedContents = file.contents
@@ -61,16 +61,13 @@ extension ClosureEndIndentationRule: CorrectableRule {
             }
         }
 
-        var corrections = correctedLocations.map {
-            Correction(ruleDescription: Self.description, location: Location(file: file, characterOffset: $0))
-        }
-
+        var numberOfCorrections = correctedLocations.count
         file.write(correctedContents)
 
         // Re-correct to catch cascading indentation from the first round.
-        corrections += correct(file: file)
+        numberOfCorrections += correct(file: file)
 
-        return corrections
+        return numberOfCorrections
     }
 
     private func correct(contents: inout String, expected: NSRange, actual: NSRange) -> Bool {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ClosureSpacingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ClosureSpacingRule.swift
@@ -79,9 +79,8 @@ private extension ClosureSpacingRule {
                 node.rightBrace = node.rightBrace.with(\.trailingTrivia, .spaces(1))
             }
             if violations.hasViolations {
-                correctionPositions.append(node.positionAfterSkippingLeadingTrivia)
+                numberOfCorrections += 1
             }
-
             return super.visit(node)
         }
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ControlStatementRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ControlStatementRule.swift
@@ -114,7 +114,7 @@ private extension ControlStatementRule {
             guard case let items = node.catchItems, items.containSuperfluousParens == true else {
                 return super.visit(node)
             }
-            correctionPositions.append(node.positionAfterSkippingLeadingTrivia)
+            numberOfCorrections += 1
             let node = node
                 .with(\.catchKeyword, node.catchKeyword.with(\.trailingTrivia, .space))
                 .with(\.catchItems, items.withoutParens)
@@ -125,7 +125,7 @@ private extension ControlStatementRule {
             guard node.conditions.containSuperfluousParens else {
                 return super.visit(node)
             }
-            correctionPositions.append(node.positionAfterSkippingLeadingTrivia)
+            numberOfCorrections += 1
             let node = node
                 .with(\.guardKeyword, node.guardKeyword.with(\.trailingTrivia, .space))
                 .with(\.conditions, node.conditions.withoutParens)
@@ -136,7 +136,7 @@ private extension ControlStatementRule {
             guard node.conditions.containSuperfluousParens else {
                 return super.visit(node)
             }
-            correctionPositions.append(node.positionAfterSkippingLeadingTrivia)
+            numberOfCorrections += 1
             let node = node
                 .with(\.ifKeyword, node.ifKeyword.with(\.trailingTrivia, .space))
                 .with(\.conditions, node.conditions.withoutParens)
@@ -147,7 +147,7 @@ private extension ControlStatementRule {
             guard let tupleElement = node.subject.unwrapped else {
                 return super.visit(node)
             }
-            correctionPositions.append(node.positionAfterSkippingLeadingTrivia)
+            numberOfCorrections += 1
             let node = node
                 .with(\.switchKeyword, node.switchKeyword.with(\.trailingTrivia, .space))
                 .with(\.subject, tupleElement.with(\.trailingTrivia, .space))
@@ -158,7 +158,7 @@ private extension ControlStatementRule {
             guard node.conditions.containSuperfluousParens else {
                 return super.visit(node)
             }
-            correctionPositions.append(node.positionAfterSkippingLeadingTrivia)
+            numberOfCorrections += 1
             let node = node
                 .with(\.whileKeyword, node.whileKeyword.with(\.trailingTrivia, .space))
                 .with(\.conditions, node.conditions.withoutParens)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/DirectReturnRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/DirectReturnRule.swift
@@ -199,7 +199,7 @@ private extension DirectReturnRule {
                   var initExpression = binding.initializer?.value else {
                 return super.visit(statements)
             }
-            correctionPositions.append(binding.positionAfterSkippingLeadingTrivia)
+            numberOfCorrections += 1
             var newStmtList = Array(statements.dropLast(2))
             let newBindingList = bindingList
                 .filter { $0 != binding }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/EmptyEnumArgumentsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/EmptyEnumArgumentsRule.swift
@@ -131,18 +131,18 @@ private extension EmptyEnumArgumentsRule {
 
     final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: SwitchCaseItemSyntax) -> SwitchCaseItemSyntax {
-            guard let (violationPosition, newPattern) = node.pattern.emptyEnumArgumentsViolation(rewrite: true) else {
+            guard let (_, newPattern) = node.pattern.emptyEnumArgumentsViolation(rewrite: true) else {
                 return super.visit(node)
             }
-            correctionPositions.append(violationPosition)
+            numberOfCorrections += 1
             return super.visit(node.with(\.pattern, newPattern))
         }
 
         override func visit(_ node: MatchingPatternConditionSyntax) -> MatchingPatternConditionSyntax {
-            guard let (violationPosition, newPattern) = node.pattern.emptyEnumArgumentsViolation(rewrite: true) else {
+            guard let (_, newPattern) = node.pattern.emptyEnumArgumentsViolation(rewrite: true) else {
                 return super.visit(node)
             }
-            correctionPositions.append(violationPosition)
+            numberOfCorrections += 1
             return super.visit(node.with(\.pattern, newPattern))
         }
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/EmptyParametersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/EmptyParametersRule.swift
@@ -46,10 +46,10 @@ private extension EmptyParametersRule {
 
     final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: FunctionTypeSyntax) -> TypeSyntax {
-            guard let violationPosition = node.emptyParametersViolationPosition else {
+            guard node.emptyParametersViolationPosition != nil else {
                 return super.visit(node)
             }
-            correctionPositions.append(violationPosition)
+            numberOfCorrections += 1
             return super.visit(node.with(\.parameters, TupleTypeElementListSyntax([])))
         }
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/EmptyParenthesesWithTrailingClosureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/EmptyParenthesesWithTrailingClosureRule.swift
@@ -59,15 +59,14 @@ private extension EmptyParenthesesWithTrailingClosureRule {
 
     final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: FunctionCallExprSyntax) -> ExprSyntax {
-            guard let violationPosition = node.violationPosition else {
+            guard node.violationPosition != nil else {
                 return super.visit(node)
             }
-
+            numberOfCorrections += 1
             let newNode = node
                 .with(\.leftParen, nil)
                 .with(\.rightParen, nil)
                 .with(\.trailingClosure, node.trailingClosure?.with(\.leadingTrivia, .spaces(1)))
-            correctionPositions.append(violationPosition)
             return super.visit(newNode)
         }
     }
@@ -80,7 +79,6 @@ private extension FunctionCallExprSyntax {
               arguments.isEmpty else {
             return nil
         }
-
         return leftParen.positionAfterSkippingLeadingTrivia
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ExplicitSelfRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ExplicitSelfRule.swift
@@ -23,21 +23,18 @@ struct ExplicitSelfRule: CorrectableRule, AnalyzerRule {
         }
     }
 
-    func correct(file: SwiftLintFile, compilerArguments: [String]) -> [Correction] {
+    func correct(file: SwiftLintFile, compilerArguments: [String]) -> Int {
         let violations = violationRanges(in: file, compilerArguments: compilerArguments)
         let matches = file.ruleEnabled(violatingRanges: violations, for: self)
-        if matches.isEmpty { return [] }
-
+        if matches.isEmpty {
+            return 0
+        }
         var contents = file.contents.bridge()
-        let description = Self.description
-        var corrections = [Correction]()
         for range in matches.reversed() {
             contents = contents.replacingCharacters(in: range, with: "self.").bridge()
-            let location = Location(file: file, characterOffset: range.location)
-            corrections.append(Correction(ruleDescription: description, location: location))
         }
         file.write(contents.bridge())
-        return corrections
+        return matches.count
     }
 
     private func violationRanges(in file: SwiftLintFile, compilerArguments: [String]) -> [NSRange] {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/LeadingWhitespaceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/LeadingWhitespaceRule.swift
@@ -36,13 +36,13 @@ struct LeadingWhitespaceRule: CorrectableRule, SourceKitFreeRule {
         ]
     }
 
-    func correct(file: SwiftLintFile) -> [Correction] {
+    func correct(file: SwiftLintFile) -> Int {
         let whitespaceAndNewline = CharacterSet.whitespacesAndNewlines
         let spaceCount = file.contents.countOfLeadingCharacters(in: whitespaceAndNewline)
         guard spaceCount > 0,
             let firstLineRange = file.lines.first?.range,
             file.ruleEnabled(violatingRanges: [firstLineRange], for: self).isNotEmpty else {
-                return []
+                return 0
         }
 
         let indexEnd = file.contents.index(
@@ -50,7 +50,6 @@ struct LeadingWhitespaceRule: CorrectableRule, SourceKitFreeRule {
             offsetBy: spaceCount,
             limitedBy: file.contents.endIndex) ?? file.contents.endIndex
         file.write(String(file.contents[indexEnd...]))
-        let location = Location(file: file.path, line: max(file.lines.count, 1))
-        return [Correction(ruleDescription: Self.description, location: location)]
+        return 1
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/NoSpaceInMethodCallRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/NoSpaceInMethodCallRule.swift
@@ -61,12 +61,9 @@ private extension NoSpaceInMethodCallRule {
             guard node.hasNoSpaceInMethodCallViolation else {
                 return super.visit(node)
             }
-
-            correctionPositions.append(node.calledExpression.endPositionBeforeTrailingTrivia)
-
+            numberOfCorrections += 1
             let newNode = node
                 .with(\.calledExpression, node.calledExpression.with(\.trailingTrivia, []))
-
             return super.visit(newNode)
         }
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/NumberSeparatorRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/NumberSeparatorRule.swift
@@ -55,7 +55,7 @@ private extension NumberSeparatorRule {
                     .floatLiteral(violation.correction)
                 )
             )
-            correctionPositions.append(violation.position)
+            numberOfCorrections += 1
             return super.visit(newNode)
         }
 
@@ -64,7 +64,7 @@ private extension NumberSeparatorRule {
                 return super.visit(node)
             }
             let newNode = node.with(\.literal, node.literal.with(\.tokenKind, .integerLiteral(violation.correction)))
-            correctionPositions.append(violation.position)
+            numberOfCorrections += 1
             return super.visit(newNode)
         }
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/OptionalEnumCaseMatchingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/OptionalEnumCaseMatchingRule.swift
@@ -185,8 +185,7 @@ private extension OptionalEnumCaseMatchingRule {
 
             if let expression = pattern.expression.as(OptionalChainingExprSyntax.self),
                !expression.expression.isDiscardAssignmentOrBoolLiteral {
-                let violationPosition = expression.questionMark.positionAfterSkippingLeadingTrivia
-                correctionPositions.append(violationPosition)
+                numberOfCorrections += 1
                 let newPattern = PatternSyntax(pattern.with(\.expression, expression.expression))
                 let newNode = node
                     .with(\.pattern, newPattern)
@@ -203,10 +202,7 @@ private extension OptionalEnumCaseMatchingRule {
                     else {
                         continue
                     }
-
-                    let violationPosition = optionalChainingExpression.questionMark.positionAfterSkippingLeadingTrivia
-                    correctionPositions.append(violationPosition)
-
+                    numberOfCorrections += 1
                     let newElement = element.with(\.expression, optionalChainingExpression.expression)
                     if let index = expression.elements.index(of: element) {
                         newExpression.elements = newExpression.elements.with(\.[index], newElement)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfTypeOverTypeOfSelfRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfTypeOverTypeOfSelfRule.swift
@@ -121,9 +121,7 @@ private extension PreferSelfTypeOverTypeOfSelfRule {
             guard let function = node.base?.as(FunctionCallExprSyntax.self), function.hasViolation else {
                 return super.visit(node)
             }
-
-            correctionPositions.append(function.positionAfterSkippingLeadingTrivia)
-
+            numberOfCorrections += 1
             let base = DeclReferenceExprSyntax(baseName: "Self")
             let baseWithTrivia = base
                 .with(\.leadingTrivia, function.leadingTrivia)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ProtocolPropertyAccessorsOrderRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ProtocolPropertyAccessorsOrderRule.swift
@@ -44,13 +44,9 @@ private extension ProtocolPropertyAccessorsOrderRule {
             guard node.hasViolation else {
                 return super.visit(node)
             }
-
-            correctionPositions.append(node.accessors.positionAfterSkippingLeadingTrivia)
-
+            numberOfCorrections += 1
             let reversedAccessors = AccessorDeclListSyntax(Array(node.accessorsList.reversed()))
-            return super.visit(
-                node.with(\.accessors, .accessors(reversedAccessors))
-            )
+            return super.visit(node.with(\.accessors, .accessors(reversedAccessors)))
         }
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SelfBindingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SelfBindingRule.swift
@@ -81,8 +81,7 @@ private extension SelfBindingRule {
 
             if let initializerIdentifier = node.initializer?.value.as(DeclReferenceExprSyntax.self),
                initializerIdentifier.baseName.text == "self" {
-                correctionPositions.append(identifierPattern.positionAfterSkippingLeadingTrivia)
-
+                numberOfCorrections += 1
                 let newPattern = PatternSyntax(
                     identifierPattern
                         .with(\.identifier, identifierPattern.identifier
@@ -94,8 +93,7 @@ private extension SelfBindingRule {
             if node.initializer == nil,
                       identifierPattern.identifier.text == "self",
                       configuration.bindIdentifier != "self" {
-                correctionPositions.append(identifierPattern.positionAfterSkippingLeadingTrivia)
-
+                numberOfCorrections += 1
                 let newPattern = PatternSyntax(
                     identifierPattern
                         .with(\.identifier, identifierPattern.identifier

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SuperfluousElseRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SuperfluousElseRule.swift
@@ -266,14 +266,14 @@ private extension SuperfluousElseRule {
     final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override init(configuration: ConfigurationType, file: SwiftLintFile) {
             super.init(configuration: configuration, file: file)
-            let correctionPositions = Visitor(configuration: configuration, file: file).walk(file: file) {
-                $0.violations.map(\.position)
-            }.filter { !$0.isContainedIn(regions: disabledRegions, locationConverter: locationConverter) }
-            self.correctionPositions.append(contentsOf: correctionPositions)
+            numberOfCorrections += Visitor(configuration: configuration, file: file)
+                .walk(file: file) { $0.violations.map(\.position) }
+                .filter { !$0.isContainedIn(regions: disabledRegions, locationConverter: locationConverter) }
+                .count
         }
 
         override func visitAny(_ node: Syntax) -> Syntax? {
-            correctionPositions.isEmpty ? node : nil // Avoid skipping all `if` expressions in a code block.
+            numberOfCorrections == 0 ? node : nil // Avoid skipping all `if` expressions in a code block.
         }
 
         override func visit(_ list: CodeBlockItemListSyntax) -> CodeBlockItemListSyntax {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/TrailingClosureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/TrailingClosureRule.swift
@@ -136,14 +136,14 @@ private extension TrailingClosureRule {
             guard node.trailingClosure == nil else { return super.visit(node) }
 
             if configuration.onlySingleMutedParameter {
-                if let param = node.singleMutedClosureParameter,
-                let converted = node.convertToTrailingClosure() {
-                     correctionPositions.append(param.positionAfterSkippingLeadingTrivia)
+                if node.singleMutedClosureParameter != nil,
+                   let converted = node.convertToTrailingClosure() {
+                    numberOfCorrections += 1
                     return super.visit(converted)
                 }
-            } else if let param = node.lastDistinctClosureParameter,
+            } else if node.lastDistinctClosureParameter != nil,
                       let converted = node.convertToTrailingClosure() {
-                correctionPositions.append(param.positionAfterSkippingLeadingTrivia)
+                numberOfCorrections += 1
                 return super.visit(converted)
             }
             return super.visit(node)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/TrailingCommaRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/TrailingCommaRule.swift
@@ -97,7 +97,7 @@ private extension TrailingCommaRule {
 
             switch (lastElement.trailingComma, configuration.mandatoryComma) {
             case (let commaToken?, false):
-                correctionPositions.append(commaToken.positionAfterSkippingLeadingTrivia)
+                numberOfCorrections += 1
                 let newTrailingTrivia = (lastElement.value.trailingTrivia)
                     .appending(trivia: commaToken.leadingTrivia)
                     .appending(trivia: commaToken.trailingTrivia)
@@ -110,7 +110,7 @@ private extension TrailingCommaRule {
                     )
                 return super.visit(newNode)
             case (nil, true) where !locationConverter.isSingleLine(node: node):
-                correctionPositions.append(lastElement.endPositionBeforeTrailingTrivia)
+                numberOfCorrections += 1
                 let newNode = node
                     .with(
                         \.[index],
@@ -132,7 +132,7 @@ private extension TrailingCommaRule {
 
             switch (lastElement.trailingComma, configuration.mandatoryComma) {
             case (let commaToken?, false):
-                correctionPositions.append(commaToken.positionAfterSkippingLeadingTrivia)
+                numberOfCorrections += 1
                 let newNode = node
                     .with(
                         \.[index],
@@ -146,7 +146,7 @@ private extension TrailingCommaRule {
                     )
                 return super.visit(newNode)
             case (nil, true) where !locationConverter.isSingleLine(node: node):
-                correctionPositions.append(lastElement.endPositionBeforeTrailingTrivia)
+                numberOfCorrections += 1
                 let newNode = node
                     .with(
                         \.[index],

--- a/Source/SwiftLintBuiltInRules/Rules/Style/TrailingNewlineRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/TrailingNewlineRule.swift
@@ -53,15 +53,15 @@ struct TrailingNewlineRule: CorrectableRule, SourceKitFreeRule {
         ]
     }
 
-    func correct(file: SwiftLintFile) -> [Correction] {
+    func correct(file: SwiftLintFile) -> Int {
         guard let count = file.contents.trailingNewlineCount(), count != 1 else {
-            return []
+            return 0
         }
         guard let lastLineRange = file.lines.last?.range else {
-            return []
+            return 0
         }
         if file.ruleEnabled(violatingRanges: [lastLineRange], for: self).isEmpty {
-            return []
+            return 0
         }
         if count < 1 {
             file.append("\n")
@@ -69,7 +69,6 @@ struct TrailingNewlineRule: CorrectableRule, SourceKitFreeRule {
             let index = file.contents.index(file.contents.endIndex, offsetBy: 1 - count)
             file.write(file.contents[..<index])
         }
-        let location = Location(file: file.path, line: max(file.lines.count, 1))
-        return [Correction(ruleDescription: Self.description, location: location)]
+        return 1
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/TrailingWhitespaceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/TrailingWhitespaceRule.swift
@@ -45,10 +45,10 @@ struct TrailingWhitespaceRule: CorrectableRule {
         }
     }
 
-    func correct(file: SwiftLintFile) -> [Correction] {
+    func correct(file: SwiftLintFile) -> Int {
         let whitespaceCharacterSet = CharacterSet.whitespaces
         var correctedLines = [String]()
-        var corrections = [Correction]()
+        var numberOfCorrections = 0
         for line in file.lines {
             guard line.content.hasTrailingWhitespace() else {
                 correctedLines.append(line.content)
@@ -77,17 +77,14 @@ struct TrailingWhitespaceRule: CorrectableRule {
             }
 
             if line.content != correctedLine {
-                let description = Self.description
-                let location = Location(file: file.path, line: line.index)
-                corrections.append(Correction(ruleDescription: description, location: location))
+                numberOfCorrections += 1
             }
             correctedLines.append(correctedLine)
         }
-        if corrections.isNotEmpty {
+        if numberOfCorrections > 0 {
             // join and re-add trailing newline
             file.write(correctedLines.joined(separator: "\n") + "\n")
-            return corrections
         }
-        return []
+        return numberOfCorrections
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/UnneededParenthesesInClosureArgumentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/UnneededParenthesesInClosureArgumentRule.swift
@@ -104,8 +104,7 @@ private extension UnneededParenthesesInClosureArgumentRule {
                 )
             }
 
-            correctionPositions.append(clause.positionAfterSkippingLeadingTrivia)
-
+            numberOfCorrections += 1
             let paramList = ClosureShorthandParameterListSyntax(items).with(\.trailingTrivia, .spaces(1))
             return super.visit(node.with(\.parameterClause, .init(paramList)))
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/VerticalWhitespaceBetweenCasesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/VerticalWhitespaceBetweenCasesRule.swift
@@ -191,31 +191,22 @@ extension VerticalWhitespaceBetweenCasesRule: OptInRule {
 }
 
 extension VerticalWhitespaceBetweenCasesRule: CorrectableRule {
-    func correct(file: SwiftLintFile) -> [Correction] {
+    func correct(file: SwiftLintFile) -> Int {
         let violatingRanges = file.ruleEnabled(violatingRanges: violationRanges(in: file), for: self)
-        guard violatingRanges.isNotEmpty else { return [] }
-
+        guard violatingRanges.isNotEmpty else {
+            return 0
+        }
         let patternRegex = regex(pattern)
-        let replacementTemplate = "$1\n$2"
-        let description = Self.description
-
-        var corrections = [Correction]()
         var fileContents = file.contents
-
         for violationRange in violatingRanges.reversed() {
             fileContents = patternRegex.stringByReplacingMatches(
                 in: fileContents,
                 options: [],
                 range: violationRange,
-                withTemplate: replacementTemplate
+                withTemplate: "$1\n$2"
             )
-
-            let location = Location(file: file, characterOffset: violationRange.location)
-            let correction = Correction(ruleDescription: description, location: location)
-            corrections.append(correction)
         }
-
         file.write(fileContents)
-        return corrections
+        return violatingRanges.count
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/VerticalWhitespaceClosingBracesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/VerticalWhitespaceClosingBracesRule.swift
@@ -37,34 +37,24 @@ struct VerticalWhitespaceClosingBracesRule: CorrectableRule, OptInRule {
         }
     }
 
-    func correct(file: SwiftLintFile) -> [Correction] {
+    func correct(file: SwiftLintFile) -> Int {
         let pattern = configuration.onlyEnforceBeforeTrivialLines ? self.trivialLinePattern : self.pattern
-
         let violatingRanges = file.ruleEnabled(violatingRanges: file.violatingRanges(for: pattern), for: self)
-        guard violatingRanges.isNotEmpty else { return [] }
-
-        let patternRegex: NSRegularExpression = regex(pattern)
-        let replacementTemplate = "$2"
-        let description = Self.description
-
-        var corrections = [Correction]()
+        guard violatingRanges.isNotEmpty else {
+            return 0
+        }
+        let patternRegex = regex(pattern)
         var fileContents = file.contents
-
         for violationRange in violatingRanges.reversed() {
             fileContents = patternRegex.stringByReplacingMatches(
                 in: fileContents,
                 options: [],
                 range: violationRange,
-                withTemplate: replacementTemplate
+                withTemplate: "$2"
             )
-
-            let location = Location(file: file, characterOffset: violationRange.location)
-            let correction = Correction(ruleDescription: description, location: location)
-            corrections.append(correction)
         }
-
         file.write(fileContents)
-        return corrections
+        return violatingRanges.count
     }
 }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/VerticalWhitespaceOpeningBracesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/VerticalWhitespaceOpeningBracesRule.swift
@@ -171,31 +171,22 @@ extension VerticalWhitespaceOpeningBracesRule: OptInRule {
 }
 
 extension VerticalWhitespaceOpeningBracesRule: CorrectableRule {
-    func correct(file: SwiftLintFile) -> [Correction] {
+    func correct(file: SwiftLintFile) -> Int {
         let violatingRanges = file.ruleEnabled(violatingRanges: file.violatingRanges(for: pattern), for: self)
-        guard violatingRanges.isNotEmpty else { return [] }
-
-        let patternRegex: NSRegularExpression = regex(pattern)
-        let replacementTemplate = "$1$3"
-        let description = Self.description
-
-        var corrections = [Correction]()
+        guard violatingRanges.isNotEmpty else {
+            return 0
+        }
+        let patternRegex = regex(pattern)
         var fileContents = file.contents
-
         for violationRange in violatingRanges.reversed() {
             fileContents = patternRegex.stringByReplacingMatches(
                 in: fileContents,
                 options: [],
                 range: violationRange,
-                withTemplate: replacementTemplate
+                withTemplate: "$1$3"
             )
-
-            let location = Location(file: file, characterOffset: violationRange.location)
-            let correction = Correction(ruleDescription: description, location: location)
-            corrections.append(correction)
         }
-
         file.write(fileContents)
-        return corrections
+        return violatingRanges.count
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/VoidReturnRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/VoidReturnRule.swift
@@ -62,7 +62,7 @@ private extension VoidReturnRule {
     final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: ReturnClauseSyntax) -> ReturnClauseSyntax {
             if node.violates {
-                correctionPositions.append(node.type.positionAfterSkippingLeadingTrivia)
+                numberOfCorrections += 1
                 let node = node
                     .with(\.type, TypeSyntax(IdentifierTypeSyntax(name: "Void")))
                     .with(\.trailingTrivia, node.type.trailingTrivia)

--- a/Source/SwiftLintCore/Models/Correction.swift
+++ b/Source/SwiftLintCore/Models/Correction.swift
@@ -1,21 +1,26 @@
 /// A value describing a SwiftLint violation that was corrected.
 public struct Correction: Equatable, Sendable {
-    /// The description of the rule for which this correction was applied.
-    public let ruleDescription: RuleDescription
-    /// The location of the original violation that was corrected.
-    public let location: Location
+    /// The name of the rule that was corrected.
+    public let ruleName: String
+    /// The path to the file that was corrected.
+    public let filePath: String?
+    /// The number of corrections that were made.
+    public let numberOfCorrections: Int
 
     /// The console-printable description for this correction.
     public var consoleDescription: String {
-        "\(location.file ?? "<nopath>"): Corrected \(ruleDescription.name)"
+        let times = numberOfCorrections == 1 ? "time" : "times"
+        return "\(filePath ?? "<nopath>"): Corrected \(ruleName) \(numberOfCorrections) \(times)"
     }
 
     /// Memberwise initializer.
     ///
-    /// - parameter ruleDescription: The description of the rule for which this correction was applied.
-    /// - parameter location:        The location of the original violation that was corrected.
-    public init(ruleDescription: RuleDescription, location: Location) {
-        self.ruleDescription = ruleDescription
-        self.location = location
+    /// - parameter ruleName: The name of the rule that was corrected.
+    /// - parameter filePath: The path to the file that was corrected.
+    /// - parameter numberOfCorrections: The number of corrections that were made.
+    public init(ruleName: String, filePath: String?, numberOfCorrections: Int) {
+        self.ruleName = ruleName
+        self.filePath = filePath
+        self.numberOfCorrections = numberOfCorrections
     }
 }

--- a/Source/SwiftLintCore/Protocols/CollectingRule.swift
+++ b/Source/SwiftLintCore/Protocols/CollectingRule.swift
@@ -43,6 +43,8 @@ public protocol CollectingRule: AnyCollectingRule {
     func validate(file: SwiftLintFile, collectedInfo: [SwiftLintFile: FileInfo]) -> [StyleViolation]
 }
 
+// MARK: - == Implementations
+
 public extension CollectingRule {
     func collectInfo(for file: SwiftLintFile, into storage: RuleStorage, compilerArguments: [String]) {
         storage.collect(info: collectInfo(for: file, compilerArguments: compilerArguments),
@@ -88,8 +90,6 @@ public extension CollectingRule where Self: AnalyzerRule {
         )
     }
 }
-
-// MARK: - == Implementations
 
 /// :nodoc:
 public extension Array where Element == any Rule {

--- a/Source/SwiftLintFramework/LintOrAnalyzeCommand.swift
+++ b/Source/SwiftLintFramework/LintOrAnalyzeCommand.swift
@@ -330,6 +330,13 @@ package struct LintOrAnalyzeCommand {
                     if options.useSTDIN {
                         queuedPrint(linter.file.contents)
                     } else {
+                        let corrections = corrections.map {
+                            Correction(
+                                ruleName: $0.0,
+                                filePath: linter.file.path,
+                                numberOfCorrections: $0.1
+                            )
+                        }
                         if options.progress {
                             await correctionsBuilder.append(corrections)
                         } else {

--- a/Source/swiftlint-dev/Rules+Template.swift
+++ b/Source/swiftlint-dev/Rules+Template.swift
@@ -183,7 +183,7 @@ private extension SwiftLintDev.Rules.Template {
                             let bindings = node.bindings.map { binding in
                                 if let pattern = binding.pattern.as(IdentifierPatternSyntax.self),
                                 pattern.identifier.text == "foo" {
-                                    correctionPositions.append(pattern.positionAfterSkippingLeadingTrivia)
+                                    numberOfCorrections += 1
                                     return binding.with(
                                         \\.pattern,
                                         PatternSyntax(pattern.with(\\.identifier, .identifier("bar")))

--- a/Tests/CLITests/RulesFilterTests.swift
+++ b/Tests/CLITests/RulesFilterTests.swift
@@ -173,7 +173,7 @@ private struct CorrectableRuleMock: CorrectableRule {
         []
     }
 
-    func correct(file _: SwiftLintFile) -> [Correction] {
-        []
+    func correct(file _: SwiftLintFile) -> Int {
+        0
     }
 }

--- a/Tests/FrameworkTests/CollectingRuleTests.swift
+++ b/Tests/FrameworkTests/CollectingRuleTests.swift
@@ -71,7 +71,6 @@ final class CollectingRuleTests: SwiftLintTestCase {
         XCTAssertFalse(violations(Example("_ = 0"), config: Spec.configuration!, requiresFileOnDisk: true).isEmpty)
     }
 
-    // swiftlint:disable:next function_body_length
     func testCorrects() {
         struct Spec: MockCollectingRule, CorrectableRule {
             var configuration = SeverityConfiguration<Self>(.warning)
@@ -92,19 +91,11 @@ final class CollectingRuleTests: SwiftLintTestCase {
                 return []
             }
 
-            func correct(file: SwiftLintFile, collectedInfo: [SwiftLintFile: String]) -> [Correction] {
-                if collectedInfo[file] == "baz" {
-                    return [
-                        Correction(
-                            ruleDescription: Self.description,
-                            location: Location(file: file, byteOffset: 2)
-                        ),
-                    ]
-                }
-                return []
+            func correct(file: SwiftLintFile, collectedInfo: [SwiftLintFile: String]) -> Int {
+                collectedInfo[file] == "baz" ? 1 : 0
             }
 
-            func correct(file: SwiftLintFile) -> [Correction] {
+            func correct(file: SwiftLintFile) -> Int {
                 correct(file: file, collectedInfo: [file: collectInfo(for: file)])
             }
         }
@@ -118,26 +109,18 @@ final class CollectingRuleTests: SwiftLintTestCase {
 
             func validate(file: SwiftLintFile, collectedInfo: [SwiftLintFile: String], compilerArguments _: [String])
                 -> [StyleViolation] {
-                    if collectedInfo[file] == "baz" {
-                        return [
-                            StyleViolation(
-                                ruleDescription: Spec.description,
-                                location: Location(file: file, byteOffset: 2)
-                            ),
-                        ]
-                    }
-                    return []
+                    collectedInfo[file] == "baz"
+                        ? [.init(ruleDescription: Spec.description, location: Location(file: file, byteOffset: 2))]
+                        : []
             }
 
             func correct(file: SwiftLintFile,
                          collectedInfo: [SwiftLintFile: String],
-                         compilerArguments _: [String]) -> [Correction] {
-                collectedInfo[file] == "baz"
-                    ? [Correction(ruleDescription: Spec.description, location: Location(file: file, byteOffset: 2))]
-                    : []
+                         compilerArguments _: [String]) -> Int {
+                collectedInfo[file] == "baz" ? 1 : 0
             }
 
-            func correct(file: SwiftLintFile) -> [Correction] {
+            func correct(file: SwiftLintFile) -> Int {
                 correct(file: file, collectedInfo: [file: collectInfo(for: file)], compilerArguments: [])
             }
         }

--- a/Tests/FrameworkTests/EmptyFileTests.swift
+++ b/Tests/FrameworkTests/EmptyFileTests.swift
@@ -23,8 +23,7 @@ final class EmptyFileTests: SwiftLintTestCase {
 
     func testShouldLintEmptyFileRespectedDuringCorrect() throws {
         let corrections = collectedLinter.correct(using: ruleStorage)
-        XCTAssertEqual(corrections.count, 1)
-        XCTAssertEqual(corrections.first?.ruleDescription.identifier, "rule_mock<LintEmptyFiles>")
+        XCTAssertEqual(corrections, ["rule_mock<LintEmptyFiles>": 1])
     }
 }
 
@@ -56,14 +55,10 @@ private struct RuleMock<ShouldLintEmptyFiles: ShouldLintEmptyFilesProtocol>: Cor
     }
 
     func validate(file: SwiftLintFile) -> [StyleViolation] {
-        [
-            StyleViolation(ruleDescription: Self.description, location: Location(file: file.path))
-        ]
+        [StyleViolation(ruleDescription: Self.description, location: Location(file: file.path))]
     }
 
-    func correct(file: SwiftLintFile) -> [Correction] {
-        [
-            Correction(ruleDescription: Self.description, location: Location(file: file.path))
-        ]
+    func correct(file _: SwiftLintFile) -> Int {
+        1
     }
 }

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -50,15 +50,10 @@ final class IntegrationTests: SwiftLintTestCase {
             forceExclude: false,
             excludeBy: .paths(excludedPaths: config.excludedPaths()))
         let storage = RuleStorage()
-        let corrections = swiftFiles.parallelFlatMap {
+        let corrections = swiftFiles.parallelMap {
             Linter(file: $0, configuration: config).collect(into: storage).correct(using: storage)
         }
-        for correction in corrections {
-            correction.location.file!.withStaticString {
-                XCTFail(correction.ruleDescription.description,
-                        file: $0, line: UInt(correction.location.line!))
-            }
-        }
+        XCTAssert(corrections.allSatisfy { $0.isEmpty }, "Unexpected corrections have been applied")
     }
 }
 


### PR DESCRIPTION
Reporting of exact positions was already [removed in 0.56.0](https://github.com/realm/SwiftLint/pull/5596) to collect feedback. So far there haven't been any complaints about the less informative report.

The new message is now like `<file_path>: Corrected Trailing Whitespace 7 times`. Counting the fixes is easy so I came up with this. The question is whether that's actually useful information ...