### PR TITLE
Add warmup step to OSS check

### DIFF
--- a/tools/oss-check
+++ b/tools/oss-check
@@ -416,6 +416,12 @@ def report_binary_size
   end
 end
 
+def warmup
+  %w[branch main].each do |branch|
+    perform("swiftlint-#{branch} lint --no-cache --enable-all-rules --quiet", dir: "#{$working_dir}/builds")
+  end
+end
+
 ################################
 # Script
 ################################
@@ -474,6 +480,7 @@ unless @options[:force]
 end
 
 setup_repos
+warmup
 
 %w[branch main].each do |branch|
   generate_reports(branch)

--- a/tools/oss-check
+++ b/tools/oss-check
@@ -418,7 +418,7 @@ end
 
 def warmup
   %w[branch main].each do |branch|
-    perform("swiftlint-#{branch} lint --no-cache --enable-all-rules --quiet", dir: "#{$working_dir}/builds")
+    perform("../builds/swiftlint-#{branch} lint --no-cache --enable-all-rules", dir: "#{$working_dir}/Aerial")
   end
 end
 


### PR DESCRIPTION
Avoid initial delay probably caused by OS level caching.