### PR TITLE
Refactor `multiline_parameters` rule for stricter validation and improved configuration handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,6 @@
 
 * Improve `multiline_parameters` rule to correctly support  
   `max_number_of_single_line_parameters` and detect mixed formatting.  
-
   [GandaLF2006](https://github.com/GandaLF2006)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,11 @@
   [kaseken](https://github.com/kaseken)
   [#6063](https://github.com/realm/SwiftLint/issues/6063)
 
+* Improve `multiline_parameters` rule to correctly support  
+  `max_number_of_single_line_parameters` and detect mixed formatting.  
+
+  [GandaLF2006](https://github.com/GandaLF2006)
+
 ### Bug Fixes
 
 * Improved error reporting when SwiftLint exits, because of an invalid configuration file

--- a/Source/SwiftLintBuiltInRules/Rules/Style/MultilineParametersRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/MultilineParametersRule.swift
@@ -35,26 +35,32 @@ private extension MultilineParametersRule {
             }
 
             var numberOfParameters = 0
-            var linesWithParameters = Set<Int>()
+            var linesWithParameters: Set<Int> = []
+            var hasMultipleParametersOnSameLine = false
 
             for position in parameterPositions {
                 let line = locationConverter.location(for: position).line
-                linesWithParameters.insert(line)
+
+                if !linesWithParameters.insert(line).inserted {
+                    hasMultipleParametersOnSameLine = true
+                }
+
                 numberOfParameters += 1
             }
 
-            if let maxNumberOfSingleLineParameters = configuration.maxNumberOfSingleLineParameters,
-               configuration.allowsSingleLine,
-               numberOfParameters > maxNumberOfSingleLineParameters {
-                return true
-            }
+            if linesWithParameters.count == 1 {
+                guard configuration.allowsSingleLine else {
+                    return numberOfParameters > 1
+                }
 
-            guard linesWithParameters.count > (configuration.allowsSingleLine ? 1 : 0),
-                  numberOfParameters != linesWithParameters.count else {
+                if let maxNumberOfSingleLineParameters = configuration.maxNumberOfSingleLineParameters {
+                    return numberOfParameters > maxNumberOfSingleLineParameters
+                }
+
                 return false
             }
 
-            return true
+            return hasMultipleParametersOnSameLine
         }
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/MultilineParametersRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/MultilineParametersRuleExamples.swift
@@ -357,11 +357,9 @@ internal struct MultilineParametersRuleExamples {
         Example("""
         func ↓foo(param1: Int,
                   param2: Bool, param3: [String]) { }
-        """,
-                configuration: ["max_number_of_single_line_parameters": 3]),
+       """, configuration: ["max_number_of_single_line_parameters": 3]),
         Example("""
-        func foo(param1: Int, param2: Bool, param3: [String]) { }
-        """,
-                configuration: ["max_number_of_single_line_parameters": 2]),
+        func ↓foo(param1: Int, param2: Bool, param3: [String]) { }
+        """, configuration: ["max_number_of_single_line_parameters": 2]),
     ]
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/MultilineParametersRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/MultilineParametersRuleExamples.swift
@@ -199,11 +199,20 @@ internal struct MultilineParametersRuleExamples {
         """, configuration: ["allows_single_line": false]),
         Example("func foo(param1: Int, param2: Bool, param3: [String]) { }",
                 configuration: ["max_number_of_single_line_parameters": 3]),
+        Example("func foo(param1: Int, param2: Bool) { }",
+                configuration: ["max_number_of_single_line_parameters": 2]),
         Example("""
         func foo(param1: Int,
                  param2: Bool,
                  param3: [String]) { }
         """, configuration: ["max_number_of_single_line_parameters": 3]),
+        Example("""
+        func foo(
+            param1: Int,
+            param2: Bool,
+            param3: [String]
+        ) { }
+        """, configuration: ["max_number_of_single_line_parameters": 2]),
     ]
 
     static let triggeringExamples: [Example] = [
@@ -350,5 +359,9 @@ internal struct MultilineParametersRuleExamples {
                   param2: Bool, param3: [String]) { }
         """,
                 configuration: ["max_number_of_single_line_parameters": 3]),
+        Example("""
+        func foo(param1: Int, param2: Bool, param3: [String]) { }
+        """,
+                configuration: ["max_number_of_single_line_parameters": 2]),
     ]
 }


### PR DESCRIPTION
This PR refactors the multiline_parameters rule to:

- Fix incorrect or incomplete handling of the max_number_of_single_line_parameters configuration
- Simplify internal logic and improve code readability without affecting performance