### PR TITLE
File grouping is pretty CPU-heavy; parallelize it.

### DIFF
--- a/Source/SwiftLintCore/Extensions/Array+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/Array+SwiftLint.swift
@@ -84,7 +84,7 @@ public extension Array {
     /// `concurrentPerform`.
     ///
     /// - parameter transform: The transformation function to extract an element to its group key,
-    ///                        or exclude the element..
+    ///                        or exclude the element.
     ///
     /// - returns: The elements grouped by applying the specified transformation.
     func parallelFilterGroup<U: Hashable & Sendable>(by transform: @Sendable (Element) -> U?) ->

--- a/Source/SwiftLintCore/Extensions/Array+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/Array+SwiftLint.swift
@@ -66,7 +66,7 @@ public extension Array {
     /// Elements for which the `transform` returns a `nil` key are removed.
     ///
     /// - parameter transform: The transformation function to extract an element to its group key,
-    ///                        or exclude the element..
+    ///                        or exclude the element.
     ///
     /// - returns: The elements grouped by applying the specified transformation.
     func filterGroup<U: Hashable & Sendable>(by transform: (Element) -> U?) ->

--- a/Source/SwiftLintCore/Extensions/Array+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/Array+SwiftLint.swift
@@ -62,6 +62,46 @@ public extension Array {
         Dictionary(grouping: self, by: { transform($0) })
     }
 
+    /// Group the elements in this array into a dictionary, keyed by applying the specified `transform`.
+    /// Elements for which the `transform` returns a `nil` key are removed.
+    ///
+    /// - parameter transform: The transformation function to extract an element to its group key,
+    ///                        or exclude the element..
+    ///
+    /// - returns: The elements grouped by applying the specified transformation.
+    func filterGroup<U: Hashable & Sendable>(by transform: (Element) -> U?) ->
+        [U: [Element]] where Element: Sendable {
+        var result = [U: [Element]]()
+        for element in self {
+            if let key = transform(element) {
+                result[key, default: []].append(element)
+            }
+        }
+        return result
+    }
+
+    /// Same as `filterGroup`, but spreads the work in the `transform` block in parallel using GCD's
+    /// `concurrentPerform`.
+    ///
+    /// - parameter transform: The transformation function to extract an element to its group key,
+    ///                        or exclude the element..
+    ///
+    /// - returns: The elements grouped by applying the specified transformation.
+    func parallelFilterGroup<U: Hashable & Sendable>(by transform: @Sendable (Element) -> U?) ->
+        [U: [Element]] where Element: Sendable {
+        if count < 16 {
+            return filterGroup(by: transform)
+        }
+        let pivot = count / 2
+        let results = [
+            Array(self[0..<pivot]),
+            Array(self[pivot...]),
+        ].parallelMap { subarray in
+            subarray.parallelFilterGroup(by: transform)
+        }
+        return results[0].merging(results[1], uniquingKeysWith: +)
+    }
+
     /// Returns the elements failing the `belongsInSecondPartition` test, followed by the elements passing the
     /// `belongsInSecondPartition` test.
     ///

--- a/Source/SwiftLintFramework/Configuration+CommandLine.swift
+++ b/Source/SwiftLintFramework/Configuration+CommandLine.swift
@@ -111,8 +111,7 @@ extension Configuration {
             )
         }
 
-        var groupedFiles = [Configuration: [SwiftLintFile]]()
-        for file in files {
+        return files.parallelFilterGroup { file in
             let fileConfiguration = configuration(for: file)
             let fileConfigurationRootPath = fileConfiguration.rootDirectory.bridge()
 
@@ -124,12 +123,8 @@ extension Configuration {
                 return filePathComponents.starts(with: excludedPathComponents)
             }
 
-            if !shouldSkip {
-                groupedFiles[fileConfiguration, default: []].append(file)
-            }
+            return shouldSkip ? nil : fileConfiguration
         }
-
-        return groupedFiles
     }
 
     private func outputFilename(for path: String, duplicateFileNames: Set<String>) -> String {


### PR DESCRIPTION
You've heard the drill by now — I care deeply about startup time, and this particular thing SwiftLint does at startup is pretty slow.

`groupFiles` is doing a fair amount of CPU work on a single thread. For my project with 12k files and at least 10 different configs, it takes ~1.6s on my M1 MBP.

I've copied patterns from other functions in Array+SwiftLint, and not unit-tested them specifically because none of the other functions here are unit-tested, but maybe that's an oversight?