### PR TITLE
Expose only SwiftLintCore in SPM and Bazel

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -55,7 +55,7 @@ swift_library(
     srcs = glob(["Source/SwiftLintCoreMacros/*.swift"]),
     copts = copts + strict_concurrency_copts,
     module_name = "SwiftLintCoreMacros",
-    visibility = ["//visibility:public"],
+    visibility = ["//:__subpackages__"],
     deps = [
         "@SwiftSyntax//:SwiftCompilerPlugin_opt",
         "@SwiftSyntax//:SwiftSyntaxMacros_opt",
@@ -110,7 +110,7 @@ swift_library(
     srcs = glob(["Source/SwiftLintBuiltInRules/**/*.swift"]),
     copts = copts + strict_concurrency_copts,
     module_name = "SwiftLintBuiltInRules",
-    visibility = ["//visibility:public"],
+    visibility = ["//:__subpackages__"],
     deps = [
         ":SwiftLintCore",
     ],
@@ -139,7 +139,7 @@ swift_library(
     ),
     copts = copts + targeted_concurrency_copts,
     module_name = "SwiftLintFramework",
-    visibility = ["//visibility:public"],
+    visibility = ["//:__subpackages__"],
     deps = [
         ":SwiftLintBuiltInRules",
         ":SwiftLintCore",

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
     platforms: [.macOS(.v12)],
     products: [
         .executable(name: "swiftlint", targets: ["swiftlint"]),
-        .library(name: "SwiftLintFramework", targets: ["SwiftLintFramework"]),
+        .library(name: "SwiftLintCore", targets: ["SwiftLintCore"]),
         .plugin(name: "SwiftLintBuildToolPlugin", targets: ["SwiftLintBuildToolPlugin"]),
         .plugin(name: "SwiftLintCommandPlugin", targets: ["SwiftLintCommandPlugin"]),
     ],

--- a/Tests/BUILD
+++ b/Tests/BUILD
@@ -41,7 +41,6 @@ swift_library(
 
 swift_test(
     name = "CLITests",
-    visibility = ["//visibility:public"],
     deps = [":CLITests.library"],
 )
 
@@ -61,7 +60,6 @@ swift_library(
 
 swift_test(
     name = "MacroTests",
-    visibility = ["//visibility:public"],
     deps = [":MacroTests.library"],
 )
 
@@ -108,7 +106,6 @@ swift_test(
         # Bazel doesn't support paths with spaces in them
         exclude = ["BuiltInRulesTests/Resources/FileNameNoSpaceRuleFixtures/**"],
     ),
-    visibility = ["//visibility:public"],
     deps = [":BuiltInRulesTests.library"],
 )
 
@@ -136,7 +133,6 @@ swift_test(
     data = glob(
         ["FrameworkTests/Resources/**"],
     ),
-    visibility = ["//visibility:public"],
     deps = [":FrameworkTests.library"],
 )
 
@@ -156,7 +152,6 @@ swift_library(
 
 swift_test(
     name = "GeneratedTests",
-    visibility = ["//visibility:public"],
     deps = [":GeneratedTests.library"],
 )
 
@@ -168,7 +163,7 @@ filegroup(
         ["**/*.swift"],
         exclude = ["**/Resources/**"],
     ),
-    visibility = ["//visibility:public"],
+    visibility = ["//:__pkg__"],
 )
 
 swift_library(
@@ -189,7 +184,6 @@ swift_test(
         "//:LintInputs",
         "IntegrationTests/default_rule_configurations.yml"
     ],
-    visibility = ["//visibility:public"],
     deps = [":IntegrationTests.library"],
 )
 


### PR DESCRIPTION
Apart from the executable `swiftlint`, only `SwiftLintCore` will be exposed from both SPM and Bazel. `SwiftLintFramework` is the implementation of the `swiftlint` command and not meant to be used to develop against.

Test targets can be private except for `ExtraRulesTests`.