### PR TITLE
Migrate ExpiringTodoRule from SourceKit to SwiftSyntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,16 +26,13 @@
   * `accessibility_label_for_image`
   * `accessibility_trait_for_button`
   * `closure_end_indentation`
+  * `expiring_todo`
   * `file_length`
   * `line_length`
   * `vertical_whitespace`
   <!-- Keep empty line to have the contributors on a separate line. -->
   [JP Simard](https://github.com/jpsim)
   [Matt Pennig](https://github.com/pennig)
-
-* Migrate `expiring_todo` rule from SourceKit to SwiftSyntax for improved performance
-  and fewer false positives.  
-  [JP Simard](https://github.com/jpsim)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@
   [JP Simard](https://github.com/jpsim)
   [Matt Pennig](https://github.com/pennig)
 
+* Migrate `expiring_todo` rule from SourceKit to SwiftSyntax and from NSRegularExpression
+  to native Swift Regex for improved performance and fewer false positives.  
+  [JP Simard](https://github.com/jpsim)
+
 ### Bug Fixes
 
 * Improved error reporting when SwiftLint exits, because of an invalid configuration file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,8 @@
   [JP Simard](https://github.com/jpsim)
   [Matt Pennig](https://github.com/pennig)
 
-* Migrate `expiring_todo` rule from SourceKit to SwiftSyntax and from NSRegularExpression
-  to native Swift Regex for improved performance and fewer false positives.  
+* Migrate `expiring_todo` rule from SourceKit to SwiftSyntax for improved performance
+  and fewer false positives.  
   [JP Simard](https://github.com/jpsim)
 
 ### Bug Fixes

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/ExpiringTodoRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/ExpiringTodoRule.swift
@@ -11,11 +11,11 @@ struct ExpiringTodoRule: Rule {
         var reason: String {
             switch self {
             case .approachingExpiry:
-                return "TODO/FIXME is approaching its expiry and should be resolved soon"
+                "TODO/FIXME is approaching its expiry and should be resolved soon"
             case .expired:
-                return "TODO/FIXME has expired and must be resolved"
+                "TODO/FIXME has expired and must be resolved"
             case .badFormatting:
-                return "Expiring TODO/FIXME is incorrectly formatted"
+                "Expiring TODO/FIXME is incorrectly formatted"
             }
         }
     }
@@ -65,20 +65,18 @@ private extension ExpiringTodoRule {
             for token in node.tokens(viewMode: .sourceAccurate) {
                 processTrivia(
                     token.leadingTrivia,
-                    baseOffset: token.position.utf8Offset,
-                    regex: regex
+                    baseOffset: token.position.utf8Offset
                 )
                 processTrivia(
                     token.trailingTrivia,
-                    baseOffset: token.endPositionBeforeTrailingTrivia.utf8Offset,
-                    regex: regex
+                    baseOffset: token.endPositionBeforeTrailingTrivia.utf8Offset
                 )
             }
 
             return .skipChildren
         }
 
-        private func processTrivia(_ trivia: Trivia, baseOffset: Int, regex: NSRegularExpression) {
+        private func processTrivia(_ trivia: Trivia, baseOffset: Int) {
             var triviaOffset = baseOffset
 
             for (index, piece) in trivia.enumerated() {
@@ -107,14 +105,14 @@ private extension ExpiringTodoRule {
                         }
                     }
 
-                    processComment(combinedText, offset: currentOffset, regex: regex)
+                    processComment(combinedText, offset: currentOffset)
                 } else {
-                    processComment(commentText, offset: triviaOffset, regex: regex)
+                    processComment(commentText, offset: triviaOffset)
                 }
             }
         }
 
-        private func processComment(_ commentText: String, offset: Int, regex: NSRegularExpression) {
+        private func processComment(_ commentText: String, offset: Int) {
             let matches = regex.matches(in: commentText, options: [], range: commentText.fullNSRange)
             let nsStringComment = commentText.bridge()
 
@@ -153,11 +151,11 @@ private extension ExpiringTodoRule {
         private func getSeverity(for violationLevel: ExpiryViolationLevel) -> ViolationSeverity? {
             switch violationLevel {
             case .approachingExpiry:
-                return configuration.approachingExpirySeverity.severity
+                configuration.approachingExpirySeverity.severity
             case .expired:
-                return configuration.expiredSeverity.severity
+                configuration.expiredSeverity.severity
             case .badFormatting:
-                return configuration.badFormattingSeverity.severity
+                configuration.badFormattingSeverity.severity
             }
         }
 
@@ -165,15 +163,21 @@ private extension ExpiringTodoRule {
             guard let expiryDate else {
                 return .badFormatting
             }
+
             guard expiryDate.isAfterToday else {
                 return .expired
             }
-            guard let approachingDate = Calendar.current.date(
+
+            let approachingDate = Calendar.current.date(
                 byAdding: .day,
                 value: -configuration.approachingExpiryThreshold,
-                to: expiryDate) else {
-                    return nil
+                to: expiryDate
+            )
+
+            guard let approachingDate else {
+                return nil
             }
+
             return approachingDate.isAfterToday ?
                 nil :
                 .approachingExpiry
@@ -191,9 +195,9 @@ private extension TriviaPiece {
     var isLineComment: Bool {
         switch self {
         case .lineComment, .docLineComment:
-            return true
+            true
         default:
-            return false
+            false
         }
     }
 
@@ -201,9 +205,9 @@ private extension TriviaPiece {
         switch self {
         case .lineComment(let text), .blockComment(let text),
              .docLineComment(let text), .docBlockComment(let text):
-            return text
+            text
         default:
-            return nil
+            nil
         }
     }
 }


### PR DESCRIPTION
## Summary

Convert ExpiringTodoRule to use SwiftSyntax for improved performance and better multiline comment handling.

## Key Technical Improvements

- **Full file content matching** to handle multiline TODO/FIXME comments
- **Enhanced comment detection** supporting comments across multiple lines
- **Improved performance** with SwiftSyntax visitor pattern over SourceKit AST parsing

## Migration Details

- Replaced `ASTRule` with `@SwiftSyntaxRule(optIn: true)` annotation
- Implemented `ViolationsSyntaxVisitor` pattern for file traversal
- Changed from per-comment processing to full file regex matching
- Added robust position-in-comment verification using trivia analysis
- Maintained full compatibility with existing rule behavior and test cases
