### PR TITLE
Require macOS 13

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -190,7 +190,7 @@ apple_universal_binary(
         "x86_64",
         "arm64",
     ],
-    minimum_os_version = "12.0",
+    minimum_os_version = "13.0",
     platform_type = "macos",
     visibility = ["//visibility:public"],
 )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   Use the severity levels `off`, `warning` or `error` instead.  
   [kaseken](https://github.com/kaseken)
 
+* SwiftLint now requires macOS 13 or higher to run.  
+  [JP Simard](https://github.com/jpsim)
+
 ### Experimental
 
 * None.

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ swiftLintPluginDependencies = [.target(name: "swiftlint")]
 
 let package = Package(
     name: "SwiftLint",
-    platforms: [.macOS(.v12)],
+    platforms: [.macOS(.v13)],
     products: [
         .executable(name: "swiftlint", targets: ["swiftlint"]),
         .library(name: "SwiftLintFramework", targets: ["SwiftLintFramework"]),


### PR DESCRIPTION
So we can start using Regex and other macOS 13+ APIs.
