### PR TITLE
Update SwiftSyntax to unbreak macro modules.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,7 +33,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMajor(from: "1.2.1")),
-        .package(url: "https://github.com/swiftlang/swift-syntax.git", exact: "601.0.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", exact: "601.0.1"),
         .package(url: "https://github.com/jpsim/SourceKitten.git", .upToNextMajor(from: "0.37.0")),
         .package(url: "https://github.com/jpsim/Yams.git", .upToNextMajor(from: "5.3.0")),
         .package(url: "https://github.com/scottrhoyt/SwiftyTextTable.git", .upToNextMajor(from: "0.9.0")),


### PR DESCRIPTION
SwiftSyntax 601.0.0 is missing the marker module `SwiftSyntax601`, meaning that it'll break builds (primarily macro modules) that support large version ranges of SwfitSyntax via `#canImport(SwiftSyntax601)` directives. This has been [fixed](https://github.com/swiftlang/swift-syntax/pull/3036) in 601.0.1, but SwiftLint via SPM will keep the graph pinned against the broken 601.0.0 (like [here](https://github.com/Kolos65/Mockable/pull/120)). [The only change of note](https://github.com/swiftlang/swift-syntax/releases/tag/601.0.1) from 601.0.0 -> 601.0.1 was adding the missing marker module, so this should be an easy fix on the SwiftLint side. 