### PR TITLE
#6054: Fix false positive for Actor-conforming delegate protocols in class_delegate_protocol rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,10 @@
 
 ### Enhancements
 
+* Fix false positive for Actor-conforming delegate protocols in `class_delegate_protocol` rule
+  [imsonalbajaj](https://github.com/imsonalbajaj)
+  [#6054](https://github.com/realm/SwiftLint/issues/6054)
+
 * Add new option `ignores_multiline_strings` to `line_length` rule. It allows to ignore too long
   lines inside of multiline strings.  
   [thisIsTheFoxe](https://github.com/thisisthefoxe)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@
 
 ### Enhancements
 
-* None.
+* Fix false positives for `Actor`-conforming delegate protocols in the `class_delegate_protocol` rule.  
+  [imsonalbajaj](https://github.com/imsonalbajaj)
+  [#6054](https://github.com/realm/SwiftLint/issues/6054)
 
 ### Bug Fixes
 
@@ -62,10 +64,6 @@
   [SimplyDanny](https://github.com/SimplyDanny)
 
 ### Enhancements
-
-* Fix false positive for Actor-conforming delegate protocols in `class_delegate_protocol` rule
-  [imsonalbajaj](https://github.com/imsonalbajaj)
-  [#6054](https://github.com/realm/SwiftLint/issues/6054)
 
 * Add new option `ignores_multiline_strings` to `line_length` rule. It allows to ignore too long
   lines inside of multiline strings.  

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ClassDelegateProtocolRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ClassDelegateProtocolRule.swift
@@ -52,6 +52,7 @@ struct ClassDelegateProtocolRule: Rule {
             Example("↓protocol FooDelegate: Foo & Bar {}"),
             Example("↓protocol FooDelegate where Self: StringProtocol {}"),
             Example("↓protocol FooDelegate where Self: A & B {}"),
+            Example("↓protocol FooDelegate: Actor {}"),
         ]
     )
 }
@@ -107,7 +108,7 @@ private extension ProtocolDeclSyntax {
 private extension TypeSyntax {
     func isObjectOrDelegate() -> Bool {
         if let typeName = `as`(IdentifierTypeSyntax.self)?.typeName {
-            return typeName == "AnyObject" || typeName == "NSObjectProtocol" || typeName.hasSuffix("Delegate")
+            return (typeName == "AnyObject" || typeName == "NSObjectProtocol" || typeName.hasSuffix("Delegate")) && && typeName != "Actor"
         }
         if let combined = `as`(CompositionTypeSyntax.self) {
             return combined.elements.contains { $0.type.isObjectOrDelegate() }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ClassDelegateProtocolRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ClassDelegateProtocolRule.swift
@@ -45,6 +45,7 @@ struct ClassDelegateProtocolRule: Rule {
             Example("protocol FooDelegate where Self: Foo & BarDelegate & Bar {}"),
             Example("protocol FooDelegate where Self: AnyObject {}"),
             Example("protocol FooDelegate where Self: NSObjectProtocol {}"),
+            Example("protocol FooDelegate: Actor {}"),
         ],
         triggeringExamples: [
             Example("↓protocol FooDelegate {}"),
@@ -52,7 +53,6 @@ struct ClassDelegateProtocolRule: Rule {
             Example("↓protocol FooDelegate: Foo & Bar {}"),
             Example("↓protocol FooDelegate where Self: StringProtocol {}"),
             Example("↓protocol FooDelegate where Self: A & B {}"),
-            Example("↓protocol FooDelegate: Actor {}"),
         ]
     )
 }
@@ -108,7 +108,8 @@ private extension ProtocolDeclSyntax {
 private extension TypeSyntax {
     func isObjectOrDelegate() -> Bool {
         if let typeName = `as`(IdentifierTypeSyntax.self)?.typeName {
-            return (typeName == "AnyObject" || typeName == "NSObjectProtocol" || typeName.hasSuffix("Delegate")) && typeName != "Actor"
+            let objectTypes = ["AnyObject", "NSObjectProtocol", "Actor"]
+            return objectTypes.contains(typeName) || typeName.hasSuffix("Delegate")
         }
         if let combined = `as`(CompositionTypeSyntax.self) {
             return combined.elements.contains { $0.type.isObjectOrDelegate() }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ClassDelegateProtocolRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ClassDelegateProtocolRule.swift
@@ -108,7 +108,7 @@ private extension ProtocolDeclSyntax {
 private extension TypeSyntax {
     func isObjectOrDelegate() -> Bool {
         if let typeName = `as`(IdentifierTypeSyntax.self)?.typeName {
-            return (typeName == "AnyObject" || typeName == "NSObjectProtocol" || typeName.hasSuffix("Delegate")) && && typeName != "Actor"
+            return (typeName == "AnyObject" || typeName == "NSObjectProtocol" || typeName.hasSuffix("Delegate")) && typeName != "Actor"
         }
         if let combined = `as`(CompositionTypeSyntax.self) {
             return combined.elements.contains { $0.type.isObjectOrDelegate() }


### PR DESCRIPTION
This PR fixes a false positive in the class_delegate_protocol rule by excluding protocols that inherit from Actor