### PR TITLE
Add test case for trailing comma in multiline arguments

### DIFF
--- a/Source/SwiftLintBuiltInRules/Rules/Style/MultilineArgumentsRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/MultilineArgumentsRuleExamples.swift
@@ -69,6 +69,12 @@ internal struct MultilineArgumentsRuleExamples {
             print("b")
         }
         """),
+        Example("""
+        f(
+            foo: 1,
+            bar: false,
+        )
+        """),
     ]
 
     static let triggeringExamples = [


### PR DESCRIPTION
Related to #6065.