### PR TITLE
Migrate MultilineParametersBracketsRule from SourceKit to SwiftSyntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
   * `file_header`
   * `file_length`
   * `line_length`
+  * `multiline_parameters_brackets`
   * `trailing_whitespace`
   * `vertical_whitespace`
   <!-- Keep empty line to have the contributors on a separate line. -->


### PR DESCRIPTION
## Summary

Convert MultilineParametersBracketsRule to use SwiftSyntax instead of
SourceKit for improved performance and better detection of multiline
parameter formatting violations.

## Key Technical Improvements

- **Enhanced multiline detection** distinguishing between structurally
  multiline parameters and parameters with multiline default values
- **Accurate position reporting** using SwiftSyntax's precise token
  locations
- **Better handling of default values** by focusing on parameter
  structure rather than content
- **Improved performance** using visitor pattern over regex-based
  SourceKit analysis
- **Reduced false positives** for single parameters with multiline
  default values

## Migration Details

- Replaced `ASTRule` with `@SwiftSyntaxRule(optIn: true)` annotation
- Implemented `ViolationsSyntaxVisitor` pattern for function and
  initializer parameter analysis
- Added helper methods to extract significant tokens (name/type)
  excluding default values
- Converted regex-based bracket detection to SwiftSyntax position
  comparisons
- Maintained full compatibility with existing rule behavior and test
  cases
