### PR TITLE
[chore] Fix bazel project and update rules

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,10 +8,10 @@ module(
 bazel_dep(name = "apple_support", version = "1.16.0", repo_name = "build_bazel_apple_support")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "platforms", version = "0.0.10")
-bazel_dep(name = "rules_apple", version = "3.8.0", repo_name = "build_bazel_rules_apple")
+bazel_dep(name = "rules_apple", version = "3.20.1", repo_name = "build_bazel_rules_apple")
 bazel_dep(name = "rules_cc", version = "0.1.1", repo_name = "build_bazel_rules_cc")
 bazel_dep(name = "rules_shell", version = "0.4.0", repo_name = "build_bazel_rules_shell")
-bazel_dep(name = "rules_swift", version = "2.1.1", repo_name = "build_bazel_rules_swift")
+bazel_dep(name = "rules_swift", version = "2.8.1", repo_name = "build_bazel_rules_swift")
 bazel_dep(name = "sourcekitten", version = "0.37.0", repo_name = "com_github_jpsim_sourcekitten")
 bazel_dep(name = "swift_argument_parser", version = "1.3.1.1", repo_name = "sourcekitten_com_github_apple_swift_argument_parser")
 bazel_dep(name = "swift-syntax", version = "601.0.0", repo_name = "SwiftSyntax")
@@ -33,4 +33,4 @@ use_repo(apple_cc_configure, "local_config_apple_cc")
 
 # Dev Dependencies
 
-bazel_dep(name = "rules_xcodeproj", version = "2.6.1", dev_dependency = True)
+bazel_dep(name = "rules_xcodeproj", version = "2.11.2", dev_dependency = True)

--- a/bazel/BUILD
+++ b/bazel/BUILD
@@ -26,7 +26,7 @@ xcodeproj(
                 "//Tests:FrameworkTests",
                 "//Tests:GeneratedTests",
                 "//Tests:IntegrationTests",
-                "//Tests:MacrosTests",
+                "//Tests:MacroTests",
             ]),
         ),
     ],
@@ -38,7 +38,7 @@ xcodeproj(
         "//Tests:FrameworkTests",
         "//Tests:GeneratedTests",
         "//Tests:IntegrationTests",
-        "//Tests:MacrosTests",
+        "//Tests:MacroTests",
     ],
 )
 


### PR DESCRIPTION
- Update a typo that was preventing the project from being generated with `bazel run //bazel:xcodeproj`
- Update `rules_xcodeproj`, `rules_apple` and `rules_swift` to their latest versions 

