### PR TITLE
Allow magic numbers to be configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@
 
 ### Enhancements
 
-* None.
+* Add new `allowed_numbers` option to the `no_magic_numbers` rule.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#6051](https://github.com/realm/SwiftLint/issues/6051)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@
 
 * Add new `allowed_numbers` option to the `no_magic_numbers` rule.  
   [Martin Redington](https://github.com/mildm8nnered)
-  [#6051](https://github.com/realm/SwiftLint/issues/6051)
 
 ### Bug Fixes
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -135,7 +135,7 @@ struct NoMagicNumbersRule: Rule {
                 return UIColor.init(hue: 0.2, saturation: 0.8, brightness: 0.7, alpha: 0.5)
             }
             """, excludeFromDocumentation: true),
-            Example("let a = b + 2", configuration: ["allowed_numbers": [2.0]]).focused(),
+            Example("let a = b + 2", configuration: ["allowed_numbers": [2]]).focused(),
         ],
         triggeringExamples: [
             Example("foo(↓321)"),

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -135,6 +135,7 @@ struct NoMagicNumbersRule: Rule {
                 return UIColor.init(hue: 0.2, saturation: 0.8, brightness: 0.7, alpha: 0.5)
             }
             """, excludeFromDocumentation: true),
+            Example("let a = b + 2", configuration: ["allowed_numbers": [2.0]]).focused(),
         ],
         triggeringExamples: [
             Example("foo(↓321)"),
@@ -290,11 +291,11 @@ private extension DeclGroupSyntax {
 }
 
 private extension TokenSyntax {
-    func isMagicNumber(_ allowedNumbers: Set<Int>) -> Bool {
+    func isMagicNumber(_ allowedNumbers: Set<Double>) -> Bool {
         guard let number = Double(text.replacingOccurrences(of: "_", with: "")) else {
             return false
         }
-        if [0, 1, 100].contains(number) {
+        if allowedNumbers.contains(number) {
             return false
         }
         guard let grandparent = parent?.parent else {

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -208,7 +208,7 @@ private extension NoMagicNumbersRule {
         }
 
         override func visitPost(_ node: FloatLiteralExprSyntax) {
-            guard node.literal.isMagicNumber else {
+            guard node.literal.isMagicNumber(configuration.allowedNumbers) else {
                 return
             }
             collectViolation(forNode: node)
@@ -226,7 +226,7 @@ private extension NoMagicNumbersRule {
         }
 
         override func visitPost(_ node: IntegerLiteralExprSyntax) {
-            guard node.literal.isMagicNumber else {
+            guard node.literal.isMagicNumber(configuration.allowedNumbers) else {
                 return
             }
             collectViolation(forNode: node)
@@ -290,7 +290,7 @@ private extension DeclGroupSyntax {
 }
 
 private extension TokenSyntax {
-    var isMagicNumber: Bool {
+    func isMagicNumber(_ allowedNumbers: Set<Int>) -> Bool {
         guard let number = Double(text.replacingOccurrences(of: "_", with: "")) else {
             return false
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -1,3 +1,5 @@
+// swiftlint:disable file_length
+
 import SwiftSyntax
 
 @SwiftSyntaxRule(foldExpressions: true, optIn: true)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -140,6 +140,7 @@ struct NoMagicNumbersRule: Rule {
             Example("let a = b + 2", configuration: ["allowed_numbers": [2]], excludeFromDocumentation: true),
             Example("let a = b + 2", configuration: ["allowed_numbers": [2.0]], excludeFromDocumentation: true),
             Example("let a = b + 1", configuration: ["allowed_numbers": [2.0]], excludeFromDocumentation: true),
+            Example("let a = b + 2.5", configuration: ["allowed_numbers": [2.5]], excludeFromDocumentation: true),
         ],
         triggeringExamples: [
             Example("foo(↓321)"),

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoMagicNumbersRule.swift
@@ -135,7 +135,9 @@ struct NoMagicNumbersRule: Rule {
                 return UIColor.init(hue: 0.2, saturation: 0.8, brightness: 0.7, alpha: 0.5)
             }
             """, excludeFromDocumentation: true),
-            Example("let a = b + 2", configuration: ["allowed_numbers": [2]]).focused(),
+            Example("let a = b + 2", configuration: ["allowed_numbers": [2]], excludeFromDocumentation: true),
+            Example("let a = b + 2", configuration: ["allowed_numbers": [2.0]], excludeFromDocumentation: true),
+            Example("let a = b + 1", configuration: ["allowed_numbers": [2.0]], excludeFromDocumentation: true),
         ],
         triggeringExamples: [
             Example("foo(↓321)"),
@@ -176,6 +178,7 @@ struct NoMagicNumbersRule: Rule {
             f(↓4.0)
             #endif
             """),
+            Example("let a = b + ↓3", configuration: ["allowed_numbers": [2.0]], excludeFromDocumentation: true),
         ]
     )
 }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NoMagicNumbersConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NoMagicNumbersConfiguration.swift
@@ -1,0 +1,18 @@
+
+@AutoConfigParser
+struct NoMagicNumbersConfiguration: SeverityBasedRuleConfiguration {
+    typealias Parent = NoMagicNumbersRule
+
+    @ConfigurationElement(key: "severity")
+    private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement(
+        key: "test_parent_classes",
+        postprocessor: { $0.formUnion(["QuickSpec", "XCTestCase"]) }
+    )
+    private(set) var testParentClasses = Set<String>()
+    @ConfigurationElement(
+        key: "allowed_numbers",
+        postprocessor: { $0.formUnion([0, 1, 100]) }
+    )
+    private(set) var allowedNumbers = Set<Int>()
+}

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NoMagicNumbersConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NoMagicNumbersConfiguration.swift
@@ -1,4 +1,3 @@
-
 @AutoConfigParser
 struct NoMagicNumbersConfiguration: SeverityBasedRuleConfiguration {
     typealias Parent = NoMagicNumbersRule

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NoMagicNumbersConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NoMagicNumbersConfiguration.swift
@@ -14,5 +14,5 @@ struct NoMagicNumbersConfiguration: SeverityBasedRuleConfiguration {
         key: "allowed_numbers",
         postprocessor: { $0.formUnion([0, 1, 100]) }
     )
-    private(set) var allowedNumbers = Set<Int>()
+    private(set) var allowedNumbers = Set<Double>()
 }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnitTestConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnitTestConfiguration.swift
@@ -3,7 +3,6 @@ import SwiftLintCore
 typealias BalancedXCTestLifecycleConfiguration = UnitTestConfiguration<BalancedXCTestLifecycleRule>
 typealias EmptyXCTestMethodConfiguration = UnitTestConfiguration<EmptyXCTestMethodRule>
 typealias FinalTestCaseConfiguration = UnitTestConfiguration<FinalTestCaseRule>
-typealias NoMagicNumbersConfiguration = UnitTestConfiguration<NoMagicNumbersRule>
 typealias SingleTestClassConfiguration = UnitTestConfiguration<SingleTestClassRule>
 typealias PrivateUnitTestConfiguration = UnitTestConfiguration<PrivateUnitTestRule>
 

--- a/Source/SwiftLintCore/Models/RuleConfigurationDescription.swift
+++ b/Source/SwiftLintCore/Models/RuleConfigurationDescription.swift
@@ -625,13 +625,11 @@ extension Double: AcceptableByConfigurationElement {
     public init(fromAny value: Any, context ruleID: String) throws {
         if let value = value as? Self {
             self = value
-            return
-        }
-        if let value = value as? Int {
+        } else if let value = value as? Int {
             self = Double(value)
-            return
+        } else {
+            throw Issue.invalidConfiguration(ruleID: ruleID)
         }
-        throw Issue.invalidConfiguration(ruleID: ruleID)
     }
 }
 

--- a/Source/SwiftLintCore/Models/RuleConfigurationDescription.swift
+++ b/Source/SwiftLintCore/Models/RuleConfigurationDescription.swift
@@ -623,10 +623,15 @@ extension Double: AcceptableByConfigurationElement {
     }
 
     public init(fromAny value: Any, context ruleID: String) throws {
-        guard let value = value as? Self else {
-            throw Issue.invalidConfiguration(ruleID: ruleID)
+        if let value = value as? Self {
+            self = value
+            return
         }
-        self = value
+        if let value = value as? Int {
+            self = Double(value)
+            return
+        }
+        throw Issue.invalidConfiguration(ruleID: ruleID)
     }
 }
 

--- a/Tests/FrameworkTests/RuleConfigurationDescriptionTests.swift
+++ b/Tests/FrameworkTests/RuleConfigurationDescriptionTests.swift
@@ -60,7 +60,7 @@ final class RuleConfigurationDescriptionTests: SwiftLintTestCase {
             severity: warning; \
             list: ["STRING1", "STRING2"]; \
             set: [1, 2, 3]; \
-            set_of_doubles: [1.0, 2.0, 3.0]; \
+            set_of_doubles: [1.0, 2.0, 3.0, 4.7]; \
             severity: error; \
             SEVERITY: warning; \
             warning: 1; \
@@ -142,7 +142,7 @@ final class RuleConfigurationDescriptionTests: SwiftLintTestCase {
             set_of_doubles
             </td>
             <td>
-            [1.0, 2.0, 3.0]
+            [1.0, 2.0, 3.0, 4.7]
             </td>
             </tr>
             <tr>
@@ -212,7 +212,7 @@ final class RuleConfigurationDescriptionTests: SwiftLintTestCase {
             severity: warning
             list: ["STRING1", "STRING2"]
             set: [1, 2, 3]
-            set_of_doubles: [1.0, 2.0, 3.0]
+            set_of_doubles: [1.0, 2.0, 3.0, 4.7]
             severity: error
             SEVERITY: warning
             warning: 1

--- a/Tests/FrameworkTests/RuleConfigurationDescriptionTests.swift
+++ b/Tests/FrameworkTests/RuleConfigurationDescriptionTests.swift
@@ -31,6 +31,8 @@ final class RuleConfigurationDescriptionTests: SwiftLintTestCase {
         var list = ["string1", "string2"]
         @ConfigurationElement(key: "set", deprecationNotice: .suggestAlternative(ruleID: "my_rule", name: "other_opt"))
         var set: Set<Int> = [1, 2, 3]
+        @ConfigurationElement(key: "set_of_doubles")
+        var setOfDoubles: Set<Double> = [1, 2, 3]
         @ConfigurationElement(inline: true)
         var severityConfig = SeverityConfiguration<Parent>(.error)
         @ConfigurationElement(key: "SEVERITY")
@@ -58,6 +60,7 @@ final class RuleConfigurationDescriptionTests: SwiftLintTestCase {
             severity: warning; \
             list: ["STRING1", "STRING2"]; \
             set: [1, 2, 3]; \
+            set_of_doubles: [1.0, 2.0, 3.0]; \
             severity: error; \
             SEVERITY: warning; \
             warning: 1; \
@@ -136,6 +139,14 @@ final class RuleConfigurationDescriptionTests: SwiftLintTestCase {
             </tr>
             <tr>
             <td>
+            set_of_doubles
+            </td>
+            <td>
+            [1.0, 2.0, 3.0]
+            </td>
+            </tr>
+            <tr>
+            <td>
             severity
             </td>
             <td>
@@ -201,6 +212,7 @@ final class RuleConfigurationDescriptionTests: SwiftLintTestCase {
             severity: warning
             list: ["STRING1", "STRING2"]
             set: [1, 2, 3]
+            set_of_doubles: [1.0, 2.0, 3.0]
             severity: error
             SEVERITY: warning
             warning: 1

--- a/Tests/FrameworkTests/RuleConfigurationDescriptionTests.swift
+++ b/Tests/FrameworkTests/RuleConfigurationDescriptionTests.swift
@@ -32,7 +32,7 @@ final class RuleConfigurationDescriptionTests: SwiftLintTestCase {
         @ConfigurationElement(key: "set", deprecationNotice: .suggestAlternative(ruleID: "my_rule", name: "other_opt"))
         var set: Set<Int> = [1, 2, 3]
         @ConfigurationElement(key: "set_of_doubles")
-        var setOfDoubles: Set<Double> = [1, 2, 3]
+        var setOfDoubles: Set<Double> = [1, 2, 3, 4.7]
         @ConfigurationElement(inline: true)
         var severityConfig = SeverityConfiguration<Parent>(.error)
         @ConfigurationElement(key: "SEVERITY")

--- a/Tests/IntegrationTests/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/default_rule_configurations.yml
@@ -724,6 +724,7 @@ no_grouping_extension:
 no_magic_numbers:
   severity: warning
   test_parent_classes: ["QuickSpec", "XCTestCase"]
+  allowed_numbers: [0.0, 1.0, 100.0]
   meta:
     opt-in: true
     correctable: false


### PR DESCRIPTION
Adds an `allowed_numbers` configuration parameter to the `no_magic_numbers` rule.

In my case, I was hitting `2` and `3` a lot.

Usage:

```
no_magic_numbers:
  allowed_numbers: [2, 3.0]
```

The rule works on `Double`'s internally - some faffing was required to make sure that configurations like `[2, 3]` were able to be mapped to the set of `Double`'s.
