### PR TITLE
Fix issue referencing the Tests package from another Bazel workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@
 
 ### Bug Fixes
 
-* None.
+* Fix issue referencing the Tests package from another Bazel workspace.  
+  [jszumski](https://github.com/jszumski)
+  [#5977](https://github.com/realm/SwiftLint/issues/5977)
 
 ## 0.58.2: New Year’s Fresh Fold
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@
 
 * Fix issue referencing the Tests package from another Bazel workspace.  
   [jszumski](https://github.com/jszumski)
-  [#5977](https://github.com/realm/SwiftLint/issues/5977)
 
 ## 0.58.2: New Year’s Fresh Fold
 

--- a/Tests/BUILD
+++ b/Tests/BUILD
@@ -104,6 +104,7 @@ swift_test(
     name = "BuiltInRulesTests",
     data = glob(
         ["BuiltInRulesTests/Resources/**"],
+        allow_empty = True,
         # Bazel doesn't support paths with spaces in them
         exclude = ["BuiltInRulesTests/Resources/FileNameNoSpaceRuleFixtures/**"],
     ),


### PR DESCRIPTION
Allow `BuiltInRulesTests` data to be empty so a workspace can load the Tests package from a release archive.

Otherwise, Bazel users with `--incompatible_disallow_empty_glob` enabled will hit this error because the release archive only contains Swift files and not any test fixtures:

```
Error in glob: glob pattern 'BuiltInRulesTests/Resources/**' didn't match anything, but allow_empty is set to False (the default value of allow_empty can be set with --incompatible_disallow_empty_glob).
```

Note that `--incompatible_disallow_empty_glob` is enabled by default in Bazel 8