### PR TITLE
Fix false positives in redundant_discardable_let rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,9 @@
   or other error.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#6052](https://github.com/realm/SwiftLint/issues/6052)
-* Fix false positives in `redundant_discardable_let` when `ignore_swiftui_view_bodies` is enabled.
+* Fix false positives of `redundant_discardable_let` rule in `@ViewBuilder` functions,
+  `#Preview` macro bodies and preview provides when `ignore_swiftui_view_bodies` is
+  enabled.  
   [kaseken](https://github.com/kaseken)
 
 ## 0.59.1: Crisp Spring Clean

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,16 +29,18 @@
 * Migrate `vertical_whitespace` rule from SourceKit to SwiftSyntax for improved performance.  
   [Matt Pennig](https://github.com/pennig)
 
+* Fix false positives of `redundant_discardable_let` rule in `@ViewBuilder` functions,
+  `#Preview` macro bodies and preview providers when `ignore_swiftui_view_bodies` is
+  enabled.  
+  [kaseken](https://github.com/kaseken)
+  [#6063](https://github.com/realm/SwiftLint/issues/6063)
+
 ### Bug Fixes
 
 * Improved error reporting when SwiftLint exits, because of an invalid configuration file
   or other error.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#6052](https://github.com/realm/SwiftLint/issues/6052)
-* Fix false positives of `redundant_discardable_let` rule in `@ViewBuilder` functions,
-  `#Preview` macro bodies and preview provides when `ignore_swiftui_view_bodies` is
-  enabled.  
-  [kaseken](https://github.com/kaseken)
 
 ## 0.59.1: Crisp Spring Clean
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
   or other error.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#6052](https://github.com/realm/SwiftLint/issues/6052)
+* Fix false positives in `redundant_discardable_let` when `ignore_swiftui_view_bodies` is enabled.
+  [kaseken](https://github.com/kaseken)
 
 ## 0.59.1: Crisp Spring Clean
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/RedundantDiscardableLetRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/RedundantDiscardableLetRule.swift
@@ -153,9 +153,7 @@ private extension AccessorBlockSyntax {
         if let binding = parent?.as(PatternBindingSyntax.self),
            binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text == "body",
            let type = binding.typeAnnotation?.type.as(SomeOrAnyTypeSyntax.self) {
-            return type.someOrAnySpecifier.text == "some"
-                && type.constraint.as(IdentifierTypeSyntax.self)?.name.text == "View"
-                && binding.parent?.parent?.is(VariableDeclSyntax.self) == true
+            return type.isView && binding.parent?.parent?.is(VariableDeclSyntax.self) == true
         }
         return false
     }
@@ -171,8 +169,7 @@ private extension AccessorBlockSyntax {
             return false
         }
 
-        return type.someOrAnySpecifier.text == "some" &&
-            type.constraint.as(IdentifierTypeSyntax.self)?.name.text == "View"
+        return type.isView
     }
 }
 
@@ -187,18 +184,19 @@ private extension FunctionDeclSyntax {
         guard attributes.contains(attributeNamed: "ViewBuilder") else {
             return false
         }
-
-        guard let returnType = signature.returnClause?.type.as(SomeOrAnyTypeSyntax.self) else {
-            return false
-        }
-
-        return returnType.someOrAnySpecifier.text == "some" &&
-            returnType.constraint.as(IdentifierTypeSyntax.self)?.name.text == "View"
+        return signature.returnClause?.type.as(SomeOrAnyTypeSyntax.self)?.isView ?? false
     }
 }
 
 private extension ClosureExprSyntax {
     var isPreviewMacroBody: Bool {
         parent?.as(MacroExpansionExprSyntax.self)?.macroName.text == "Preview"
+    }
+}
+
+private extension SomeOrAnyTypeSyntax {
+    var isView: Bool {
+        someOrAnySpecifier.text == "some" &&
+            constraint.as(IdentifierTypeSyntax.self)?.name.text == "View"
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/RedundantDiscardableLetRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/RedundantDiscardableLetRule.swift
@@ -54,19 +54,19 @@ struct RedundantDiscardableLetRule: Rule {
             Example("""
                 @ViewBuilder
                 func bar() -> some View {
-                    let _ = foo()
+                    ↓let _ = foo()
                     return Text("Hello, World!")
                 }
                 """),
             Example("""
                 #Preview {
-                    let _ = foo()
+                    ↓let _ = foo()
                     return Text("Hello, World!")
                 }
                 """),
             Example("""
                 static var previews: some View {
-                    let _ = foo()
+                    ↓let _ = foo()
                     Text("Hello, World!")
                 }
                 """),

--- a/Source/SwiftLintBuiltInRules/Rules/Style/RedundantDiscardableLetRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/RedundantDiscardableLetRule.swift
@@ -86,6 +86,52 @@ struct RedundantDiscardableLetRule: Rule {
         corrections: [
             Example("↓let _ = foo()"): Example("_ = foo()"),
             Example("if _ = foo() { ↓let _ = bar() }"): Example("if _ = foo() { _ = bar() }"),
+            Example("""
+                var body: some View {
+                    ↓let _ = foo()
+                    Text("Hello, World!")
+                }
+                """): Example("""
+                    var body: some View {
+                        _ = foo()
+                        Text("Hello, World!")
+                    }
+                    """),
+            Example("""
+                @ViewBuilder
+                func bar() -> some View {
+                    ↓let _ = foo()
+                    return Text("Hello, World!")
+                }
+                """): Example("""
+                    @ViewBuilder
+                    func bar() -> some View {
+                        _ = foo()
+                        return Text("Hello, World!")
+                    }
+                    """),
+            Example("""
+                #Preview {
+                    ↓let _ = foo()
+                    return Text("Hello, World!")
+                }
+                """): Example("""
+                    #Preview {
+                        _ = foo()
+                        return Text("Hello, World!")
+                    }
+                    """),
+            Example("""
+                static var previews: some View {
+                    ↓let _ = foo()
+                    Text("Hello, World!")
+                }
+                """): Example("""
+                    static var previews: some View {
+                        _ = foo()
+                        Text("Hello, World!")
+                    }
+                    """),
         ]
     )
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/RedundantDiscardableLetRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/RedundantDiscardableLetRule.swift
@@ -70,6 +70,18 @@ struct RedundantDiscardableLetRule: Rule {
                     Text("Hello, World!")
                 }
                 """),
+            Example("""
+                var notBody: some View {
+                    ↓let _ = foo()
+                    Text("Hello, World!")
+                }
+                """, configuration: ["ignore_swiftui_view_bodies": true], excludeFromDocumentation: true),
+            Example("""
+                var body: some NotView {
+                    ↓let _ = foo()
+                    Text("Hello, World!")
+                }
+                """, configuration: ["ignore_swiftui_view_bodies": true], excludeFromDocumentation: true),
         ],
         corrections: [
             Example("↓let _ = foo()"): Example("_ = foo()"),

--- a/Source/SwiftLintBuiltInRules/Rules/Style/RedundantDiscardableLetRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/RedundantDiscardableLetRule.swift
@@ -152,21 +152,15 @@ private extension AccessorBlockSyntax {
         guard let binding = parent?.as(PatternBindingSyntax.self),
               binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text == "previews",
               let bindingList = binding.parent?.as(PatternBindingListSyntax.self),
-              let variableDecl = bindingList.parent?.as(VariableDeclSyntax.self) else {
+              let variableDecl = bindingList.parent?.as(VariableDeclSyntax.self),
+              variableDecl.modifiers.contains(keyword: .static),
+              variableDecl.bindingSpecifier.tokenKind == .keyword(.var),
+              let type = binding.typeAnnotation?.type.as(SomeOrAnyTypeSyntax.self) else {
             return false
         }
 
-        guard variableDecl.modifiers.contains(keyword: .static) &&
-                variableDecl.bindingSpecifier.tokenKind == .keyword(.var) else {
-            return false
-        }
-
-        if let type = binding.typeAnnotation?.type.as(SomeOrAnyTypeSyntax.self) {
-            return type.someOrAnySpecifier.text == "some" &&
-                type.constraint.as(IdentifierTypeSyntax.self)?.name.text == "View"
-        }
-
-        return false
+        return type.someOrAnySpecifier.text == "some" &&
+            type.constraint.as(IdentifierTypeSyntax.self)?.name.text == "View"
     }
 }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/RedundantDiscardableLetRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/RedundantDiscardableLetRule.swift
@@ -199,10 +199,6 @@ private extension FunctionDeclSyntax {
 
 private extension ClosureExprSyntax {
     var isPreviewMacroBody: Bool {
-        if let macroExpansionExpr = parent?.as(MacroExpansionExprSyntax.self),
-           macroExpansionExpr.macroName.text == "Preview" {
-            return true
-        }
-        return false
+        parent?.as(MacroExpansionExprSyntax.self)?.macroName.text == "Preview"
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/RedundantDiscardableLetRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/RedundantDiscardableLetRule.swift
@@ -98,19 +98,6 @@ struct RedundantDiscardableLetRule: Rule {
                     }
                     """),
             Example("""
-                @ViewBuilder
-                func bar() -> some View {
-                    ↓let _ = foo()
-                    return Text("Hello, World!")
-                }
-                """): Example("""
-                    @ViewBuilder
-                    func bar() -> some View {
-                        _ = foo()
-                        return Text("Hello, World!")
-                    }
-                    """),
-            Example("""
                 #Preview {
                     ↓let _ = foo()
                     return Text("Hello, World!")
@@ -122,14 +109,14 @@ struct RedundantDiscardableLetRule: Rule {
                     }
                     """),
             Example("""
-                static var previews: some View {
-                    ↓let _ = foo()
-                    Text("Hello, World!")
+                var body: some View {
+                    let _ = foo()
+                    return Text("Hello, World!")
                 }
-                """): Example("""
-                    static var previews: some View {
-                        _ = foo()
-                        Text("Hello, World!")
+                """, configuration: ["ignore_swiftui_view_bodies": true]): Example("""
+                    var body: some View {
+                        let _ = foo()
+                        return Text("Hello, World!")
                     }
                     """),
         ]

--- a/Source/SwiftLintBuiltInRules/Rules/Style/RedundantDiscardableLetRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/RedundantDiscardableLetRule.swift
@@ -175,16 +175,11 @@ private extension AccessorBlockSyntax {
 
 private extension CodeBlockSyntax {
     var isViewBuilderFunctionBody: Bool {
-        parent?.as(FunctionDeclSyntax.self)?.isViewBuilderFunction == true
-    }
-}
-
-private extension FunctionDeclSyntax {
-    var isViewBuilderFunction: Bool {
-        guard attributes.contains(attributeNamed: "ViewBuilder") else {
+        guard let functionDecl = parent?.as(FunctionDeclSyntax.self),
+              functionDecl.attributes.contains(attributeNamed: "ViewBuilder") else {
             return false
         }
-        return signature.returnClause?.type.as(SomeOrAnyTypeSyntax.self)?.isView ?? false
+        return functionDecl.signature.returnClause?.type.as(SomeOrAnyTypeSyntax.self)?.isView ?? false
     }
 }
 


### PR DESCRIPTION
Fixes #6063

I’d appreciate any feedback or suggestions.  Thanks in advance for your time and review!

#### Changes

- Fix false positive for `@ViewBuilder` functions when ignore_swiftui_view_bodies is set to true.
- Fix false positive for #Preview when ignore_swiftui_view_bodies is set to true.
- Fix false positive for PreviewProvider when ignore_swiftui_view_bodies is set to true.