### PR TITLE
Add opt-in `unneeded_throws_rethrows` rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -48,6 +48,7 @@ disabled_rules:
   - todo
   - trailing_closure
   - type_contents_order
+  - unneeded_throws_rethrows
   - vertical_whitespace_between_cases
 
 # Configurations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@
 
 ### Enhancements
 
-* None.
+* Add opt-in `unneeded_throws_rethrows` rules that triggers when declarations
+  marked `throws`/`rethrows` never actually throw or call any throwing code.
+  [Tony Ngo](https://github.com/tonyskansf)
 
 ### Bug Fixes
 

--- a/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
+++ b/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
@@ -221,6 +221,7 @@ public let builtInRules: [any Rule.Type] = [
     UnneededOverrideRule.self,
     UnneededParenthesesInClosureArgumentRule.self,
     UnneededSynthesizedInitializerRule.self,
+    UnneededThrowsRule.self,
     UnownedVariableCaptureRule.self,
     UntypedErrorInCatchRule.self,
     UnusedClosureParameterRule.self,

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnneededThrowsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnneededThrowsRule.swift
@@ -1,0 +1,165 @@
+import SwiftLintCore
+import SwiftSyntax
+
+@SwiftSyntaxRule(correctable: true, optIn: true)
+struct UnneededThrowsRule: Rule {
+    var configuration = SeverityConfiguration<Self>(.warning)
+
+    static let description = RuleDescription(
+        identifier: "unneeded_throws_rethrows",
+        name: "Unneeded (re)throws keyword",
+        description: "Non-throwing functions/variables should not me marked as `throws` or `rethrows`",
+        kind: .lint,
+        nonTriggeringExamples: UnneededThrowsRuleExamples.nonTriggeringExamples,
+        triggeringExamples: UnneededThrowsRuleExamples.triggeringExamples,
+        corrections: UnneededThrowsRuleExamples.corrections
+    )
+}
+
+private extension UnneededThrowsRule {
+    typealias Scope = [ThrowsClauseSyntax]
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
+        private var scopes = Stack<Scope>()
+
+        override var skippableDeclarations: [any DeclSyntaxProtocol.Type] { [
+            ProtocolDeclSyntax.self,
+        ] }
+
+        override func visit(_: FunctionParameterClauseSyntax) -> SyntaxVisitorContinueKind {
+            .skipChildren
+        }
+
+        override func visit(_ node: InitializerDeclSyntax) -> SyntaxVisitorContinueKind {
+            scopes.openScope(with: node.signature.effectSpecifiers?.throwsClause)
+            return .visitChildren
+        }
+
+        override func visitPost(_: InitializerDeclSyntax) {
+            if let closedScope = scopes.closeScope() {
+                validateScope(
+                    closedScope,
+                    reason: "The initializer does not throw any error"
+                )
+            }
+        }
+
+        override func visit(_ node: AccessorDeclSyntax) -> SyntaxVisitorContinueKind {
+            scopes.openScope(with: node.effectSpecifiers?.throwsClause)
+            return .visitChildren
+        }
+
+        override func visitPost(_: AccessorDeclSyntax) {
+            if let closedScope = scopes.closeScope() {
+                validateScope(
+                    closedScope,
+                    reason: "The accessor does not throw any error"
+                )
+            }
+        }
+
+        override func visitPost(_: VariableDeclSyntax) {
+            if let closedScope = scopes.closeScope() {
+                validateScope(
+                    closedScope,
+                    reason: "The variable does not throw any error"
+                )
+            }
+        }
+
+        override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+            scopes.openScope(with: node.signature.effectSpecifiers?.throwsClause)
+            return .visitChildren
+        }
+
+        override func visitPost(_: FunctionDeclSyntax) {
+            if let closedScope = scopes.closeScope() {
+                validateScope(
+                    closedScope,
+                    reason: "The body of this function does not throw any error"
+                )
+            }
+        }
+
+        override func visit(_ node: FunctionTypeSyntax) -> SyntaxVisitorContinueKind {
+            scopes.openScope(with: node.effectSpecifiers?.throwsClause)
+            return .visitChildren
+        }
+
+        override func visitPost(_: FunctionTypeSyntax) {
+            if let closedScope = scopes.closeScope() {
+                validateScope(
+                    closedScope,
+                    reason: "The closure type does not throw any error"
+                )
+            }
+        }
+
+        override func visit(_: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
+            scopes.openScope()
+            return .visitChildren
+        }
+
+        override func visitPost(_: FunctionCallExprSyntax) {
+            scopes.closeScope()
+        }
+
+        override func visit(_: DoStmtSyntax) -> SyntaxVisitorContinueKind {
+            scopes.openScope()
+            return .visitChildren
+        }
+
+        override func visitPost(_ node: CodeBlockSyntax) {
+            if node.parent?.is(DoStmtSyntax.self) == true {
+                scopes.closeScope()
+            }
+        }
+
+        override func visitPost(_ node: TryExprSyntax) {
+            if node.questionOrExclamationMark == nil {
+                scopes.markCurrentScopeAsThrowing()
+            }
+        }
+
+        override func visitPost(_: ThrowStmtSyntax) {
+            scopes.markCurrentScopeAsThrowing()
+        }
+
+        private func validateScope(_ scope: Scope, reason: String) {
+            guard let throwsToken = scope.last?.throwsSpecifier else { return }
+            violations.append(
+                ReasonedRuleViolation(
+                    position: throwsToken.positionAfterSkippingLeadingTrivia,
+                    reason: reason,
+                    correction: ReasonedRuleViolation.ViolationCorrection(
+                        start: throwsToken.positionAfterSkippingLeadingTrivia,
+                        end: throwsToken.endPosition,
+                        replacement: ""
+                    )
+                )
+            )
+        }
+    }
+}
+
+private extension Stack where Element == UnneededThrowsRule.Scope {
+    mutating func markCurrentScopeAsThrowing() {
+        modifyLast { currentScope in
+            _ = currentScope.popLast()
+        }
+    }
+
+    mutating func openScope() {
+        push([])
+    }
+
+    mutating func openScope(with throwsClause: ThrowsClauseSyntax?) {
+        if let throwsClause {
+            push([throwsClause])
+        }
+    }
+
+    @discardableResult
+    mutating func closeScope() -> [ThrowsClauseSyntax]? {
+        pop()
+    }
+}

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnneededThrowsRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnneededThrowsRuleExamples.swift
@@ -1,0 +1,258 @@
+internal struct UnneededThrowsRuleExamples {
+    static let nonTriggeringExamples = [
+        Example("""
+            func foo() throws {
+                try bar()
+            }
+            """),
+        Example("""
+            func foo() throws {
+                throw Example.failure
+            }
+            """),
+        Example("""
+            func foo(_ bar: () throws -> T) rethrows -> Int {
+                try items.map { try bar() }
+            }
+            """),
+        Example("""
+            func foo() {
+                func bar() throws {
+                    try baz()
+                }
+                try? bar()
+            }
+            """),
+        Example("""
+            protocol Foo {
+                func bar() throws
+            }
+            """),
+        Example("""
+            func foo() throws {
+                guard false else {
+                    throw Example.failure
+                }
+            }
+            """),
+        Example("""
+            func foo() throws {
+                do { try bar() } 
+                catch {
+                    throw Example.failure
+                }
+            }
+            """),
+        Example("""
+            func foo() throws {
+                do { try bar() } 
+                catch {
+                    try baz()
+                }
+            }
+            """),
+        Example("""
+        func foo() throws {
+            do {
+                throw Example.failure
+            } catch {
+                do {
+                    throw Example.failure
+                } catch {
+                    throw Example.failure
+                }
+            }
+        }
+        """),
+        Example("""
+            func foo() throws {
+                switch bar {
+                case 1: break
+                default: try bar()
+                }
+            }
+            """),
+        Example("""
+            var foo: Int {
+                get throws {
+                    try bar
+                }
+            }
+            """),
+    ]
+
+    static let triggeringExamples = [
+        Example("func foo() ↓throws {}"),
+        Example("let foo: () ↓throws -> Void = {}"),
+        Example("let foo: (() ↓throws -> Void)? = {}"),
+        Example("func foo(bar: () throws -> Void) ↓rethrows {}"),
+        Example("init() ↓throws {}"),
+        Example("""
+            func foo() ↓throws {
+                bar()
+            }
+            """),
+        Example("""
+            func foo() {
+                func bar() ↓throws {}
+                bar()
+            }
+            """),
+        Example("""
+            func foo() {
+                func bar() ↓throws {
+                    baz()
+                }
+                bar()
+            }
+            """),
+        Example("""
+            func foo() {
+                func bar() ↓throws {
+                    baz()
+                }
+                try? bar()
+            }
+            """),
+        Example("""
+            func foo() ↓throws {
+                func bar() ↓throws {
+                    baz()
+                }
+            }
+            """),
+        Example("""
+            func foo() ↓throws {
+                do { try bar() } 
+                catch {}
+            }
+            """),
+        Example("""
+            func foo() ↓throws {
+                do {} 
+                catch {}
+            }
+            """),
+        Example("""
+            func foo() {
+                do {
+                    func bar() ↓throws {}
+                    try bar()
+                } catch {}
+            }
+            """),
+        Example("""
+            func foo() ↓throws {
+                do {
+                    try bar()
+                    func baz() throws { try bar() }
+                    try baz()
+                } catch {}
+            }
+            """),
+        Example("""
+            func foo() ↓throws {
+                do {
+                    try bar()
+                } catch {
+                    do {
+                        throw Example.failure
+                    } catch {}
+                }
+            }
+            """),
+        Example("""
+            func foo() ↓throws {
+                do {
+                    try bar()
+                } catch {
+                    do {
+                        try bar()
+                        func baz() ↓throws {}
+                        try baz()
+                    } catch {}
+                }
+            }
+            """),
+        Example("""
+            func foo() ↓throws {
+                switch bar {
+                case 1: break
+                default: break
+                }
+            }
+            """),
+        Example("""
+            func foo() ↓throws {
+                _ = try? bar()
+            }
+            """),
+        Example("""
+            func foo() ↓throws {
+                Task {
+                    try bar()
+                }
+            }
+            """),
+        Example("""
+            func foo() throws {
+                try bar()
+                Task {
+                    func baz() ↓throws {}
+                }
+            }
+            """),
+        Example("""
+            var foo: Int {
+                get ↓throws {
+                    0
+                }
+            }
+            """),
+    ]
+
+    static let corrections = [
+        Example("func foo() ↓throws {}"): Example("func foo() {}"),
+        Example("init() ↓throws {}"): Example("init() {}"),
+        Example("""
+        func foo() {
+            func bar() ↓throws {}
+            bar()
+        }
+        """): Example("""
+            func foo() {
+                func bar() {}
+                bar()
+            }
+            """),
+        Example("""
+            var foo: Int {
+                get ↓throws {
+                    0
+                }
+            }
+            """): Example("""
+            var foo: Int {
+                get {
+                    0
+                }
+            }
+            """),
+        Example("""
+            let foo: () ↓throws -> Void = {}
+            """): Example("""
+            let foo: () -> Void = {}
+            """),
+        Example("""
+            func foo() ↓throws {
+                do {}
+                catch {}
+            }
+            """): Example("""
+            func foo() {
+                do {}
+                catch {}
+            }
+            """),
+    ]
+}

--- a/Tests/GeneratedTests/GeneratedTests.swift
+++ b/Tests/GeneratedTests/GeneratedTests.swift
@@ -1321,6 +1321,12 @@ final class UnneededSynthesizedInitializerRuleGeneratedTests: SwiftLintTestCase 
     }
 }
 
+final class UnneededThrowsRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(UnneededThrowsRule.description)
+    }
+}
+
 final class UnownedVariableCaptureRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(UnownedVariableCaptureRule.description)

--- a/Tests/IntegrationTests/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/default_rule_configurations.yml
@@ -1262,6 +1262,11 @@ unneeded_synthesized_initializer:
   meta:
     opt-in: false
     correctable: true
+unneeded_throws:
+  severity: warning
+  meta:
+    opt-in: true
+    correctable: false
 unowned_variable_capture:
   severity: warning
   meta:


### PR DESCRIPTION
Add a new opt-in rule that detects unnecessary `throws`, helping avoid misleading definitions and requirements for the caller to write unnecessary error handling.