### PR TITLE
Allow severity of `duplicate_imports` rule to be configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@
 * Fix issue referencing the Tests package from another Bazel workspace.  
   [jszumski](https://github.com/jszumski)
 
+* Allow severity of `duplicate_imports` rule to be configurable.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#5978](https://github.com/realm/SwiftLint/issues/5978)
+
 ## 0.58.2: New Year’s Fresh Fold
 
 ### Breaking

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DuplicateImportsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DuplicateImportsRule.swift
@@ -26,6 +26,7 @@ struct DuplicateImportsRule: SwiftSyntaxCorrectableRule {
         file.duplicateImportsViolationPositions().map { position in
             StyleViolation(
                 ruleDescription: Self.description,
+                severity: configuration.severity,
                 location: Location(file: file, position: position)
             )
         }


### PR DESCRIPTION
Fixes #5978.