### PR TITLE
Add `build --incompatible_strict_action_env` to `.bazelrc`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -13,6 +13,7 @@ build --disk_cache=~/.bazel_cache
 build --experimental_remote_cache_compression
 build --remote_build_event_upload=minimal
 build --nolegacy_important_outputs
+build --incompatible_strict_action_env
 
 build:release \
   --compilation_mode=opt \


### PR DESCRIPTION
Which should help get better remote cache hits.
