### PR TITLE
Add `line_length` parameter: `ignores_multiline_strings`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 
 ### Enhancements
 
+* Add new option `ignores_multiline_strings` to `line_length` rule. It allows to ignore too long
+  lines inside of multiline strings.  
+  [thisIsTheFoxe](https://github.com/thisisthefoxe)
+  [#2689](https://github.com/realm/SwiftLint/issues/2689)
 * Ignore `UIColor` initializers in `no_magic_numbers` rule.  
   [suojae](https://github.com/suojae)
   [hyeffie](https://github.com/hyeffie)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
   [suojae](https://github.com/suojae)
   [hyeffie](https://github.com/hyeffie)
   [#5183](https://github.com/realm/SwiftLint/issues/5183)
+* Add `line_length` parameter: `ignores_multiline_strings`
+  [thisIsTheFoxe](https://github.com/thisisthefoxe)
+  [#2689](https://github.com/realm/SwiftLint/issues/2689)
 
 * Exclude types with a `@Suite` attribute and functions annotated with `@Test` from `no_magic_numbers` rule.
   Also treat a type as a `@Suite` if it contains `@Test` functions.  

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/LineLengthRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/LineLengthRule.swift
@@ -104,7 +104,7 @@ struct LineLengthRule: Rule {
         // contents of multiline strings only include one string element per line
         guard syntaxKindsByLine[line.index] == [.string] else { return false }
 
-        // find the trailing delimiter `"""` in to make sure we're not in a list of concatinated strings
+        // find the trailing delimiter `"""` in order to make sure we're not in a list of concatenated strings
         let lastStringLineIndex = syntaxKindsByLine.dropFirst(line.index + 1).firstIndex(where: { $0 != [.string] })
         guard let lastStringLineIndex else {
             return file.lines.last?.content.trimmingCharacters(in: .whitespaces).hasPrefix("\"\"\"") == true

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/LineLengthRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/LineLengthRule.swift
@@ -62,6 +62,14 @@ struct LineLengthRule: Rule {
                 return nil
             }
 
+            if configuration.ignoresMultilineStrings,
+               syntaxKindsByLine.value[line.index] == [.string] {
+                let lastStringLineIndex = (syntaxKindsByLine.value.dropFirst(line.index + 1).firstIndex(where: { $0 != [.string] }) ?? (file.lines.count + 1)) - 2
+                if file.lines[lastStringLineIndex].content.trimmingCharacters(in: .whitespaces).hasPrefix("\"\"\"") {
+                    return nil
+                }
+            }
+
             for pattern in configuration.excludedLinesPatterns where line.containsMatchingPattern(pattern) {
                 return nil
             }

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/LineLengthRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/LineLengthRule.swift
@@ -109,7 +109,7 @@ struct LineLengthRule: Rule {
         guard let lastStringLineIndex else {
             return file.lines.last?.content.trimmingCharacters(in: .whitespaces).hasPrefix("\"\"\"") == true
         }
-        
+
         // lines include leading empty element
         // check last string line for single `"""`
         // and if it fails, check the next line contains more than just a string for `"""; let a = 1`

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/LineLengthConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/LineLengthConfiguration.swift
@@ -14,6 +14,8 @@ struct LineLengthConfiguration: RuleConfiguration {
     private(set) var ignoresComments = false
     @ConfigurationElement(key: "ignores_interpolated_strings")
     private(set) var ignoresInterpolatedStrings = false
+    @ConfigurationElement(key: "ignores_multiline_strings")
+    private(set) var ignoresMultilineStrings = false
     @ConfigurationElement(key: "excluded_lines_patterns")
     private(set) var excludedLinesPatterns: Set<String> = []
 

--- a/Tests/BuiltInRulesTests/LineLengthConfigurationTests.swift
+++ b/Tests/BuiltInRulesTests/LineLengthConfigurationTests.swift
@@ -47,6 +47,14 @@ final class LineLengthConfigurationTests: SwiftLintTestCase {
         XCTAssertFalse(configuration2.ignoresInterpolatedStrings)
     }
 
+    func testLineLengthConfigurationInitialiserSetsIgnoresMultilineStrings() {
+        let configuration1 = LineLengthConfiguration(length: severityLevels, ignoresMultilineStrings: true)
+        XCTAssertTrue(configuration1.ignoresMultilineStrings)
+
+        let configuration2 = LineLengthConfiguration(length: severityLevels)
+        XCTAssertFalse(configuration2.ignoresMultilineStrings)
+    }
+
     func testLineLengthConfigurationInitialiserSetsExcludedLinesPatterns() {
         let patterns: Set = ["foo", "bar"]
         let configuration1 = LineLengthConfiguration(length: severityLevels, excludedLinesPatterns: patterns)

--- a/Tests/BuiltInRulesTests/LineLengthRuleTests.swift
+++ b/Tests/BuiltInRulesTests/LineLengthRuleTests.swift
@@ -95,10 +95,12 @@ final class LineLengthRuleTests: SwiftLintTestCase {
 
     func testLineLengthWithIgnoreMultilineStringsTrue() {
         let triggeringLines = [multilineStringFail]
-        let nonTriggeringLines = [multilineString,
-                                  multilineStringWithExpression,
-                                  multilineStringWithNewlineExpression,
-                                  multilineStringWithFunction]
+        let nonTriggeringLines = [
+            multilineString,
+            multilineStringWithExpression,
+            multilineStringWithNewlineExpression,
+            multilineStringWithFunction
+        ]
 
         let baseDescription = LineLengthRule.description
         let nonTriggeringExamples = baseDescription.nonTriggeringExamples + nonTriggeringLines

--- a/Tests/BuiltInRulesTests/LineLengthRuleTests.swift
+++ b/Tests/BuiltInRulesTests/LineLengthRuleTests.swift
@@ -25,10 +25,11 @@ final class LineLengthRuleTests: SwiftLintTestCase {
         String(repeating: "A", count: 121) + "\n" +
         "\"\"\"\n")
     private let multilineStringWithExpression = Example("let multilineString = \"\"\"\n" +
-        String(repeating: "A", count: 121) + "\n" + "\n" +
-        " \"\"\"\n; let a = 1")
-    private let multilineStringFail = Example("let multilineString = \"A\" + \n \"\(String(repeating: "A", count: 121))\" + \n" +
-        "\"\n")
+        String(repeating: "A", count: 121) + "\n\n\"\"\"; let a = 1")
+    private let multilineStringWithNewlineExpression = Example("let multilineString = \"\"\"\n" +
+        String(repeating: "A", count: 121) + "\n\n\"\"\"\n; let a = 1")
+    private let multilineStringFail = Example("let multilineString = \"A\" + \n\"" +
+        String(repeating: "A", count: 121) + "\"\n")
 
     func testLineLength() {
         verifyRule(LineLengthRule.description, commentDoesntViolate: false, stringDoesntViolate: false)
@@ -91,7 +92,7 @@ final class LineLengthRuleTests: SwiftLintTestCase {
 
     func testLineLengthWithIgnoreMultilineStringsTrue() {
         let triggeringLines = [multilineStringFail]
-        let nonTriggeringLines = [multilineString, multilineStringWithExpression]
+        let nonTriggeringLines = [multilineString, multilineStringWithExpression, multilineStringWithNewlineExpression]
 
         let baseDescription = LineLengthRule.description
         let nonTriggeringExamples = baseDescription.nonTriggeringExamples + nonTriggeringLines

--- a/Tests/BuiltInRulesTests/LineLengthRuleTests.swift
+++ b/Tests/BuiltInRulesTests/LineLengthRuleTests.swift
@@ -30,6 +30,9 @@ final class LineLengthRuleTests: SwiftLintTestCase {
         String(repeating: "A", count: 121) + "\n\n\"\"\"\n; let a = 1")
     private let multilineStringFail = Example("let multilineString = \"A\" + \n\"" +
         String(repeating: "A", count: 121) + "\"\n")
+    private let multilineStringWithFunction = Example("let multilineString = \"\"\"\n" +
+        String(repeating: "A", count: 121) + "\n" +
+        "\"\"\".functionCall()")
 
     func testLineLength() {
         verifyRule(LineLengthRule.description, commentDoesntViolate: false, stringDoesntViolate: false)
@@ -92,7 +95,10 @@ final class LineLengthRuleTests: SwiftLintTestCase {
 
     func testLineLengthWithIgnoreMultilineStringsTrue() {
         let triggeringLines = [multilineStringFail]
-        let nonTriggeringLines = [multilineString, multilineStringWithExpression, multilineStringWithNewlineExpression]
+        let nonTriggeringLines = [multilineString,
+                                  multilineStringWithExpression,
+                                  multilineStringWithNewlineExpression,
+                                  multilineStringWithFunction]
 
         let baseDescription = LineLengthRule.description
         let nonTriggeringExamples = baseDescription.nonTriggeringExamples + nonTriggeringLines

--- a/Tests/BuiltInRulesTests/LineLengthRuleTests.swift
+++ b/Tests/BuiltInRulesTests/LineLengthRuleTests.swift
@@ -99,7 +99,7 @@ final class LineLengthRuleTests: SwiftLintTestCase {
             multilineString,
             multilineStringWithExpression,
             multilineStringWithNewlineExpression,
-            multilineStringWithFunction
+            multilineStringWithFunction,
         ]
 
         let baseDescription = LineLengthRule.description

--- a/Tests/BuiltInRulesTests/LineLengthRuleTests.swift
+++ b/Tests/BuiltInRulesTests/LineLengthRuleTests.swift
@@ -21,6 +21,15 @@ final class LineLengthRuleTests: SwiftLintTestCase {
     private let interpolatedString = Example("print(\"\\(value)" + String(repeating: "A", count: 113) + "\" )\n")
     private let plainString = Example("print(\"" + String(repeating: "A", count: 121) + ")\"\n")
 
+    private let multilineString = Example("let multilineString = \"\"\"\n" +
+        String(repeating: "A", count: 121) + "\n" +
+        "\"\"\"\n")
+    private let multilineStringWithExpression = Example("let multilineString = \"\"\"\n" +
+        String(repeating: "A", count: 121) + "\n" + "\n" +
+        " \"\"\"\n; let a = 1")
+    private let multilineStringFail = Example("let multilineString = \"A\" + \n \"\(String(repeating: "A", count: 121))\" + \n" +
+        "\"\n")
+
     func testLineLength() {
         verifyRule(LineLengthRule.description, commentDoesntViolate: false, stringDoesntViolate: false)
     }
@@ -79,6 +88,22 @@ final class LineLengthRuleTests: SwiftLintTestCase {
         verifyRule(description, ruleConfiguration: ["ignores_interpolated_strings": true],
                    commentDoesntViolate: false, stringDoesntViolate: false)
     }
+
+    func testLineLengthWithIgnoreMultilineStringsTrue() {
+        let triggeringLines = [multilineStringFail]
+        let nonTriggeringLines = [multilineString, multilineStringWithExpression]
+
+        let baseDescription = LineLengthRule.description
+        let nonTriggeringExamples = baseDescription.nonTriggeringExamples + nonTriggeringLines
+        let triggeringExamples = baseDescription.triggeringExamples + triggeringLines
+
+        let description = baseDescription.with(nonTriggeringExamples: nonTriggeringExamples)
+            .with(triggeringExamples: triggeringExamples)
+
+        verifyRule(description, ruleConfiguration: ["ignores_multiline_strings": true],
+                   commentDoesntViolate: false, stringDoesntViolate: false)
+    }
+
     func testLineLengthWithIgnoreInterpolatedStringsFalse() {
         let triggeringLines = [plainString, interpolatedString]
 

--- a/Tests/IntegrationTests/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/default_rule_configurations.yml
@@ -606,6 +606,7 @@ line_length:
   ignores_function_declarations: false
   ignores_comments: false
   ignores_interpolated_strings: false
+  ignores_multiline_strings: false
   excluded_lines_patterns: []
   meta:
     opt-in: false


### PR DESCRIPTION
- https://github.com/realm/SwiftLint/issues/2689
- ignore swift multiline strings marked by `"""`

The idea here is:
1. if line is a string only (within two `"""`)
2. and if next line that isn't a string only doesn't start with `"""` -> ignore as it's part of a multiline string
if 2 is false, then we might be within a string that's concatinated:
```swift
let a = "abc" +
"def"
+ "ghi"
```