### PR TITLE
[CI] Use Bazel for "Registration" job

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -28,6 +28,6 @@ steps:
   - label: "Registration"
     commands:
       - echo "+++ Register Rules and Reporters"
-      - make --always-make register
+      - make --always-make bazel_register
       - echo "+++ Diff Files"
       - git diff --quiet HEAD

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,11 @@ register:
 	swift run swiftlint-dev rules register
 	swift run swiftlint-dev reporters register
 
+bazel_register:
+	bazel build //:swiftlint-dev
+	./bazel-bin/swiftlint-dev rules register
+	./bazel-bin/swiftlint-dev reporters register
+
 test: clean_xcode
 	$(BUILD_TOOL) $(XCODEFLAGS) test
 


### PR DESCRIPTION
Which should be much faster than the previous SwiftPM build in the common case of not having to rebuild SwiftSyntax.

Finished in 7s ([job](https://buildkite.com/swiftlint/swiftlint/builds/9844#01978aef-03e5-4df6-b6c4-570e6aa39b81)) instead of 1m18s ([job](https://buildkite.com/swiftlint/swiftlint/builds/9841/steps/canvas?jid=01978adb-0f3e-45a3-8244-878900e5fccb)). Adds up when there are lots of PRs up at once.