### PR TITLE
avoid pre-reading files

### DIFF
--- a/Source/SwiftLintFramework/Models/Linter.swift
+++ b/Source/SwiftLintFramework/Models/Linter.swift
@@ -66,29 +66,33 @@ private extension Rule {
         return superfluousDisableCommandViolations
     }
 
+    func shouldRun(onFile file: SwiftLintFile) -> Bool {
+        // We shouldn't lint if the current Swift version is not supported by the rule
+        guard SwiftVersion.current >= Self.description.minSwiftVersion else {
+            return false
+        }
+
+        // Empty files shouldn't trigger violations if `shouldLintEmptyFiles` is `false`
+        if file.isEmpty, !shouldLintEmptyFiles {
+            return false
+        }
+
+        if !(self is any SourceKitFreeRule) && file.sourcekitdFailed {
+            warnSourceKitFailedOnce()
+            return false
+        }
+
+        return true
+    }
+
     // As we need the configuration to get custom identifiers.
-    // swiftlint:disable:next function_parameter_count function_body_length
+    // swiftlint:disable:next function_parameter_count
     func lint(file: SwiftLintFile,
               regions: [Region],
               benchmark: Bool,
               storage: RuleStorage,
               superfluousDisableCommandRule: SuperfluousDisableCommandRule?,
-              compilerArguments: [String]) -> LintResult? {
-        // We shouldn't lint if the current Swift version is not supported by the rule
-        guard SwiftVersion.current >= Self.description.minSwiftVersion else {
-            return nil
-        }
-
-        // Empty files shouldn't trigger violations if `shouldLintEmptyFiles` is `false`
-        if file.isEmpty, !shouldLintEmptyFiles {
-            return nil
-        }
-
-        if !(self is any SourceKitFreeRule) && file.sourcekitdFailed {
-            warnSourceKitFailedOnce()
-            return nil
-        }
-
+              compilerArguments: [String]) -> LintResult {
         let ruleID = Self.identifier
 
         let violations: [StyleViolation]
@@ -226,12 +230,7 @@ public struct Linter {
         self.configuration = configuration
         self.compilerArguments = compilerArguments
 
-        let fileIsEmpty = file.isEmpty
         let rules = configuration.rules.filter { rule in
-            if fileIsEmpty, !rule.shouldLintEmptyFiles {
-                return false
-            }
-
             if compilerArguments.isEmpty {
                 return !(rule is any AnalyzerRule)
             }
@@ -307,11 +306,15 @@ public struct CollectedLinter {
         let superfluousDisableCommandRule = rules.first(where: {
             $0 is SuperfluousDisableCommandRule
         }) as? SuperfluousDisableCommandRule
-        let validationResults = rules.parallelCompactMap {
-            $0.lint(file: file, regions: regions, benchmark: benchmark,
-                    storage: storage,
-                    superfluousDisableCommandRule: superfluousDisableCommandRule,
-                    compilerArguments: compilerArguments)
+        let validationResults: [LintResult] = rules.parallelCompactMap {
+            guard $0.shouldRun(onFile: file) else {
+                return nil
+            }
+
+            return $0.lint(file: file, regions: regions, benchmark: benchmark,
+                           storage: storage,
+                           superfluousDisableCommandRule: superfluousDisableCommandRule,
+                           compilerArguments: compilerArguments)
         }
         let undefinedSuperfluousCommandViolations = self.undefinedSuperfluousCommandViolations(
             regions: regions, configuration: configuration,
@@ -378,7 +381,13 @@ public struct CollectedLinter {
         }
 
         var corrections = [Correction]()
-        for rule in rules.compactMap({ $0 as? any CorrectableRule }) {
+        for rule in rules.compactMap({ (rule: any Rule) -> (any CorrectableRule)? in
+            guard rule.shouldRun(onFile: file) else {
+                return nil
+            }
+
+            return rule as? any CorrectableRule
+        }) {
             let newCorrections = rule.correct(file: file, using: storage, compilerArguments: compilerArguments)
             corrections += newCorrections
             if newCorrections.isNotEmpty, !file.isVirtual {

--- a/Source/SwiftLintFramework/Models/Linter.swift
+++ b/Source/SwiftLintFramework/Models/Linter.swift
@@ -381,13 +381,10 @@ public struct CollectedLinter {
         }
 
         var corrections = [Correction]()
-        for rule in rules.compactMap({ (rule: any Rule) -> (any CorrectableRule)? in
-            guard rule.shouldRun(onFile: file) else {
-                return nil
+        for rule in rules where rule.shouldRun(onFile: file) {
+            guard let rule = rule as? any CorrectableRule else {
+                continue
             }
-
-            return rule as? any CorrectableRule
-        }) {
             let newCorrections = rule.correct(file: file, using: storage, compilerArguments: compilerArguments)
             corrections += newCorrections
             if newCorrections.isNotEmpty, !file.isVirtual {

--- a/Tests/FrameworkTests/EmptyFileTests.swift
+++ b/Tests/FrameworkTests/EmptyFileTests.swift
@@ -1,0 +1,75 @@
+import SwiftLintFramework
+import XCTest
+
+private protocol BooleanConstant {
+    static var boolValue: Bool { get }
+}
+
+private struct True: BooleanConstant {
+    static var boolValue: Bool { true }
+}
+
+private struct False: BooleanConstant {
+    static var boolValue: Bool { false }
+}
+
+private struct RuleWithLintEmptyFilesMock<ShouldLintEmptyFiles: BooleanConstant>: CorrectableRule {
+    var configuration = SeverityConfiguration<Self>(.warning)
+
+    static var description: RuleDescription {
+        RuleDescription(identifier: "lint_empty_files_mock<\(ShouldLintEmptyFiles.boolValue)>",
+                        name: "",
+                        description: "",
+                        kind: .style,
+                        deprecatedAliases: ["mock"])
+    }
+
+    init() { /* conformance for test */ }
+    init(configuration _: Any) throws {
+        self.init()
+    }
+
+    var shouldLintEmptyFiles: Bool {
+        ShouldLintEmptyFiles.boolValue
+    }
+
+    func validate(file: SwiftLintFile) -> [StyleViolation] {
+        [
+            StyleViolation(ruleDescription: Self.description, location: Location(file: file.path))
+        ]
+    }
+
+    func correct(file: SwiftLintFile) -> [Correction] {
+        [
+            Correction(ruleDescription: Self.description, location: Location(file: file.path))
+        ]
+    }
+}
+
+final class EmptyFileTests: SwiftLintTestCase {
+    func testShouldLintEmptyFileRespectedDuringLint() {
+        let ruleList = RuleList(rules: RuleWithLintEmptyFilesMock<False>.self,
+                                RuleWithLintEmptyFilesMock<True>.self)
+        let configuration = try! Configuration(dict: [:], ruleList: ruleList) // swiftlint:disable:this force_try
+        let file = SwiftLintFile(contents: "")
+        let linter = Linter(file: file, configuration: configuration)
+        let ruleStorage = RuleStorage()
+        let collectedLinter = linter.collect(into: ruleStorage)
+        let styleViolations = collectedLinter.styleViolations(using: ruleStorage)
+        XCTAssertEqual(styleViolations.count, 1)
+        XCTAssertEqual(styleViolations.first?.ruleIdentifier, "lint_empty_files_mock<true>")
+    }
+
+    func testShouldLintEmptyFileRespectedDuringCorrect() {
+        let ruleList = RuleList(rules: RuleWithLintEmptyFilesMock<False>.self,
+                                RuleWithLintEmptyFilesMock<True>.self)
+        let configuration = try! Configuration(dict: [:], ruleList: ruleList) // swiftlint:disable:this force_try
+        let file = SwiftLintFile(contents: "")
+        let linter = Linter(file: file, configuration: configuration)
+        let ruleStorage = RuleStorage()
+        let collectedLinter = linter.collect(into: ruleStorage)
+        let corrections = collectedLinter.correct(using: ruleStorage)
+        XCTAssertEqual(corrections.count, 1)
+        XCTAssertEqual(corrections.first?.ruleDescription.identifier, "lint_empty_files_mock<true>")
+    }
+}

--- a/Tests/FrameworkTests/EmptyFileTests.swift
+++ b/Tests/FrameworkTests/EmptyFileTests.swift
@@ -6,18 +6,12 @@ final class EmptyFileTests: SwiftLintTestCase {
     var ruleStorage: RuleStorage! // swiftlint:disable:this implicitly_unwrapped_optional
 
     override func setUpWithError() throws {
-        let ruleList = RuleList(rules: RuleMock<DontLintEmptyFiles>.self,
-                                RuleMock<LintEmptyFiles>.self)
+        let ruleList = RuleList(rules: RuleMock<DontLintEmptyFiles>.self, RuleMock<LintEmptyFiles>.self)
         let configuration = try Configuration(dict: [:], ruleList: ruleList)
         let file = SwiftLintFile(contents: "")
         let linter = Linter(file: file, configuration: configuration)
         ruleStorage = RuleStorage()
         collectedLinter = linter.collect(into: ruleStorage)
-    }
-
-    override func tearDownWithError() throws {
-        collectedLinter = nil
-        ruleStorage = nil
     }
 
     func testShouldLintEmptyFileRespectedDuringLint() throws {

--- a/Tests/FrameworkTests/EmptyFileTests.swift
+++ b/Tests/FrameworkTests/EmptyFileTests.swift
@@ -1,6 +1,7 @@
 import SwiftLintFramework
 import XCTest
 
+// swiftlint:disable:next balanced_xctest_lifecycle
 final class EmptyFileTests: SwiftLintTestCase {
     var collectedLinter: CollectedLinter! // swiftlint:disable:this implicitly_unwrapped_optional
     var ruleStorage: RuleStorage! // swiftlint:disable:this implicitly_unwrapped_optional


### PR DESCRIPTION
Per #5947, files are being read unnecessarily when they have been previously linted and appear in the cache.

To avoid this,
* remove the test for file emptiness from `Linter.init`
* extract the redundant check for this in `Rule.lint` to a helper, which simplifies `Rule.lint` and allows it to return non-optional
* check the helper before calling either `Rule.lint` or `Rule.correct`. 
