### PR TITLE
Revert "Improve performance of excluded files filter"

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -94,7 +94,6 @@ swift_library(
         ":SourceKittenFramework.wrapper",
         "@sourcekitten_com_github_jpsim_yams//:Yams",
         "@swiftlint_com_github_scottrhoyt_swifty_text_table//:SwiftyTextTable",
-        "@com_github_ileitch_swift-filename-matcher//:FilenameMatcher"
     ] + select({
         "@platforms//os:linux": ["@com_github_krzyzanowskim_cryptoswift//:CryptoSwift"],
         "//conditions:default": [":DyldWarningWorkaround"],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@
   [SimplyDanny](https://github.com/SimplyDanny)
   [#5954](https://github.com/realm/SwiftLint/issues/5954)
 
+* Revert changes to improve performance when exclude patterns resolve to a large set of files. While resolving files
+  indeed got much faster in certain setups, it leads to missed exclusions for nested configurations and when the linted
+  folder is not the current folder.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#5953](https://github.com/realm/SwiftLint/issues/5953)
+
 #### Experimental
 
 * None.

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,7 +14,6 @@ bazel_dep(name = "sourcekitten", version = "0.36.0", repo_name = "com_github_jps
 bazel_dep(name = "swift-syntax", version = "600.0.0", repo_name = "SwiftSyntax")
 bazel_dep(name = "swift_argument_parser", version = "1.3.1.1", repo_name = "sourcekitten_com_github_apple_swift_argument_parser")
 bazel_dep(name = "yams", version = "5.1.3", repo_name = "sourcekitten_com_github_jpsim_yams")
-bazel_dep(name = "swift-filename-matcher", version = "2.0.0", repo_name = "com_github_ileitch_swift-filename-matcher")
 
 swiftlint_repos = use_extension("//bazel:repos.bzl", "swiftlint_repos_bzlmod")
 use_repo(

--- a/Package.resolved
+++ b/Package.resolved
@@ -37,15 +37,6 @@
       }
     },
     {
-      "identity" : "swift-filename-matcher",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/ileitch/swift-filename-matcher",
-      "state" : {
-        "revision" : "516ff95f6a06c7a9eff8e944e989c7af076c5cdb",
-        "version" : "2.0.0"
-      }
-    },
-    {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",

--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,6 @@ let package = Package(
         .package(url: "https://github.com/scottrhoyt/SwiftyTextTable.git", from: "0.9.0"),
         .package(url: "https://github.com/JohnSundell/CollectionConcurrencyKit.git", from: "0.2.0"),
         .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", .upToNextMinor(from: "1.8.4")),
-        .package(url: "https://github.com/ileitch/swift-filename-matcher", .upToNextMinor(from: "2.0.0")),
     ],
     targets: [
         .executableTarget(
@@ -92,7 +91,6 @@ let package = Package(
                 .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
                 .product(name: "SwiftyTextTable", package: "SwiftyTextTable"),
                 .product(name: "Yams", package: "Yams"),
-                .product(name: "FilenameMatcher", package: "swift-filename-matcher"),
                 "SwiftLintCoreMacros",
             ],
             swiftSettings: swiftFeatures + strictConcurrency

--- a/Source/SwiftLintCore/Extensions/String+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/String+SwiftLint.swift
@@ -68,18 +68,9 @@ public extension String {
 
     /// Returns a new string, converting the path to a canonical absolute path.
     ///
-    /// > Important: This method might use an incorrect working directory internally. This can cause test failures
-    /// in Bazel builds but does not seem to cause trouble in production.
-    ///
     /// - returns: A new `String`.
     func absolutePathStandardized() -> String {
         bridge().absolutePathRepresentation().bridge().standardizingPath
-    }
-
-    /// Like ``absolutePathStandardized()`` but with the working directory that's used everywhere else.
-    var normalized: String {
-        let cwd = FileManager.default.currentDirectoryPath.bridge().standardizingPath
-        return bridge().absolutePathRepresentation(rootDirectory: cwd)
     }
 
     var isFile: Bool {

--- a/Source/SwiftLintFramework/Helpers/Glob.swift
+++ b/Source/SwiftLintFramework/Helpers/Glob.swift
@@ -1,4 +1,3 @@
-import FilenameMatcher
 import Foundation
 
 #if os(Linux)
@@ -35,28 +34,6 @@ struct Glob {
             .unique
             .sorted()
             .map { $0.absolutePathStandardized() }
-    }
-
-    static func createFilenameMatchers(root: String, pattern: String) -> [FilenameMatcher] {
-        var absolutPathPattern = pattern
-        if !pattern.starts(with: root) {
-            // If the root is not already part of the pattern, prepend it.
-            absolutPathPattern = root + (root.hasSuffix("/") ? "" : "/") + absolutPathPattern
-        }
-        if pattern.hasSuffix(".swift") || pattern.hasSuffix("/**") {
-            // Suffix is already well defined.
-            return [FilenameMatcher(pattern: absolutPathPattern)]
-        }
-        if pattern.hasSuffix("/") {
-            // Matching all files in the folder.
-            return [FilenameMatcher(pattern: absolutPathPattern + "**")]
-        }
-        // The pattern could match files in the last folder in the path or all contained files if the last component
-        // represents folders.
-        return [
-            FilenameMatcher(pattern: absolutPathPattern),
-            FilenameMatcher(pattern: absolutPathPattern + "/**"),
-        ]
     }
 
     // MARK: Private

--- a/Tests/FrameworkTests/GlobTests.swift
+++ b/Tests/FrameworkTests/GlobTests.swift
@@ -83,31 +83,4 @@ final class GlobTests: SwiftLintTestCase {
         let files = Glob.resolveGlob(mockPath.stringByAppendingPathComponent("**/*.swift"))
         XCTAssertEqual(files.sorted(), expectedFiles.sorted())
     }
-
-    func testCreateFilenameMatchers() {
-        func assertGlobMatch(root: String, pattern: String, filename: String) {
-            let matchers = Glob.createFilenameMatchers(root: root, pattern: pattern)
-            XCTAssert(matchers.anyMatch(filename: filename))
-        }
-
-        assertGlobMatch(root: "/a/b/", pattern: "c/*.swift", filename: "/a/b/c/d.swift")
-        assertGlobMatch(root: "/a", pattern: "**/*.swift", filename: "/a/b/c/d.swift")
-        assertGlobMatch(root: "/a", pattern: "**/*.swift", filename: "/a/b.swift")
-        assertGlobMatch(root: "", pattern: "**/*.swift", filename: "/a/b.swift")
-        assertGlobMatch(root: "", pattern: "a/**/b.swift", filename: "a/b.swift")
-        assertGlobMatch(root: "", pattern: "a/**/b.swift", filename: "a/c/b.swift")
-        assertGlobMatch(root: "", pattern: "**/*.swift", filename: "a.swift")
-        assertGlobMatch(root: "", pattern: "a/**/*.swift", filename: "a/b/c.swift")
-        assertGlobMatch(root: "", pattern: "a/**/*.swift", filename: "a/b.swift")
-        assertGlobMatch(root: "/a/b", pattern: "/a/b/c/*.swift", filename: "/a/b/c/d.swift")
-        assertGlobMatch(root: "/a/", pattern: "/a/b/c/*.swift", filename: "/a/b/c/d.swift")
-
-        assertGlobMatch(root: "", pattern: "/a/b/c", filename: "/a/b/c/d.swift")
-        assertGlobMatch(root: "", pattern: "/a/b/c/", filename: "/a/b/c/d.swift")
-        assertGlobMatch(root: "", pattern: "/a/b/c/*.swift", filename: "/a/b/c/d.swift")
-        assertGlobMatch(root: "", pattern: "/d.swift/*.swift", filename: "/d.swift/e.swift")
-        assertGlobMatch(root: "", pattern: "/a/**", filename: "/a/b/c/d.swift")
-        assertGlobMatch(root: "", pattern: "**/*Test*", filename: "/a/b/c/MyTest2.swift")
-        assertGlobMatch(root: "", pattern: "**/*Test*", filename: "/a/b/MyTests/c.swift")
-    }
 }

--- a/Tests/IntegrationTests/IntegrationTests.swift
+++ b/Tests/IntegrationTests/IntegrationTests.swift
@@ -23,7 +23,7 @@ final class IntegrationTests: SwiftLintTestCase {
         let swiftFiles = config.lintableFiles(
             inPath: "",
             forceExclude: false,
-            excludeByPrefix: false)
+            excludeBy: .paths(excludedPaths: config.excludedPaths()))
         XCTAssert(
             swiftFiles.contains(where: { #filePath.bridge().absolutePathRepresentation() == $0.path }),
             "current file should be included"
@@ -48,7 +48,7 @@ final class IntegrationTests: SwiftLintTestCase {
         let swiftFiles = config.lintableFiles(
             inPath: "",
             forceExclude: false,
-            excludeByPrefix: false)
+            excludeBy: .paths(excludedPaths: config.excludedPaths()))
         let storage = RuleStorage()
         let corrections = swiftFiles.parallelFlatMap {
             Linter(file: $0, configuration: config).collect(into: storage).correct(using: storage)

--- a/bazel/repos.bzl
+++ b/bazel/repos.bzl
@@ -64,13 +64,6 @@ def swiftlint_repos(bzlmod = False):
         url = "https://github.com/krzyzanowskim/CryptoSwift/archive/refs/tags/1.8.4.tar.gz",
     )
 
-    http_archive(
-        name = "com_github_ileitch_swift-filename-matcher",
-        sha256 = "1adbb1eb042910f996689827f7dee217bebf7c5178f34178bcfe468b5b3268a2",
-        strip_prefix = "swift-filename-matcher-2.0.0",
-        url = "https://github.com/ileitch/swift-filename-matcher/archive/refs/tags/2.0.0.tar.gz",
-    )
-
 def _swiftlint_repos_bzlmod(_):
     swiftlint_repos(bzlmod = True)
 


### PR DESCRIPTION
This reverts commit 152355e36f97ef5cf1c420181237f2e89e653b28.

Fixes #5953.

#5157 seemed promising. However, there are still details missing that need further investigation. While resolving files indeed got much faster in certain setups, it leads to missed exclusions for nested configurations and when the linted folder is not the current folder.