### PR TITLE
Better error reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,10 @@
 
 ### Bug Fixes
 
-* None.
+* Improved error reporting when SwiftLint exits, because of an invalid configuration file
+  or other error.  
+  [Martin Redington](https://github.com/mildm8nnered)
+  [#6052](https://github.com/realm/SwiftLint/issues/6052)
 
 ## 0.59.1: Crisp Spring Clean
 

--- a/Source/SwiftLintCore/Models/Issue.swift
+++ b/Source/SwiftLintCore/Models/Issue.swift
@@ -116,7 +116,7 @@ public enum Issue: LocalizedError, Equatable {
     }
 
     /// The issues description which is ready to be printed to the console.
-    package var errorDescription: String {
+    public var errorDescription: String? {
         switch self {
         case .genericError:
             return "error: \(message)"
@@ -132,8 +132,8 @@ public enum Issue: LocalizedError, Equatable {
         if case .ruleDeprecated = self, !Self.printDeprecationWarnings {
             return
         }
-        Self.printQueueContinuation?.yield(errorDescription)
-        queuedPrintError(errorDescription)
+        Self.printQueueContinuation?.yield(localizedDescription)
+        queuedPrintError(localizedDescription)
     }
 
     private var message: String {

--- a/Source/SwiftLintFramework/Configuration/Configuration.swift
+++ b/Source/SwiftLintFramework/Configuration/Configuration.swift
@@ -280,7 +280,7 @@ public struct Configuration {
             if useDefaultConfigOnFailure ?? !hasCustomConfigurationFiles {
                 // No files were explicitly specified, so maybe the user doesn't want a config at all -> warn
                 queuedPrintError(
-                    "\(Issue.wrap(error: error).errorDescription) – Falling back to default configuration"
+                    "\(Issue.wrap(error: error).localizedDescription) – Falling back to default configuration"
                 )
                 self.init(rulesMode: rulesMode, cachePath: cachePath)
             } else {


### PR DESCRIPTION
Implements `errorDescription` "correctly" (it should return `String?` rather than `String`).

Errors should now be reported correctly, rather than printing the generic "the operation could not be completed" message.

Partly addresses #6052