### PR TITLE
Update non_optional_string_data_conversion rule docs and examples to make it more clear

### DIFF
--- a/Source/SwiftLintBuiltInRules/Rules/Lint/NonOptionalStringDataConversionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/NonOptionalStringDataConversionRule.swift
@@ -5,14 +5,16 @@ struct NonOptionalStringDataConversionRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
     static let description = RuleDescription(
         identifier: "non_optional_string_data_conversion",
-        name: "Non-optional String -> Data Conversion",
-        description: "Prefer non-optional `Data(_:)` initializer when converting `String` to `Data`",
+        name: "Non-optional String <-> Data Conversion",
+        description: "Prefer the non-optional initializers when converting between `String` and `Data` (e.g. `Data(_:)` and `String(decoding:as:)`)",
         kind: .lint,
         nonTriggeringExamples: [
-            Example("Data(\"foo\".utf8)")
+            Example("Data(\"foo\".utf8)"),
+            Example("String(decoding: data, as: UTF8.self)"),
         ],
         triggeringExamples: [
-            Example("\"foo\".data(using: .utf8)")
+            Example("\"foo\".data(using: .utf8)"),
+            Example("String(data: data, encoding: .utf8)"),
         ]
     )
 }


### PR DESCRIPTION
**Motivation:**

The rule `non_optional_string_data_conversion` is bidirectional it is triggered when converting string to data as well as when converting from data to string so this behaviour is needed to be clearly documented.

**Changes:**

- Updated the description to clearly show that the rule will be triggered in both scenarios with the references to preferred initialisers
- Updated triggering and non-triggering examples 