### PR TITLE
Add `ConditionallySourceKitFree` to migrate custom rules to SwiftSyntax

### DIFF
--- a/Source/SwiftLintCore/Extensions/Request+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/Request+SwiftLint.swift
@@ -19,7 +19,10 @@ public extension Request {
                     }
 
                     // Check if the current rule is a SourceKitFreeRule
-                    if ruleType is any SourceKitFreeRule.Type {
+                    // Skip check for ConditionallySourceKitFree rules since we can't determine
+                    // at the type level if they're effectively SourceKit-free
+                    if ruleType is any SourceKitFreeRule.Type &&
+                       !(ruleType is any ConditionallySourceKitFree.Type) {
                         queuedFatalError("""
                             '\(ruleID)' is a SourceKitFreeRule and should not be making requests to SourceKit.
                             """)

--- a/Source/SwiftLintFramework/Documentation/RuleDocumentation.swift
+++ b/Source/SwiftLintFramework/Documentation/RuleDocumentation.swift
@@ -12,7 +12,12 @@ struct RuleDocumentation {
     var isLinterRule: Bool { !isAnalyzerRule }
 
     /// If this rule uses SourceKit.
-    var usesSourceKit: Bool { !(ruleType is any SourceKitFreeRule.Type) }
+    /// Note: For ConditionallySourceKitFree rules, this returns true since we can't
+    /// determine at the type level if they're effectively SourceKit-free.
+    var usesSourceKit: Bool {
+        !(ruleType is any SourceKitFreeRule.Type) ||
+            (ruleType is any ConditionallySourceKitFree.Type)
+    }
 
     /// If this rule is disabled by default.
     var isDisabledByDefault: Bool { ruleType is any OptInRule.Type }

--- a/Source/SwiftLintFramework/Models/Linter.swift
+++ b/Source/SwiftLintFramework/Models/Linter.swift
@@ -78,7 +78,9 @@ private extension Rule {
             return false
         }
 
-        if !(self is any SourceKitFreeRule) && file.sourcekitdFailed {
+        // Only check sourcekitdFailed if the rule requires SourceKit.
+        // This avoids triggering SourceKit initialization for SourceKit-free rules.
+        if requiresSourceKit && file.sourcekitdFailed {
             warnSourceKitFailedOnce()
             return false
         }

--- a/Source/SwiftLintFramework/Rules/CustomRules.swift
+++ b/Source/SwiftLintFramework/Rules/CustomRules.swift
@@ -36,7 +36,7 @@ struct CustomRulesConfiguration: RuleConfiguration, CacheDescriptionProvider {
 
 // MARK: - CustomRules
 
-struct CustomRules: Rule, CacheDescriptionProvider {
+struct CustomRules: Rule, CacheDescriptionProvider, ConditionallySourceKitFree {
     var cacheDescription: String {
         configuration.cacheDescription
     }
@@ -55,6 +55,11 @@ struct CustomRules: Rule, CacheDescriptionProvider {
         kind: .style)
 
     var configuration = CustomRulesConfiguration()
+
+    var isEffectivelySourceKitFree: Bool {
+        // Just a stub, will be implemented in a follow-up PR
+        false
+    }
 
     func validate(file: SwiftLintFile) -> [StyleViolation] {
         var configurations = configuration.customRuleConfigurations

--- a/Source/swiftlint/Commands/Rules.swift
+++ b/Source/swiftlint/Commands/Rules.swift
@@ -132,7 +132,7 @@ private extension TextTable {
                 configuredRule != nil ? "yes" : "no",
                 ruleType.description.kind.rawValue,
                 (rule is any AnalyzerRule) ? "yes" : "no",
-                (rule is any SourceKitFreeRule) ? "no" : "yes",
+                rule.requiresSourceKit ? "yes" : "no",
                 truncate((defaultConfig ? rule : configuredRule ?? rule).createConfigurationDescription().oneLiner()),
             ])
         }

--- a/Tests/FrameworkTests/ConditionallySourceKitFreeTests.swift
+++ b/Tests/FrameworkTests/ConditionallySourceKitFreeTests.swift
@@ -1,0 +1,87 @@
+@testable import SwiftLintCore
+@testable import SwiftLintFramework
+import XCTest
+
+final class ConditionallySourceKitFreeTests: XCTestCase {
+    // Mock rule for testing ConditionallySourceKitFree protocol
+    private struct MockConditionalRule: Rule, ConditionallySourceKitFree {
+        static let description = RuleDescription(
+            identifier: "mock_conditional",
+            name: "Mock Conditional Rule",
+            description: "A mock rule for testing ConditionallySourceKitFree",
+            kind: .style
+        )
+
+        var configuration = SeverityConfiguration<Self>(.warning)
+        var isEffectivelySourceKitFree = true
+
+        func validate(file _: SwiftLintFile) -> [StyleViolation] {
+            []
+        }
+    }
+
+    private struct MockSourceKitFreeRule: Rule, SourceKitFreeRule {
+        static let description = RuleDescription(
+            identifier: "mock_sourcekit_free",
+            name: "Mock SourceKit Free Rule",
+            description: "A mock rule that is always SourceKit-free",
+            kind: .style
+        )
+
+        var configuration = SeverityConfiguration<Self>(.warning)
+
+        func validate(file _: SwiftLintFile) -> [StyleViolation] {
+            []
+        }
+    }
+
+    private struct MockRegularRule: Rule {
+        static let description = RuleDescription(
+            identifier: "mock_regular",
+            name: "Mock Regular Rule",
+            description: "A mock rule that requires SourceKit",
+            kind: .style
+        )
+
+        var configuration = SeverityConfiguration<Self>(.warning)
+
+        func validate(file _: SwiftLintFile) -> [StyleViolation] {
+            []
+        }
+    }
+
+    func testRequiresSourceKitForDifferentRuleTypes() {
+        // SourceKitFreeRule should not require SourceKit
+        let sourceKitFreeRule = MockSourceKitFreeRule()
+        XCTAssertFalse(sourceKitFreeRule.requiresSourceKit)
+
+        // ConditionallySourceKitFree rule that is effectively SourceKit-free
+        var conditionalRuleFree = MockConditionalRule()
+        conditionalRuleFree.isEffectivelySourceKitFree = true
+        XCTAssertFalse(conditionalRuleFree.requiresSourceKit)
+
+        // ConditionallySourceKitFree rule that requires SourceKit
+        var conditionalRuleRequires = MockConditionalRule()
+        conditionalRuleRequires.isEffectivelySourceKitFree = false
+        XCTAssertTrue(conditionalRuleRequires.requiresSourceKit)
+
+        // Regular rule should require SourceKit
+        let regularRule = MockRegularRule()
+        XCTAssertTrue(regularRule.requiresSourceKit)
+    }
+
+    func testTypeCheckingBehavior() {
+        // Verify instance-level checks work correctly
+        let sourceKitFreeRule: any Rule = MockSourceKitFreeRule()
+        XCTAssertTrue(sourceKitFreeRule is any SourceKitFreeRule)
+        XCTAssertFalse(sourceKitFreeRule is any ConditionallySourceKitFree)
+
+        let conditionalRule: any Rule = MockConditionalRule()
+        XCTAssertFalse(conditionalRule is any SourceKitFreeRule)
+        XCTAssertTrue(conditionalRule is any ConditionallySourceKitFree)
+
+        let regularRule: any Rule = MockRegularRule()
+        XCTAssertFalse(regularRule is any SourceKitFreeRule)
+        XCTAssertFalse(regularRule is any ConditionallySourceKitFree)
+    }
+}


### PR DESCRIPTION
The protocol will be used to tag rules that may or may not require
SourceKit depending on its configuration. I only expect this to be used
for custom rules as utility to help transition to a fully SwiftSyntax
based approach.
