### PR TITLE
Fix issue referencing `FrameworkTests` from another Bazel workspace

### DIFF
--- a/Tests/BUILD
+++ b/Tests/BUILD
@@ -135,6 +135,7 @@ swift_test(
     name = "FrameworkTests",
     data = glob(
         ["FrameworkTests/Resources/**"],
+        allow_empty = True,
     ),
     visibility = ["//visibility:public"],
     deps = [":FrameworkTests.library"],


### PR DESCRIPTION
Allow `FrameworkTests` data to be empty so a workspace can load the Tests package from a release archive.  Similar to https://github.com/realm/SwiftLint/pull/5977.

Two options to fix this long term:
- Add a smoke test of `ExtraRules` into the BCR pipeline.  One downside is you wouldn't detect issues until after the release was made.
- Move the definitions for `FrameworkTests` and `BuiltInRulesTests` into BUILD files one level deeper so they don't get eagerly loaded for anyone using custom `extra_rules`.

Happy to open a PR for either one if we decide on the best approach.