### PR TITLE
Allow `prefer_key_paths` to ignore identity closures (`{ $0 }`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,9 +113,14 @@
   [leo-lem](https://github.com/leo-lem)  
   [#1940](https://github.com/realm/SwiftLint/issues/1940)
 * Add new `ignore_identity_closures` parameter to `prefer_key_paths` rule to skip conversion of identity closures 
+
+* Add new `ignore_identity_closures` parameter to `prefer_key_paths` rule to skip conversion of identity closures
   (`{ $0 }`) to identity key paths (`\self`).
-  Add a small note to the rule description stating that identity key path conversion is Swift 6+ only.  
+  Note that identity key paths are only support from Swift 6 on, hence this option
+  will be implicitly ignored/set to `true` when SwiftLint detects a Swift <6 compiler
+  to avoid causing compilation errors.  
   [p4checo](https://github.com/p4checo)
+  [#5965](https://github.com/realm/SwiftLint/issues/5965)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,11 +112,10 @@
   `style: always` option which is the default.  
   [leo-lem](https://github.com/leo-lem)  
   [#1940](https://github.com/realm/SwiftLint/issues/1940)
-* Add new `ignore_identity_closures` parameter to `prefer_key_paths` rule to skip conversion of identity closures 
 
-* Add new `ignore_identity_closures` parameter to `prefer_key_paths` rule to skip conversion of identity closures
-  (`{ $0 }`) to identity key paths (`\self`).
-  Note that identity key paths are only support from Swift 6 on, hence this option
+* Add new `ignore_identity_closures` parameter to `prefer_key_paths` rule to skip
+  conversion of identity closures (`{ $0 }`) to identity key paths (`\.self`).
+  Note that identity key paths are only supported from Swift 6 on, hence this option
   will be implicitly ignored/set to `true` when SwiftLint detects a Swift <6 compiler
   to avoid causing compilation errors.  
   [p4checo](https://github.com/p4checo)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,10 @@
   `style: always` option which is the default.  
   [leo-lem](https://github.com/leo-lem)  
   [#1940](https://github.com/realm/SwiftLint/issues/1940)
+* Add new `ignore_identity_closures` parameter to `prefer_key_paths` rule to skip conversion of identity closures 
+  (`{ $0 }`) to identity key paths (`\self`).
+  Add a small note to the rule description stating that identity key path conversion is Swift 6+ only.  
+  [p4checo](https://github.com/p4checo)
 
 ### Bug Fixes
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferKeyPathRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferKeyPathRule.swift
@@ -7,16 +7,19 @@ struct PreferKeyPathRule: Rule {
 
     private static let extendedMode = ["restrict_to_standard_functions": false]
     private static let ignoreIdentity = ["ignore_identity_closures": true]
-    private static let extendedModeAndIgnoreIdentity = extendedMode.merging(ignoreIdentity, uniquingKeysWith: { $1 })
+    private static let extendedModeAndIgnoreIdentity = [
+        "restrict_to_standard_functions": false,
+        "ignore_identity_closures": true,
+    ]
 
     static let description = RuleDescription(
         identifier: "prefer_key_path",
         name: "Prefer Key Path",
         description: "Use a key path argument instead of a closure with property access",
         rationale: """
-            Note: Swift 5 doesn't support identity key path conversion (`{ $0 }` -> `(\\.self)`), regardless of
-            `ignore_identity_closures` parameter value
-        """,
+            Note: Swift 5 doesn't support identity key path conversions (`{ $0 }` -> `(\\.self)`) and so
+            SwiftLint disregards `ignore_identity_closures: false` if it runs on a Swift <6 project.
+            """,
         kind: .idiomatic,
         minSwiftVersion: .fiveDotTwo,
         nonTriggeringExamples: [

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferKeyPathRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferKeyPathRule.swift
@@ -9,7 +9,7 @@ struct PreferKeyPathRule: Rule {
     private static let ignoreIdentity = ["ignore_identity_closures": true]
     private static let extendedModeAndIgnoreIdentity = [
         "restrict_to_standard_functions": false,
-        "ignore_identity_closures": true
+        "ignore_identity_closures": true,
     ]
 
     static let description = RuleDescription(
@@ -17,8 +17,8 @@ struct PreferKeyPathRule: Rule {
         name: "Prefer Key Path",
         description: """
             Use a key path argument instead of a closure with property access
-            
-            Note: Swift 5 doesn't support identity key path conversion (`{ $0 }` -> `(\\.self)`) independently of  
+
+            Note: Swift 5 doesn't support identity key path conversion (`{ $0 }` -> `(\\.self)`), regardless of
             `ignore_identity_closures` parameter value
         """,
         kind: .idiomatic,
@@ -48,8 +48,6 @@ struct PreferKeyPathRule: Rule {
             Example("f.first ↓{ $0.a }"),
             Example("f.contains ↓{ $0.a }"),
             Example("f.contains(where: ↓{ $0.a })"),
-            Example("f.flatMap ↓{ $0 }"),
-            Example("f ↓{ $0 }", configuration: extendedMode),
             Example("f(↓{ $0.a })", configuration: extendedMode),
             Example("f(a: ↓{ $0.b })", configuration: extendedMode),
             Example("f(a: ↓{ a in a.b }, x)", configuration: extendedMode),
@@ -89,10 +87,6 @@ struct PreferKeyPathRule: Rule {
                 Example("f.partition(by: \\.a.b)"),
             Example("f.contains ↓{ $0.a.b }"):
                 Example("f.contains(where: \\.a.b)"),
-            Example("f.flatMap ↓{ $0 }"):
-                Example("f.flatMap(\\.self)"),
-            Example("f ↓{ $0 }", configuration: extendedMode):
-                Example("f(\\.self)"),
             Example("f.first ↓{ element in element.a }"):
                 Example("f.first(where: \\.a)"),
             Example("f.drop ↓{ element in element.a }"):

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferKeyPathRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferKeyPathRule.swift
@@ -7,17 +7,13 @@ struct PreferKeyPathRule: Rule {
 
     private static let extendedMode = ["restrict_to_standard_functions": false]
     private static let ignoreIdentity = ["ignore_identity_closures": true]
-    private static let extendedModeAndIgnoreIdentity = [
-        "restrict_to_standard_functions": false,
-        "ignore_identity_closures": true,
-    ]
+    private static let extendedModeAndIgnoreIdentity = extendedMode.merging(ignoreIdentity, uniquingKeysWith: { $1 })
 
     static let description = RuleDescription(
         identifier: "prefer_key_path",
         name: "Prefer Key Path",
-        description: """
-            Use a key path argument instead of a closure with property access
-
+        description: "Use a key path argument instead of a closure with property access",
+        rationale: """
             Note: Swift 5 doesn't support identity key path conversion (`{ $0 }` -> `(\\.self)`), regardless of
             `ignore_identity_closures` parameter value
         """,
@@ -93,6 +89,10 @@ struct PreferKeyPathRule: Rule {
                 Example("f.drop(while: \\.a)"),
             Example("f.compactMap ↓{ $0.a.b.c.d }"):
                 Example("f.compactMap(\\.a.b.c.d)"),
+            Example("f { $0 }", configuration: extendedModeAndIgnoreIdentity): // no change with option enabled
+                Example("f { $0 }", configuration: extendedModeAndIgnoreIdentity),
+            Example("f.map { $0 }", configuration: ignoreIdentity): // no change with option enabled
+                Example("f.map { $0 }", configuration: ignoreIdentity),
         ]
     )
 }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PreferKeyPathConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/PreferKeyPathConfiguration.swift
@@ -8,4 +8,6 @@ struct PreferKeyPathConfiguration: SeverityBasedRuleConfiguration {
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "restrict_to_standard_functions")
     private(set) var restrictToStandardFunctions = true
+    @ConfigurationElement(key: "ignore_identity_closures")
+    private(set) var ignoreIdentityClosures = false
 }

--- a/Tests/BuiltInRulesTests/PreferKeyPathRuleTests.swift
+++ b/Tests/BuiltInRulesTests/PreferKeyPathRuleTests.swift
@@ -30,6 +30,10 @@ final class PreferKeyPathRuleTests: SwiftLintTestCase {
                     Example("f.map(\\.self)"),
                 Example("f.g { $0 }", configuration: Self.extendedMode):
                     Example("f.g(\\.self)"),
+                Example("f { $0 }", configuration: Self.extendedModeAndIgnoreIdentity): // no change with option enabled
+                    Example("f { $0 }"),
+                Example("f.map { $0 }", configuration: Self.ignoreIdentity): // no change with option enabled
+                    Example("f.map { $0 }"),
             ])
 
         verifyRule(description)

--- a/Tests/BuiltInRulesTests/PreferKeyPathRuleTests.swift
+++ b/Tests/BuiltInRulesTests/PreferKeyPathRuleTests.swift
@@ -4,6 +4,11 @@ import XCTest
 
 final class PreferKeyPathRuleTests: SwiftLintTestCase {
     private static let extendedMode = ["restrict_to_standard_functions": false]
+    private static let ignoreIdentity = ["ignore_identity_closures": true]
+    private static let extendedModeAndIgnoreIdentity = [
+        "restrict_to_standard_functions": false,
+        "ignore_identity_closures": true,
+    ]
 
     func testIdentityExpressionInSwift6() throws {
         try XCTSkipIf(SwiftVersion.current < .six)
@@ -12,6 +17,8 @@ final class PreferKeyPathRuleTests: SwiftLintTestCase {
             .with(nonTriggeringExamples: [
                 Example("f.filter { a in b }"),
                 Example("f.g { $1 }", configuration: Self.extendedMode),
+                Example("f { $0 }", configuration: Self.extendedModeAndIgnoreIdentity),
+                Example("f.map { $0 }", configuration: Self.ignoreIdentity),
             ])
             .with(triggeringExamples: [
                 Example("f.compactMap ↓{ $0 }"),

--- a/Tests/IntegrationTests/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/default_rule_configurations.yml
@@ -864,6 +864,7 @@ prefer_condition_list:
 prefer_key_path:
   severity: warning
   restrict_to_standard_functions: true
+  ignore_identity_closures: false
   meta:
     opt-in: true
     correctable: true


### PR DESCRIPTION
Add new `ignore_identity_closures` parameter to `prefer_key_paths` rule to skip conversion of identity closures (`{ $0 }`) to identity key paths (`\self`).

Add a small note to the rule description stating that identity key path conversion is Swift 6+ only.