### PR TITLE
UnneededOverrideRule: add 'excluded' configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,9 @@
   [kapitoshka438](https://github.com/kapitoshka438)
   [#3723](https://github.com/realm/SwiftLint/issues/3723)
 
-* Add `excluded` configuration option to `unneeded_override` to opt out checking methods with a given name.
+* Add `excluded_methods` configuration option to `unneeded_override` to opt out checking methods with a given name.
   For example, this helps avoid a conflict with `balanced_xctest_lifecycle` where one of `setUp/tearDown`
-  is empty but the other is not.
+  is empty but the other is not.  
   [jaredgrubb](https://github.com/jaredgrubb)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@
   [kapitoshka438](https://github.com/kapitoshka438)
   [#3723](https://github.com/realm/SwiftLint/issues/3723)
 
+* Add `excluded` configuration option to `unneeded_override` to opt out checking methods with a given name.
+  For example, this helps avoid a conflict with `balanced_xctest_lifecycle` where one of `setUp/tearDown`
+  is empty but the other is not.
+  [jaredgrubb](https://github.com/jaredgrubb)
+
 ### Bug Fixes
 
 * Fix issue referencing the Tests package from another Bazel workspace.  

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnneededOverrideRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnneededOverrideRule.swift
@@ -19,7 +19,7 @@ struct UnneededOverrideRule: Rule {
 private extension UnneededOverrideRule {
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FunctionDeclSyntax) {
-            if node.isUnneededOverride {
+            if node.isUnneededOverride(configuration: configuration) {
                 self.violations.append(node.positionAfterSkippingLeadingTrivia)
             }
         }
@@ -33,7 +33,7 @@ private extension UnneededOverrideRule {
 
     final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: FunctionDeclSyntax) -> DeclSyntax {
-            guard node.isUnneededOverride else {
+            guard node.isUnneededOverride(configuration: configuration) else {
                 return super.visit(node)
             }
 
@@ -59,8 +59,8 @@ private extension UnneededOverrideRule {
 }
 
 private extension FunctionDeclSyntax {
-    var isUnneededOverride: Bool {
-        mayBeUnneededOverride(name: name.text)
+    func isUnneededOverride(configuration: UnneededOverrideRuleConfiguration) -> Bool {
+        mayBeUnneededOverride(name: name.text) && !configuration.excluded.contains(name.text)
     }
 }
 
@@ -83,7 +83,7 @@ private protocol OverridableDecl: WithAttributesSyntax, WithModifiersSyntax {
 }
 
 private extension OverridableDecl {
-    /// Perform checks common to all overridable types of declarations.
+    /// Perform checks common to all overridable types of declarations. Returns `true` if the `override` appears to be unneeded.
     func mayBeUnneededOverride(name: String) -> Bool {
         guard modifiers.contains(keyword: .override), let statement = body?.statements.onlyElement else {
             return false

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnneededOverrideRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnneededOverrideRuleExamples.swift
@@ -138,12 +138,12 @@ struct UnneededOverrideRuleExamples {
         }
         """),
         Example("""
-        class Foo {
+        class FooTestCase: XCTestCase {
             override func setUp() {
                 super.setUp()
             }
         }
-        """, configuration: ["excluded": ["setUp"]]),
+        """, configuration: ["excluded_methods": ["setUp"]]),
     ]
 
     static let triggeringExamples = [

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnneededOverrideRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnneededOverrideRuleExamples.swift
@@ -137,6 +137,13 @@ struct UnneededOverrideRuleExamples {
             }
         }
         """),
+        Example("""
+        class Foo {
+            override func setUp() {
+                super.setUp()
+            }
+        }
+        """, configuration: ["excluded": ["setUp"]]),
     ]
 
     static let triggeringExamples = [

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnneededOverrideRuleConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnneededOverrideRuleConfiguration.swift
@@ -8,6 +8,6 @@ struct UnneededOverrideRuleConfiguration: SeverityBasedRuleConfiguration {
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "affect_initializers")
     private(set) var affectInits = false
-    @ConfigurationElement(key: "excluded")
-    private(set) var excluded = Set<String>()
+    @ConfigurationElement(key: "excluded_methods")
+    private(set) var excludedMethods = Set<String>()
 }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnneededOverrideRuleConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnneededOverrideRuleConfiguration.swift
@@ -8,4 +8,6 @@ struct UnneededOverrideRuleConfiguration: SeverityBasedRuleConfiguration {
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "affect_initializers")
     private(set) var affectInits = false
+    @ConfigurationElement(key: "excluded")
+    private(set) var excluded = Set<String>()
 }

--- a/Tests/IntegrationTests/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/default_rule_configurations.yml
@@ -1033,7 +1033,7 @@ unneeded_break_in_switch:
 unneeded_override:
   severity: warning
   affect_initializers: false
-  excluded: []
+  excluded_methods: []
   meta:
     opt-in: false
 unneeded_parentheses_in_closure_argument:

--- a/Tests/IntegrationTests/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/default_rule_configurations.yml
@@ -1033,6 +1033,7 @@ unneeded_break_in_switch:
 unneeded_override:
   severity: warning
   affect_initializers: false
+  excluded: []
   meta:
     opt-in: false
 unneeded_parentheses_in_closure_argument:


### PR DESCRIPTION
Consider a XCTestCase class that has a `tearDown` but no `setUp`:
 - `balanced_xctest_lifecycle` wants them to balance, so asks you to add `setUp`
 - `unneeded_override` complains that an empty `setUp` should not be used

I am adding an `excluded` option to `unneeded_override` so I can add `setUp`(etc) to it and have it skip those methods.