### PR TITLE
Parallelize SwiftLintFile construction, for a modest speedup

### DIFF
--- a/Source/SwiftLintFramework/Configuration/Configuration+LintableFiles.swift
+++ b/Source/SwiftLintFramework/Configuration/Configuration+LintableFiles.swift
@@ -20,7 +20,9 @@ extension Configuration {
                               forceExclude: Bool,
                               excludeBy: ExcludeBy) -> [SwiftLintFile] {
         lintablePaths(inPath: path, forceExclude: forceExclude, excludeBy: excludeBy)
-            .compactMap(SwiftLintFile.init(pathDeferringReading:))
+            .parallelCompactMap {
+                SwiftLintFile(pathDeferringReading: $0)
+            }
     }
 
     /// Returns the paths for files that can be linted by SwiftLint in the specified parent path.


### PR DESCRIPTION
`SwiftLintFile` is relatively expensive to construct; doing so in parallel provides a modest improvement to startup overhead.