### PR TITLE
Add new rule `unnest_switches_using_tuple`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@
 
 * Add new `allowed_numbers` option to the `no_magic_numbers` rule.  
   [Martin Redington](https://github.com/mildm8nnered)
+* Add new `unnest_switches_using_tuple` opt-in rule that triggers when
+  nested switches are encountered that reference the same variable. These
+  can be replaced by a switch on a tuple.  
+  [Alfons Hoogervorst](https://github.com/snofla/SwiftLint)
 
 ### Bug Fixes
 

--- a/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
+++ b/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
@@ -221,6 +221,7 @@ public let builtInRules: [any Rule.Type] = [
     UnneededOverrideRule.self,
     UnneededParenthesesInClosureArgumentRule.self,
     UnneededSynthesizedInitializerRule.self,
+    UnnestSwitchesUsingTupleRule.self,
     UnownedVariableCaptureRule.self,
     UntypedErrorInCatchRule.self,
     UnusedClosureParameterRule.self,

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnnestSwitchesUsingTupleRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnnestSwitchesUsingTupleRule.swift
@@ -1,0 +1,204 @@
+import SwiftLintCore
+import SwiftSyntax
+
+@SwiftSyntaxRule(optIn: true)
+struct UnnestSwitchesUsingTupleRule: Rule {
+    var configuration = SeverityConfiguration<Self>(.warning)
+
+    static let description = RuleDescription(
+        identifier: "unnest_switches_using_tuple",
+        name: "Unnest Switches Using Tuple",
+        description: "Prevent nesting switches by preferring a switch on a tuple",
+        kind: .lint,
+        nonTriggeringExamples: [
+            Example("""
+                switch (a, b) {
+                case (1, 1): 
+                    break
+                case (1, 2):
+                    break
+                case (2, 1):
+                    break
+                case (2, 2):
+                    break
+                }
+            """),
+            Example("""
+                switch (a, b) {
+                case (1, 1):
+                    break 
+                case (1, 2):
+                    break
+                case (2, _):
+                    break
+                }
+            """),
+            Example("""
+                switch a {
+                case 1: 
+                    let b = something
+                    switch b {
+                    case 1:
+                        break
+                    case 2:
+                        break
+                    }
+                case 2:
+                    break
+                }
+            """),
+        ],
+        triggeringExamples: [
+            Example("""
+                ↓switch a {
+                  case 1: 
+                    switch b {
+                    case 1:
+                      break
+                    case 2:
+                      break
+                    }      
+                  case 2:
+                    switch b {
+                    case 1:
+                      break
+                    case 2:
+                      break
+                    }
+                }            
+            """),
+            Example("""
+                ↓switch a {
+                case 1: 
+                    switch b {
+                    case 1:
+                        break
+                    case 2:
+                        break
+                    }
+                case 2:
+                    break
+                }
+            """),
+            Example("""
+                switch a {
+                case 1: 
+                    ↓switch b {
+                    case 1:
+                        switch c {
+                        case 1:
+                            break
+                        }
+                    case 2:
+                        break
+                    }
+                case 2:
+                    break
+                }
+            """),
+        ]
+    )
+}
+
+private extension UnnestSwitchesUsingTupleRule {
+    
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
+        
+        override func visitPost(_ node: SwitchExprSyntax) {
+            guard let nestingSwitch = self.switchNestedSwitches[node] else {
+                // does this switch have a parent switch?
+                guard let parent = node.firstParent(ofKind: .switchExpr),
+                      let parentSwitchExpr = parent.as(SwitchExprSyntax.self) else {
+                    return
+                }
+                // file this node, which is a nested switch, under its parent
+                self.switchNestedSwitches[parentSwitchExpr, default: []].append(node)
+                return
+            }
+            // check the parent switch
+            defer { self.switchNestedSwitches = [:] }
+            guard !nestingSwitch.isEmpty else {
+                return
+            }
+            // we only want the nested switched without a local reference
+            // to the switch's decl expression, so the following is
+            // not triggering a violation:
+            //
+            //      let b = 1 // or a var
+            //      switch (b) {
+            //      }
+            //
+            let variables: Set<String> = nestingSwitch
+                .filter { !$0.hasDeclarationInLabelScope(for: $0.referencedVariable) }
+                .compactMap { $0.referencedVariable }
+                .reduce(into: [], { p, e in p.insert(e) })
+            
+            // we want all nested switches to reference the same variable
+            // to be able to unnest a switch using tuples
+            guard variables.count == 1 else {
+                // different variables referenced
+                return
+            }
+            self.violations.append(node.positionAfterSkippingLeadingTrivia)
+        }
+        
+        private var switchNestedSwitches: [SwitchExprSyntax: [SwitchExprSyntax]] = [:]
+    }
+}
+
+private extension SwitchExprSyntax {
+    
+    func hasDeclarationInLabelScope(for variable: String?) -> Bool {
+        guard let variable else {
+            return false
+        }
+        guard let switchCaseSyntax = self.firstParent(ofKind: .switchCase)?.as(SwitchCaseSyntax.self) else {
+            return false
+        }
+        guard let switchCodeBlockItem = self.firstParent(ofKind: .codeBlockItem)?.as(CodeBlockItemSyntax.self) else {
+            return false
+        }
+        let declReferencingVariable = switchCaseSyntax.statements
+            .prefix { $0 != switchCodeBlockItem }
+            .first { $0.containsReference(to: variable) }
+        return declReferencingVariable != nil
+    }
+    
+    var referencedVariable: String? {
+        self.subject.as(DeclReferenceExprSyntax.self)?.baseName.text
+    }
+}
+
+private extension CodeBlockItemSyntax {
+    
+    func containsReference(to variable: String) -> Bool {
+        guard self.item.kind == .variableDecl else {
+            return false
+        }
+        guard let variableDecl = self.item.as(VariableDeclSyntax.self) else {
+            return false
+        }
+        guard variableDecl.references(variable) else {
+            return false
+        }
+        return true
+    }
+}
+
+private extension VariableDeclSyntax {
+    
+    func references(_ variable: String) -> Bool {
+        self.bindings.first?.pattern.as(IdentifierPatternSyntax.self)?.identifier.text == variable
+    }
+}
+
+private extension SyntaxProtocol {
+
+    func firstParent(ofKind type: SyntaxKind) -> Syntax? {
+        var someParent: Syntax? = self.parent
+        while let current = someParent, current.kind != type {
+            someParent = current.parent
+        }
+        return someParent
+    }
+}

--- a/Tests/GeneratedTests/GeneratedTests.swift
+++ b/Tests/GeneratedTests/GeneratedTests.swift
@@ -1321,6 +1321,12 @@ final class UnneededSynthesizedInitializerRuleGeneratedTests: SwiftLintTestCase 
     }
 }
 
+final class UnnestSwitchesUsingTupleRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(UnnestSwitchesUsingTupleRule.description)
+    }
+}
+
 final class UnownedVariableCaptureRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(UnownedVariableCaptureRule.description)

--- a/Tests/IntegrationTests/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/default_rule_configurations.yml
@@ -1262,6 +1262,11 @@ unneeded_synthesized_initializer:
   meta:
     opt-in: false
     correctable: true
+unnest_switches_using_tuple:
+  severity: warning
+  meta:
+    opt-in: true
+    correctable: false
 unowned_variable_capture:
   severity: warning
   meta:


### PR DESCRIPTION
This introduces a new rule that detects nested switches that reference the same variable. This prevents needless indentation. 

The canonical example is: 
```
switch a {
case .one:
    switch b {
    case .one:
        break
    case .two:
        break
    }
case .two:
    switch b {
    case .one:
        break
    case .two:
        break
    }
}
```

A better suggestion in this case is to switch on a tuple. (While the general suggestion would be to move the switch to a separate function.)

```
switch (a, b) {
case (.one, .one):
    break
case (.one, .two):
    break
case (.two, .one):
    break
case (.two, .two):
    break
}
```