### PR TITLE
Fix Ignore UIColor initializers in no_magic_numbers rule issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 * Ignore `UIColor` initializers in `no_magic_numbers` rule.  
   [suojae](https://github.com/suojae)
+  [hyeffie](https://github.com/hyeffie)
   [#5183](https://github.com/realm/SwiftLint/issues/5183)
 
 * Exclude types with a `@Suite` attribute and functions annotated with `@Test` from `no_magic_numbers` rule.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Enhancements
 
-* Fix Ignore UIColor initializers in no_magic_numbers rule issue.
+* Ignore `UIColor` initializers in `no_magic_numbers` rule.  
   [suojae](https://github.com/suojae)
   [#5183](https://github.com/realm/SwiftLint/issues/5183)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ### Enhancements
 
+* Fix Ignore UIColor initializers in no_magic_numbers rule issue.
+  [suojae](https://github.com/suojae)
+  [#5183](https://github.com/realm/SwiftLint/issues/5183)
+
 * Exclude types with a `@Suite` attribute and functions annotated with `@Test` from `no_magic_numbers` rule.
   Also treat a type as a `@Suite` if it contains `@Test` functions.  
   [SimplyDanny](https://github.com/SimplyDanny)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -113,11 +113,9 @@ struct NoMagicNumbersRule: Rule {
             Example("""
             let myColor: UIColor = UIColor(red: 0.6, green: 1.0, blue: 0.2, alpha: 0.52)
             """),
-            
             Example("""
             let colorLiteral = #colorLiteral(red: 0.7019607843, green: 0.7019607843, blue: 0.7019607843, alpha: 1)
             """),
-
             Example("""
             let yourColor: UIColor = UIColor(hue: 0.9, saturation: 0.6, brightness: 0.333334, alpha: 1.0)
             """),
@@ -245,11 +243,9 @@ private extension NoMagicNumbersRule {
             if node.isOperandOfFreestandingShiftOperation() {
                 return
             }
-            
             if node.isPartOfUIColorInitializer() {
                 return
             }
-            
             let violation = node.positionAfterSkippingLeadingTrivia
             if let extendedTypeName = node.extendedTypeName() {
                 if !testClasses.contains(extendedTypeName) {
@@ -350,7 +346,6 @@ private extension ExprSyntaxProtocol {
         }
         return false
     }
-    
     func isPartOfUIColorInitializer() -> Bool {
         var parent = parent
         while let currentParent = parent, !currentParent.is(FunctionCallExprSyntax.self) {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -368,9 +368,8 @@ private extension ExprSyntaxProtocol {
                 return true
             }
             if let memberAccess = call.calledExpression.as(MemberAccessExprSyntax.self),
-               memberAccess.declName.baseName.text == "init",
                let baseExpr = memberAccess.base?.as(DeclReferenceExprSyntax.self),
-               baseExpr.baseName.text == "UIColor" {
+               baseExpr.baseName.text == "UIColor" && memberAccess.declName.baseName.text == "init" {
                 return true
             }
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -252,6 +252,7 @@ private extension NoMagicNumbersRule {
             if node.isOperandOfFreestandingShiftOperation() {
                 return
             }
+            
             if node.isPartOfUIColorInitializer() {
                 return
             }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -354,6 +354,7 @@ private extension ExprSyntaxProtocol {
         }
         return false
     }
+
     func isPartOfUIColorInitializer() -> Bool {
         guard let param = parent?.as(LabeledExprSyntax.self),
               let label = param.label?.text else {
@@ -371,12 +372,12 @@ private extension ExprSyntaxProtocol {
             }
             if let memberAccess = call.calledExpression.as(MemberAccessExprSyntax.self),
                let baseExpr = memberAccess.base?.as(DeclReferenceExprSyntax.self),
-               baseExpr.baseName.text == "UIColor" && memberAccess.declName.baseName.text == "init" {
+               baseExpr.baseName.text == "UIColor",
+               memberAccess.declName.baseName.text == "init" {
                 return true
             }
         }
-        let colorLiteralLabels = ["red", "green", "blue", "alpha"]
-        if colorLiteralLabels.contains(label),
+        if ["red", "green", "blue", "alpha"].contains(label),
            let call = param.parent?.as(LabeledExprListSyntax.self)?.parent?.as(MacroExpansionExprSyntax.self),
            call.macroName.text == "colorLiteral" {
             return true

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -369,6 +369,7 @@ private extension ExprSyntaxProtocol {
                 return true
             }
             if let memberAccess = call.calledExpression.as(MemberAccessExprSyntax.self),
+               memberAccess.declName.baseName.text == "init",
                let baseExpr = memberAccess.base?.as(DeclReferenceExprSyntax.self),
                baseExpr.baseName.text == "UIColor" {
                 return true

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -252,7 +252,6 @@ private extension NoMagicNumbersRule {
             if node.isOperandOfFreestandingShiftOperation() {
                 return
             }
-            
             if node.isPartOfUIColorInitializer() {
                 return
             }
@@ -356,6 +355,7 @@ private extension ExprSyntaxProtocol {
         }
         return false
     }
+    
     func isPartOfUIColorInitializer() -> Bool {
         guard let param = parent?.as(LabeledExprSyntax.self),
               let label = param.label?.text else {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -110,6 +110,25 @@ struct NoMagicNumbersRule: Rule {
             let a = 2
             #endif
             """),
+            Example("""
+            let myColor: UIColor = UIColor(red: 0.6, green: 1.0, blue: 0.2, alpha: 0.52)
+            """),
+            
+            Example("""
+            let colorLiteral = #colorLiteral(red: 0.7019607843, green: 0.7019607843, blue: 0.7019607843, alpha: 1)
+            """),
+
+            Example("""
+            let yourColor: UIColor = UIColor(hue: 0.9, saturation: 0.6, brightness: 0.333334, alpha: 1.0)
+            """),
+            Example("""
+            let systemColor = UIColor(displayP3Red: 0.3, green: 0.8, blue: 0.5, alpha: 0.75)
+            """),
+            Example("""
+            func createColor() -> UIColor {
+                return UIColor(white: 0.5, alpha: 0.8)
+            }
+            """),
         ],
         triggeringExamples: [
             Example("foo(↓321)"),

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -118,24 +118,23 @@ struct NoMagicNumbersRule: Rule {
             """),
             Example("""
             let yourColor: UIColor = UIColor(hue: 0.9, saturation: 0.6, brightness: 0.333334, alpha: 1.0)
-            """),
+            """, excludeFromDocumentation: true),
             Example("""
             let systemColor = UIColor(displayP3Red: 0.3, green: 0.8, blue: 0.5, alpha: 0.75)
-            """),
+            """, excludeFromDocumentation: true),
             Example("""
             func createColor() -> UIColor {
                 return UIColor(white: 0.5, alpha: 0.8)
             }
-            """),
+            """, excludeFromDocumentation: true),
             Example("""
             let memberColor = UIColor.init(red: 0.5, green: 0.3, blue: 0.9, alpha: 1.0)
-            """),
-
+            """, excludeFromDocumentation: true),
             Example("""
             func createMemberColor() -> UIColor {
                 return UIColor.init(hue: 0.2, saturation: 0.8, brightness: 0.7, alpha: 0.5)
             }
-            """),
+            """, excludeFromDocumentation: true),
         ],
         triggeringExamples: [
             Example("foo(↓321)"),

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -127,6 +127,15 @@ struct NoMagicNumbersRule: Rule {
                 return UIColor(white: 0.5, alpha: 0.8)
             }
             """),
+            Example("""
+            let memberColor = UIColor.init(red: 0.5, green: 0.3, blue: 0.9, alpha: 1.0)
+            """),
+
+            Example("""
+            func createMemberColor() -> UIColor {
+                return UIColor.init(hue: 0.2, saturation: 0.8, brightness: 0.7, alpha: 0.5)
+            }
+            """),
         ],
         triggeringExamples: [
             Example("foo(↓321)"),

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -357,16 +357,11 @@ private extension ExprSyntaxProtocol {
         return false
     }
     func isPartOfUIColorInitializer() -> Bool {
-        let uiColorInitializerLabels: Set<String> = [
-            "white", "alpha", "red", "displayP3Red", "green", "blue", "hue", "saturation", "brightness",
-            "cgColor", "ciColor", "resource", "patternImage"
-        ]
-        let colorLiteralLabels: Set<String> = ["red", "green", "blue", "alpha"]
         guard let param = parent?.as(LabeledExprSyntax.self),
               let label = param.label?.text else {
             return false
         }
-        if uiColorInitializerLabels.contains(label),
+        if ["white", "alpha", "red", "displayP3Red", "green", "blue", "hue", "saturation", "brightness","cgColor", "ciColor", "resource", "patternImage"].contains(label),
            let call = param.parent?.as(LabeledExprListSyntax.self)?.parent?.as(FunctionCallExprSyntax.self) {
             if let calledExpr = call.calledExpression.as(DeclReferenceExprSyntax.self),
                calledExpr.baseName.text == "UIColor" {
@@ -378,7 +373,7 @@ private extension ExprSyntaxProtocol {
                 return true
             }
         }
-        if colorLiteralLabels.contains(label),
+        if ["red", "green", "blue", "alpha"].contains(label),
            let call = param.parent?.as(LabeledExprListSyntax.self)?.parent?.as(MacroExpansionExprSyntax.self),
            call.macroName.text == "colorLiteral" {
             return true

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -354,13 +354,15 @@ private extension ExprSyntaxProtocol {
         }
         return false
     }
-    
     func isPartOfUIColorInitializer() -> Bool {
         guard let param = parent?.as(LabeledExprSyntax.self),
               let label = param.label?.text else {
             return false
         }
-        let uiColorInitializerLabels = ["white", "alpha", "red", "displayP3Red", "green", "blue", "hue", "saturation", "brightness","cgColor", "ciColor", "resource", "patternImage"]
+        let uiColorInitializerLabels = [
+            "white", "alpha", "red", "displayP3Red", "green", "blue", "hue",
+            "saturation", "brightness", "cgColor", "ciColor", "resource", "patternImage",
+        ]
         if uiColorInitializerLabels.contains(label),
            let call = param.parent?.as(LabeledExprListSyntax.self)?.parent?.as(FunctionCallExprSyntax.self) {
             if let calledExpr = call.calledExpression.as(DeclReferenceExprSyntax.self),

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -361,7 +361,8 @@ private extension ExprSyntaxProtocol {
               let label = param.label?.text else {
             return false
         }
-        if ["white", "alpha", "red", "displayP3Red", "green", "blue", "hue", "saturation", "brightness","cgColor", "ciColor", "resource", "patternImage"].contains(label),
+        let uiColorInitializerLabels = ["white", "alpha", "red", "displayP3Red", "green", "blue", "hue", "saturation", "brightness","cgColor", "ciColor", "resource", "patternImage"]
+        if uiColorInitializerLabels.contains(label),
            let call = param.parent?.as(LabeledExprListSyntax.self)?.parent?.as(FunctionCallExprSyntax.self) {
             if let calledExpr = call.calledExpression.as(DeclReferenceExprSyntax.self),
                calledExpr.baseName.text == "UIColor" {
@@ -373,7 +374,8 @@ private extension ExprSyntaxProtocol {
                 return true
             }
         }
-        if ["red", "green", "blue", "alpha"].contains(label),
+        let colorLiteralLabels = ["red", "green", "blue", "alpha"]
+        if colorLiteralLabels.contains(label),
            let call = param.parent?.as(LabeledExprListSyntax.self)?.parent?.as(MacroExpansionExprSyntax.self),
            call.macroName.text == "colorLiteral" {
             return true


### PR DESCRIPTION
### Description

**Resolves: #5183**

This PR addresses issue #5183 by making the `no_magic_numbers` rule ignore numerical literals used in UIColor initializers. Since color definitions inherently use numeric values (such as RGB components, alpha values, etc.), it makes sense to exempt these from being flagged as magic numbers.

### Implementation
- Added a new `isPartOfUIColorInitializer()` method to detect when a numeric literal is part of a UIColor initialize.
- Modified the `collectViolation` method to skip reporting violations for numbers used in color definitions.

### Test Coverage
Added several non-triggering examples to ensure different UIColor initializer formats are properly handled:
- Standard RGB with alpha: `UIColor(red: 0.6, green: 1.0, blue: 0.2, alpha: 0.52)`
- Color literal: `#colorLiteral(red: 0.7019607843, green: 0.7019607843, blue: 0.7019607843, alpha: 1)`
- HSB with alpha: `UIColor(hue: 0.9, saturation: 0.6, brightness: 0.333334, alpha: 1.0)`
- Display P3 color space: `UIColor(displayP3Red: 0.3, green: 0.8, blue: 0.5, alpha: 0.75)`
- Grayscale with alpha: `UIColor(white: 0.5, alpha: 0.8)`