### PR TITLE
Linux: static builds + arm64 build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@
 !Source
 !Tests
 !Package.*
+!tools/build-linux-release.sh

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,9 +25,6 @@ jobs:
   build:
     name: Build Docker Image
     runs-on: ubuntu-24.04
-    strategy:
-      matrix:
-        platform: [amd64, arm64]
     steps:
     - name: Define variables on push to `main`
       if: github.event_name == 'push'
@@ -62,6 +59,8 @@ jobs:
         REPOSITORY: ${{ github.repository }}
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
+    - name: Install cross-binutils for aarch64
+      run: sudo apt install -y binutils-aarch64-linux-gnu
     - name: Login to GitHub registry
       uses: docker/login-action@v3
       with:
@@ -72,16 +71,29 @@ jobs:
       with:
         context: .
         tags: ghcr.io/${{ env.REPOSITORY_LC }}:${{ env.DOCKER_TAG }}
-        platforms: linux/${{ matrix.platform }}
+        platforms: linux/amd64, linux/arm64
         outputs: ${{ env.OUTPUT_TYPE }}
-    - name: Rename binary artifact
+    - name: Strip and move binary artifacts
       if: contains(env.OUTPUT_TYPE, 'local')
-      run: mv artifacts/usr/bin/swiftlint artifacts/usr/bin/swiftlint_linux_${{ matrix.platform }}
-    - name: Upload binary artifact
+      run: |
+        strip artifacts/linux_amd64/usr/bin/swiftformat
+        mv artifacts/linux_amd64/usr/bin/swiftlint artifacts/usr/bin/swiftlint_linux_amd64
+        aarch64-linux-gnu-strip artifacts/linux_arm64/usr/bin/swiftformat
+        mv artifacts/linux_arm64/usr/bin/swiftlint artifacts/usr/bin/swiftlint_linux_arm64
+
+    - name: Upload AMD64 binary artifact
       if: contains(env.OUTPUT_TYPE, 'local')
       uses: actions/upload-artifact@v4
       with:
-        name: swiftlint_linux_${{ matrix.platform }}
-        path: artifacts/usr/bin/swiftlint_linux_${{ matrix.platform }}
+        name: swiftlint_linux_amd64
+        path: artifacts/usr/bin/swiftlint_linux_amd64
+        if-no-files-found: error
+        retention-days: 2
+    - name: Upload ARM64 binary artifact
+      if: contains(env.OUTPUT_TYPE, 'local')
+      uses: actions/upload-artifact@v4
+      with:
+        name: swiftlint_linux_arm64
+        path: artifacts/usr/bin/swiftlint_linux_arm64
         if-no-files-found: error
         retention-days: 2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,6 +25,9 @@ jobs:
   build:
     name: Build Docker Image
     runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        platform: [amd64, arm64]
     steps:
     - name: Define variables on push to `main`
       if: github.event_name == 'push'
@@ -69,16 +72,16 @@ jobs:
       with:
         context: .
         tags: ghcr.io/${{ env.REPOSITORY_LC }}:${{ env.DOCKER_TAG }}
-        platforms: linux/amd64
+        platforms: linux/${{ matrix.platform }}
         outputs: ${{ env.OUTPUT_TYPE }}
     - name: Rename binary artifact
       if: contains(env.OUTPUT_TYPE, 'local')
-      run: mv artifacts/usr/bin/swiftlint artifacts/usr/bin/swiftlint_linux_amd64
+      run: mv artifacts/usr/bin/swiftlint artifacts/usr/bin/swiftlint_linux_${{ matrix.platform }}
     - name: Upload binary artifact
       if: contains(env.OUTPUT_TYPE, 'local')
       uses: actions/upload-artifact@v4
       with:
-        name: swiftlint_linux_amd64
-        path: artifacts/usr/bin/swiftlint_linux_amd64
+        name: swiftlint_linux_${{ matrix.platform }}
+        path: artifacts/usr/bin/swiftlint_linux_${{ matrix.platform }}
         if-no-files-found: error
         retention-days: 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,64 +1,23 @@
-# Explicitly specify `noble` to keep the Swift & Ubuntu images in sync.
-ARG BUILDER_IMAGE=swift:6.0-noble
-ARG RUNTIME_IMAGE=ubuntu:noble
+# syntax=docker/dockerfile:1
 
