### PR TITLE
Disable boolean values for validates_start_with_lowercase and remove deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Breaking
 
-* Removed support for boolean values in the `validates_start_with_lowercase` option
-  and its deprecation warning. Use severity levels (`off`, `warning`, or `error`) instead.
+* Remove support for boolean values in the `validates_start_with_lowercase` option entirely.
+  Use the severity levels `off`, `warning` or `error` instead.  
   [kaseken](https://github.com/kaseken)
 
 ### Experimental

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Breaking
 
-* None.
+* Removed support for boolean values in the `validates_start_with_lowercase` option
+  and its deprecation warning. Use severity levels (`off`, `warning`, or `error`) instead.
+  [kaseken](https://github.com/kaseken)
 
 ### Experimental
 

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NameConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NameConfiguration.swift
@@ -73,16 +73,6 @@ struct NameConfiguration<Parent: Rule>: RuleConfiguration, InlinableOptionType {
         }
         if let validatesStartWithLowercase = configurationDict[$validatesStartWithLowercase.key] as? String {
             try self.validatesStartWithLowercase.apply(configuration: validatesStartWithLowercase)
-        } else if let validatesStartWithLowercase = configurationDict[$validatesStartWithLowercase.key] as? Bool {
-            // TODO: [05/10/2025] Remove deprecation warning after ~2 years.
-            self.validatesStartWithLowercase = validatesStartWithLowercase ? .error : .off
-            Issue.genericWarning(
-                """
-                The \"validates_start_with_lowercase\" configuration now expects a severity (warning or \
-                error). The boolean value 'true' will still enable it as an error. It is now deprecated and will be \
-                removed in a future release.
-                """
-            ).print()
         }
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/IdentifierNameRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/IdentifierNameRuleExamples.swift
@@ -33,11 +33,6 @@ internal struct IdentifierNameRuleExamples {
     ]
 
     static let triggeringExamples = [
-        Example(
-            "let ↓MyLet = 0",
-            configuration: ["validates_start_with_lowercase": true],
-            excludeFromDocumentation: true
-        ),
         Example("class C { static let ↓_myLet = 0 }"),
         Example("class C { class let ↓MyLet = 0 }"),
         Example("class C { static func ↓MyFunc() {} }"),

--- a/Tests/BuiltInRulesTests/GenericTypeNameRuleTests.swift
+++ b/Tests/BuiltInRulesTests/GenericTypeNameRuleTests.swift
@@ -58,6 +58,6 @@ final class GenericTypeNameRuleTests: SwiftLintTestCase {
 
         let description = baseDescription.with(nonTriggeringExamples: nonTriggeringExamples)
                                          .with(triggeringExamples: triggeringExamples)
-        verifyRule(description, ruleConfiguration: ["validates_start_with_lowercase": false])
+        verifyRule(description, ruleConfiguration: ["validates_start_with_lowercase": "off"])
     }
 }

--- a/Tests/BuiltInRulesTests/IdentifierNameRuleTests.swift
+++ b/Tests/BuiltInRulesTests/IdentifierNameRuleTests.swift
@@ -62,7 +62,7 @@ final class IdentifierNameRuleTests: SwiftLintTestCase {
         let description = baseDescription.with(nonTriggeringExamples: nonTriggeringExamples)
                                          .with(triggeringExamples: triggeringExamples)
 
-        verifyRule(description, ruleConfiguration: ["validates_start_with_lowercase": false])
+        verifyRule(description, ruleConfiguration: ["validates_start_with_lowercase": "off"])
     }
 
     func testStartsWithLowercaseCheck() {
@@ -81,14 +81,14 @@ final class IdentifierNameRuleTests: SwiftLintTestCase {
             IdentifierNameRule.description
                 .with(triggeringExamples: triggeringExamples)
                 .with(nonTriggeringExamples: nonTriggeringExamples),
-            ruleConfiguration: ["validates_start_with_lowercase": true]
+            ruleConfiguration: ["validates_start_with_lowercase": "error"]
         )
 
         verifyRule(
             IdentifierNameRule.description
                 .with(triggeringExamples: [])
                 .with(nonTriggeringExamples: nonTriggeringExamples + triggeringExamples.removingViolationMarkers()),
-            ruleConfiguration: ["validates_start_with_lowercase": false]
+            ruleConfiguration: ["validates_start_with_lowercase": "off"]
         )
     }
 
@@ -103,7 +103,7 @@ final class IdentifierNameRuleTests: SwiftLintTestCase {
                     Example("enum Foo { case myCase }"),
                 ]),
             ruleConfiguration: [
-                "validates_start_with_lowercase": true,
+                "validates_start_with_lowercase": "error",
                 "allowed_symbols": ["M"],
             ] as [String: any Sendable]
         )

--- a/Tests/BuiltInRulesTests/NameConfigurationTests.swift
+++ b/Tests/BuiltInRulesTests/NameConfigurationTests.swift
@@ -47,21 +47,6 @@ final class NameConfigurationTests: SwiftLintTestCase {
         XCTAssertEqual(nameConfig.validatesStartWithLowercase, .warning)
     }
 
-    func testNameConfigurationWithDeprecatedBooleanSeverity() throws {
-        var nameConfig = TesteeType(minLengthWarning: 0,
-                                    minLengthError: 0,
-                                    maxLengthWarning: 0,
-                                    maxLengthError: 0)
-
-        XCTAssertEqual(nameConfig.validatesStartWithLowercase, .error)
-
-        try nameConfig.apply(configuration: ["validates_start_with_lowercase": false])
-        XCTAssertEqual(nameConfig.validatesStartWithLowercase, .off)
-
-        try nameConfig.apply(configuration: ["validates_start_with_lowercase": true])
-        XCTAssertEqual(nameConfig.validatesStartWithLowercase, .error)
-    }
-
     func testNameConfigurationThrowsOnBadConfig() {
         let config = 17
         var nameConfig = TesteeType(minLengthWarning: 0,

--- a/Tests/BuiltInRulesTests/TypeNameRuleTests.swift
+++ b/Tests/BuiltInRulesTests/TypeNameRuleTests.swift
@@ -58,6 +58,6 @@ final class TypeNameRuleTests: SwiftLintTestCase {
         let description = baseDescription.with(nonTriggeringExamples: nonTriggeringExamples)
                                          .with(triggeringExamples: triggeringExamples)
 
-        verifyRule(description, ruleConfiguration: ["validates_start_with_lowercase": false])
+        verifyRule(description, ruleConfiguration: ["validates_start_with_lowercase": "off"])
     }
 }


### PR DESCRIPTION
Resolves #6076

- Disallow boolean values for validates_start_with_lowercase config.
- Remove associated deprecation warning.