-# Builder image
-FROM ${BUILDER_IMAGE} AS builder
-RUN apt-get update && apt-get install -y \
-    libcurl4-openssl-dev \
-    libxml2-dev \
- && rm -r /var/lib/apt/lists/*
-WORKDIR /workdir/
-COPY Plugins Plugins/
-COPY Source Source/
-COPY Tests Tests/
-COPY Package.* ./
+# Base image and static SDK have to be updated together.
+FROM swift:6.0.1 AS builder
+WORKDIR /workspace
+RUN swift sdk install \
+	https://download.swift.org/swift-6.0.1-release/static-sdk/swift-6.0.1-RELEASE/swift-6.0.1-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz \
+	--checksum d4f46ba40e11e697387468e18987ee622908bc350310d8af54eb5e17c2ff5481
 
-RUN swift package update
-ARG SWIFT_FLAGS="-c release -Xswiftc -static-stdlib -Xlinker -l_CFURLSessionInterface -Xlinker -l_CFXMLInterface -Xlinker -lcurl -Xlinker -lxml2 -Xswiftc -I. -Xlinker -fuse-ld=lld -Xlinker -L/usr/lib/swift/linux"
-RUN swift build $SWIFT_FLAGS --product swiftlint
-RUN mv `swift build $SWIFT_FLAGS --show-bin-path`/swiftlint /usr/bin
-RUN strip /usr/bin/swiftlint
+COPY . /workspace
+ARG TARGETPLATFORM
+RUN --mount=type=cache,target=/workspace/.build,id=build-$TARGETPLATFORM \
+	./tools/build-linux-release.sh && \
+	cp /workspace/.build/release/swiftlint /workspace
 
-# Runtime image
-FROM ${RUNTIME_IMAGE}
-LABEL org.opencontainers.image.source=https://github.com/realm/SwiftLint
-RUN apt-get update && apt-get install -y \
-    libcurl4 \
-    libxml2 \
- && rm -r /var/lib/apt/lists/*
-COPY --from=builder /usr/lib/libsourcekitdInProc.so /usr/lib
-COPY --from=builder /usr/lib/swift/host/libSwiftBasicFormat.so /usr/lib
-COPY --from=builder /usr/lib/swift/host/libSwiftCompilerPluginMessageHandling.so /usr/lib
-COPY --from=builder /usr/lib/swift/host/libSwiftDiagnostics.so /usr/lib
-COPY --from=builder /usr/lib/swift/host/libSwiftIDEUtils.so /usr/lib
-COPY --from=builder /usr/lib/swift/host/libSwiftOperators.so /usr/lib
-COPY --from=builder /usr/lib/swift/host/libSwiftParser.so /usr/lib
-COPY --from=builder /usr/lib/swift/host/libSwiftParserDiagnostics.so /usr/lib
-COPY --from=builder /usr/lib/swift/host/libSwiftRefactor.so /usr/lib
-COPY --from=builder /usr/lib/swift/host/libSwiftSyntax.so /usr/lib
-COPY --from=builder /usr/lib/swift/host/libSwiftSyntaxBuilder.so /usr/lib
-COPY --from=builder /usr/lib/swift/host/libSwiftSyntaxMacroExpansion.so /usr/lib
-COPY --from=builder /usr/lib/swift/host/libSwiftSyntaxMacros.so /usr/lib
-COPY --from=builder /usr/lib/swift/linux/lib_FoundationICU.so /usr/lib
-COPY --from=builder /usr/lib/swift/linux/libBlocksRuntime.so /usr/lib
-COPY --from=builder /usr/lib/swift/linux/libdispatch.so /usr/lib
-COPY --from=builder /usr/lib/swift/linux/libFoundation.so /usr/lib
-COPY --from=builder /usr/lib/swift/linux/libFoundationInternationalization.so /usr/lib
-COPY --from=builder /usr/lib/swift/linux/libFoundationEssentials.so /usr/lib
-COPY --from=builder /usr/lib/swift/linux/libFoundationNetworking.so /usr/lib
-COPY --from=builder /usr/lib/swift/linux/libFoundationXML.so /usr/lib
-COPY --from=builder /usr/lib/swift/linux/libswift_Concurrency.so /usr/lib
-COPY --from=builder /usr/lib/swift/linux/libswift_RegexParser.so /usr/lib
-COPY --from=builder /usr/lib/swift/linux/libswift_StringProcessing.so /usr/lib
-COPY --from=builder /usr/lib/swift/linux/libswiftCore.so /usr/lib
-COPY --from=builder /usr/lib/swift/linux/libswiftDispatch.so /usr/lib
-COPY --from=builder /usr/lib/swift/linux/libswiftGlibc.so /usr/lib
-COPY --from=builder /usr/lib/swift/linux/libswiftSynchronization.so /usr/lib
-COPY --from=builder /usr/lib/swift/linux/libswiftSwiftOnoneSupport.so /usr/lib
-COPY --from=builder /usr/bin/swiftlint /usr/bin
+FROM scratch AS runner
+COPY --from=builder /workspace/swiftlint /usr/bin/swiftlint
 
-RUN swiftlint version
-RUN echo "_ = 0" | swiftlint --use-stdin
+RUN /usr/bin/swiftlint version
+RUN echo "_ = 0" | /usr/bin/swiftlint --use-stdin
 
-CMD ["swiftlint"]
+ENTRYPOINT [ "/usr/bin/swiftlint" ]
+CMD ["."]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # syntax=docker/dockerfile:1
 
 # Base image and static SDK have to be updated together.
-FROM swift:6.0.1 AS builder
+FROM swift:6.0.3 AS builder
 WORKDIR /workspace
 RUN swift sdk install \
-	https://download.swift.org/swift-6.0.1-release/static-sdk/swift-6.0.1-RELEASE/swift-6.0.1-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz \
-	--checksum d4f46ba40e11e697387468e18987ee622908bc350310d8af54eb5e17c2ff5481
+	https://download.swift.org/swift-6.0.3-release/static-sdk/swift-6.0.3-RELEASE/swift-6.0.3-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz \
+	--checksum 67f765e0030e661a7450f7e4877cfe008db4f57f177d5a08a6e26fd661cdd0bd
 
 COPY . /workspace
 ARG TARGETPLATFORM

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,5 @@ RUN --mount=type=cache,target=/workspace/.build,id=build-$TARGETPLATFORM \
 FROM scratch AS runner
 COPY --from=builder /workspace/swiftlint /usr/bin/swiftlint
 
-RUN /usr/bin/swiftlint version
-RUN echo "_ = 0" | /usr/bin/swiftlint --use-stdin
-
 ENTRYPOINT [ "/usr/bin/swiftlint" ]
 CMD ["."]

--- a/tools/build-linux-release.sh
+++ b/tools/build-linux-release.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -eo pipefail
+
+pushd "$(dirname "${BASH_SOURCE[0]}")/.." > /dev/null
+
+BUILD_ARGS=(
+    --product swiftlint
+    --configuration release
+    -Xlinker -S
+)
+
+if [[ -z "$TARGETPLATFORM" ]]; then
+    ARCH="$(uname -m)"
+else
+    if [[ "$TARGETPLATFORM" = "linux/amd64" ]]; then
+        ARCH="x86_64"
+    elif [[ "$TARGETPLATFORM" = "linux/arm64" ]]; then
+        ARCH="aarch64"
+    else
+        echo "Unsupported target platform: $TARGETPLATFORM"
+        exit 1
+    fi
+fi
+BUILD_ARGS+=(--swift-sdk "${ARCH}-swift-linux-musl")
+
+swift build "${BUILD_ARGS[@]}"

--- a/tools/info.json.template
+++ b/tools/info.json.template
@@ -15,7 +15,7 @@
                 },
                 {
                     "path": "swiftlint-__VERSION__-linux-gnu/bin/swiftlint_arm64",
-                    "supportedTriples": ["x86_64-unknown-linux-gnu", "arm64-unknown-linux-gnu"]
+                    "supportedTriples": ["aarch64-unknown-linux-gnu", "arm64-unknown-linux-gnu"]
                 }
             ]
         }

--- a/tools/info.json.template
+++ b/tools/info.json.template
@@ -12,6 +12,10 @@
                 {
                     "path": "swiftlint-__VERSION__-linux-gnu/bin/swiftlint",
                     "supportedTriples": ["x86_64-unknown-linux-gnu"]
+                },
+                {
+                    "path": "swiftlint-__VERSION__-linux-gnu/bin/swiftlint_arm64",
+                    "supportedTriples": ["x86_64-unknown-linux-gnu", "arm64-unknown-linux-gnu"]
                 }
             ]
         }


### PR DESCRIPTION
- Linux builds with Docker are now built using the [static Linux SDK from Apple](https://www.swift.org/documentation/articles/static-linux-getting-started.html) so that Linux hosts no longer need to worry about runtime dependencies.
- Add an ARM64 build to the build artifacts and include this in linux release arifacts and the cross-platform artifact bundle.
   - The artifact paths of the original amd64 binary are unaffected, and the new arm64 binary is named `swiftlint_arm64`, located in the same directory as the amd64 binary.