### PR TITLE
Add `function_name_whitespace` rule to validate and autocorrect spacing around function names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,6 +175,16 @@
   to avoid causing compilation errors.  
   [p4checo](https://github.com/p4checo)
   [#5965](https://github.com/realm/SwiftLint/issues/5965)
+* Add `function_name_whitespace` rule to enforce consistent spacing between the `func`
+  keyword, function name, and its generic parameters. Ensures exactly one space between
+  `func` and the function name, and configurable spacing around generics via
+  `generic_space`:
+  * `no_space` (default): `func name<T>()`
+  * `leading_space`: `func name <T>()`
+  * `trailing_space`: `func name<T> ()`
+  * `leading_trailing_space`: `func name <T> ()`
+  Supports autocorrection.  
+  [GandaLF2006](https://github.com/GandaLF2006)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@
   when running this binary.  
   [SimplyDanny](https://github.com/SimplyDanny)
 
+* Add `function_name_whitespace` rule to enforce consistent spacing between the `func`
+  keyword, function name, and its generic parameters. Ensures exactly one space between
+  `func` and the function name, and configurable spacing around generics via
+  `generic_spacing`:
+  * `no_space` (default): `func name<T>()`
+  * `leading_space`: `func name <T>()`
+  * `trailing_space`: `func name<T> ()`
+  * `leading_trailing_space`: `func name <T> ()`
+  Supports autocorrection.  
+  [GandaLF2006](https://github.com/GandaLF2006)
+
 ### Bug Fixes
 
 * None.
@@ -175,16 +186,6 @@
   to avoid causing compilation errors.  
   [p4checo](https://github.com/p4checo)
   [#5965](https://github.com/realm/SwiftLint/issues/5965)
-* Add `function_name_whitespace` rule to enforce consistent spacing between the `func`
-  keyword, function name, and its generic parameters. Ensures exactly one space between
-  `func` and the function name, and configurable spacing around generics via
-  `generic_space`:
-  * `no_space` (default): `func name<T>()`
-  * `leading_space`: `func name <T>()`
-  * `trailing_space`: `func name<T> ()`
-  * `leading_trailing_space`: `func name <T> ()`
-  Supports autocorrection.  
-  [GandaLF2006](https://github.com/GandaLF2006)
 
 ### Bug Fixes
 

--- a/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
+++ b/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
@@ -81,6 +81,7 @@ public let builtInRules: [any Rule.Type] = [
     ForceUnwrappingRule.self,
     FunctionBodyLengthRule.self,
     FunctionDefaultParameterAtEndRule.self,
+    FunctionNameWhitespaceRule.self,
     FunctionParameterCountRule.self,
     GenericTypeNameRule.self,
     IBInspectableInExtensionRule.self,

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/NSObjectPreferIsEqualRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/NSObjectPreferIsEqualRuleExamples.swift
@@ -13,7 +13,7 @@ internal struct NSObjectPreferIsEqualRuleExamples {
         // Class with == which does not subclass NSObject
         Example("""
         class AClass: Equatable {
-            static func ==(lhs: AClass, rhs: AClass) -> Bool {
+            static func == (lhs: AClass, rhs: AClass) -> Bool {
                 return true
             }
         """),
@@ -36,7 +36,7 @@ internal struct NSObjectPreferIsEqualRuleExamples {
         // NSObject subclass implementing == with different signature
         Example("""
         class AClass: NSObject {
-            static func ==(lhs: AClass, rhs: BClass) -> Bool {
+            static func == (lhs: AClass, rhs: BClass) -> Bool {
                 return true
             }
         }
@@ -44,7 +44,7 @@ internal struct NSObjectPreferIsEqualRuleExamples {
         // Equatable struct
         Example("""
         struct AStruct: Equatable {
-            static func ==(lhs: AStruct, rhs: AStruct) -> Bool {
+            static func == (lhs: AStruct, rhs: AStruct) -> Bool {
                 return false
             }
         }
@@ -52,7 +52,7 @@ internal struct NSObjectPreferIsEqualRuleExamples {
         // Equatable enum
         Example("""
         enum AnEnum: Equatable {
-            static func ==(lhs: AnEnum, rhs: AnEnum) -> Bool {
+            static func == (lhs: AnEnum, rhs: AnEnum) -> Bool {
                 return true
             }
         }
@@ -61,7 +61,7 @@ internal struct NSObjectPreferIsEqualRuleExamples {
         Example("""
         class C: NSObject {
             class NestedClass {
-                static func ==(lhs: NestedClass, rhs: NestedClass) -> Bool {
+                static func == (lhs: NestedClass, rhs: NestedClass) -> Bool {
                     return false
                 }
             }
@@ -89,7 +89,7 @@ internal struct NSObjectPreferIsEqualRuleExamples {
         // NSObject subclass implementing ==
         Example("""
         class AClass: NSObject {
-            ↓static func ==(lhs: AClass, rhs: AClass) -> Bool {
+            ↓static func == (lhs: AClass, rhs: AClass) -> Bool {
                 return false
             }
         }
@@ -97,7 +97,7 @@ internal struct NSObjectPreferIsEqualRuleExamples {
         // @objc class implementing ==
         Example("""
         @objc class AClass: SomeOtherNSObjectSubclass {
-            ↓static func ==(lhs: AClass, rhs: AClass) -> Bool {
+            ↓static func == (lhs: AClass, rhs: AClass) -> Bool {
                 return true
             }
         }
@@ -105,7 +105,7 @@ internal struct NSObjectPreferIsEqualRuleExamples {
         // Equatable NSObject subclass implementing ==
         Example("""
         class AClass: NSObject, Equatable {
-            ↓static func ==(lhs: AClass, rhs: AClass) -> Bool {
+            ↓static func == (lhs: AClass, rhs: AClass) -> Bool {
                 return false
             }
         }
@@ -120,7 +120,7 @@ internal struct NSObjectPreferIsEqualRuleExamples {
                 return true
             }
 
-            ↓static func ==(lhs: AClass, rhs: AClass) -> Bool {
+            ↓static func == (lhs: AClass, rhs: AClass) -> Bool {
                 return false
             }
         }
@@ -129,14 +129,14 @@ internal struct NSObjectPreferIsEqualRuleExamples {
         Example("""
         class C {
             @objc class NestedClass {
-                ↓static func ==(lhs: NestedClass, rhs: NestedClass) -> Bool {
+                ↓static func == (lhs: NestedClass, rhs: NestedClass) -> Bool {
                     return false
                 }
             }
         }
         struct S {
             @objcMembers class NestedClass {
-                ↓static func ==(lhs: NestedClass, rhs: NestedClass) -> Bool {
+                ↓static func == (lhs: NestedClass, rhs: NestedClass) -> Bool {
                     return false
                 }
             }
@@ -144,7 +144,7 @@ internal struct NSObjectPreferIsEqualRuleExamples {
         enum E {
             struct S {
                 @objc class NestedClass {
-                    ↓static func ==(lhs: NestedClass, rhs: NestedClass) -> Bool {
+                    ↓static func == (lhs: NestedClass, rhs: NestedClass) -> Bool {
                         return false
                     }
                 }
@@ -152,7 +152,7 @@ internal struct NSObjectPreferIsEqualRuleExamples {
         }
         extension E {
             @objc class NestedClass {
-                ↓static func ==(lhs: NestedClass, rhs: NestedClass) -> Bool {
+                ↓static func == (lhs: NestedClass, rhs: NestedClass) -> Bool {
                     return false
                 }
             }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FunctionNameWhitespaceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FunctionNameWhitespaceConfiguration.swift
@@ -1,0 +1,41 @@
+import SwiftLintCore
+
+@AutoConfigParser
+struct FunctionNameWhitespaceConfiguration: SeverityBasedRuleConfiguration {
+    typealias Parent = FunctionNameWhitespaceRule
+
+    @ConfigurationElement(key: "severity")
+    private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement(key: "generic_space")
+    private(set) var genericSpace = GenericSpaceType.noSpace
+
+    @AcceptableByConfigurationElement
+    enum GenericSpaceType: String {
+        case noSpace = "no_space"
+        case leadingSpace = "leading_space"
+        case trailingSpace = "trailing_space"
+        case leadingTrailingSpace = "leading_trailing_space"
+
+        var reasonForName: String {
+            switch self {
+            case .noSpace:
+                return "Remove space after function name"
+            case .leadingSpace:
+                return "Insert a single space after function name"
+            case .trailingSpace:
+                return "Remove space after function name"
+            case .leadingTrailingSpace:
+                return "Insert a single space after function name"
+            }
+        }
+
+        var reasonForGenericAngleBracket: String {
+            switch self {
+            case .noSpace, .leadingSpace:
+                return "Remove space after closing angle bracket"
+            case .trailingSpace, .leadingTrailingSpace:
+                return "Insert a single space after closing angle bracket"
+            }
+        }
+    }
+}

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FunctionNameWhitespaceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/FunctionNameWhitespaceConfiguration.swift
@@ -6,35 +6,31 @@ struct FunctionNameWhitespaceConfiguration: SeverityBasedRuleConfiguration {
 
     @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    @ConfigurationElement(key: "generic_space")
-    private(set) var genericSpace = GenericSpaceType.noSpace
+    @ConfigurationElement(key: "generic_spacing")
+    private(set) var genericSpacing = GenericSpacingType.noSpace
 
     @AcceptableByConfigurationElement
-    enum GenericSpaceType: String {
+    enum GenericSpacingType: String {
         case noSpace = "no_space"
         case leadingSpace = "leading_space"
         case trailingSpace = "trailing_space"
         case leadingTrailingSpace = "leading_trailing_space"
 
-        var reasonForName: String {
+        var beforeGenericViolationReason: String {
             switch self {
-            case .noSpace:
-                return "Remove space after function name"
-            case .leadingSpace:
-                return "Insert a single space after function name"
-            case .trailingSpace:
-                return "Remove space after function name"
-            case .leadingTrailingSpace:
-                return "Insert a single space after function name"
+            case .noSpace, .trailingSpace:
+                "Superfluous space between function name and generic parameter(s)"
+            case .leadingSpace, .leadingTrailingSpace:
+                "Missing space between function name and generic parameter(s)"
             }
         }
 
-        var reasonForGenericAngleBracket: String {
+        var afterGenericViolationReason: String {
             switch self {
             case .noSpace, .leadingSpace:
-                return "Remove space after closing angle bracket"
+                "Superfluous space after generic parameter(s)"
             case .trailingSpace, .leadingTrailingSpace:
-                return "Insert a single space after closing angle bracket"
+                "Missing space after generic parameter(s)"
             }
         }
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/FunctionNameWhitespaceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/FunctionNameWhitespaceRule.swift
@@ -18,7 +18,7 @@ struct FunctionNameWhitespaceRule: Rule {
 private extension FunctionNameWhitespaceRule {
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FunctionDeclSyntax) {
-            guard node.isNamedFunction else { return }
+            guard case .identifier = node.name.tokenKind else { return }
             validateFuncKeywordSpacing(for: node)
             correctSingleCommentTrivia(
                 after: node.name,
@@ -115,13 +115,6 @@ private extension FunctionNameWhitespaceRule {
                 )
             )
         }
-    }
-}
-
-private extension FunctionDeclSyntax {
-    var isNamedFunction: Bool {
-        guard case .identifier = name.tokenKind else { return false }
-        return true
     }
 }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/FunctionNameWhitespaceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/FunctionNameWhitespaceRule.swift
@@ -47,7 +47,7 @@ private extension FunctionNameWhitespaceRule {
             guard let replacement else { return }
             violations.append(
                 .init(
-                    position: node.name.positionAfterSkippingLeadingTrivia,
+                    position: node.name.endPositionBeforeTrailingTrivia,
                     reason: configuration.genericSpacing.beforeGenericViolationReason,
                     correction: .init(
                         start: node.name.endPositionBeforeTrailingTrivia,
@@ -62,7 +62,7 @@ private extension FunctionNameWhitespaceRule {
             guard node.funcKeyword.trailingTrivia.isNotSingleSpaceWithoutComments else { return }
             violations.append(
                 .init(
-                    position: node.name.positionAfterSkippingLeadingTrivia,
+                    position: node.funcKeyword.endPositionBeforeTrailingTrivia,
                     reason: "Too many spaces between 'func' and function name",
                     correction: .init(
                         start: node.funcKeyword.endPositionBeforeTrailingTrivia,
@@ -85,7 +85,7 @@ private extension FunctionNameWhitespaceRule {
             guard let replacement else { return }
             violations.append(
                 .init(
-                    position: node.positionAfterSkippingLeadingTrivia,
+                    position: node.endPositionBeforeTrailingTrivia,
                     reason: configuration.genericSpacing.afterGenericViolationReason,
                     correction: .init(
                         start: node.endPositionBeforeTrailingTrivia,
@@ -105,7 +105,7 @@ private extension FunctionNameWhitespaceRule {
 
             violations.append(
                 .init(
-                    position: node.positionAfterSkippingLeadingTrivia,
+                    position: node.endPositionBeforeTrailingTrivia,
                     reason: reason,
                     correction: .init(
                         start: node.endPositionBeforeTrailingTrivia,

--- a/Source/SwiftLintBuiltInRules/Rules/Style/FunctionNameWhitespaceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/FunctionNameWhitespaceRule.swift
@@ -1,0 +1,218 @@
+import SwiftSyntax
+
+@SwiftSyntaxRule(correctable: true, optIn: true)
+struct FunctionNameWhitespaceRule: Rule {
+    var configuration = FunctionNameWhitespaceConfiguration()
+
+    static let description = RuleDescription(
+        identifier: "function_name_whitespace",
+        name: "Function Name Whitespace",
+        description: "Checks whitespace before and after function name and generics",
+        kind: .style,
+        nonTriggeringExamples: FunctionNameWhitespaceRuleExamples.nonTriggeringExamples,
+        triggeringExamples: FunctionNameWhitespaceRuleExamples.triggeringExamples,
+        corrections: FunctionNameWhitespaceRuleExamples.corrections
+    )
+}
+
+private extension FunctionNameWhitespaceRule {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
+        override func visitPost(_ node: FunctionDeclSyntax) {
+            guard node.isNamedFunction else { return }
+
+            validateFuncKeywordSpacing(for: node)
+
+            correctSingleCommentTriviaIfNeeded(
+                trivia: node.name.trailingTrivia,
+                correctionStart: node.name.endPositionBeforeTrailingTrivia,
+                position: node.name.positionAfterSkippingLeadingTrivia,
+                reason: configuration.genericSpace.reasonForName
+            )
+            if let genericParameterClause = node.genericParameterClause {
+                correctSingleCommentTriviaIfNeeded(
+                    trivia: genericParameterClause.rightAngle.trailingTrivia,
+                    correctionStart: genericParameterClause.endPositionBeforeTrailingTrivia,
+                    position: genericParameterClause.positionAfterSkippingLeadingTrivia,
+                    reason: configuration.genericSpace.reasonForGenericAngleBracket
+                )
+            }
+
+            validateGenericSpacing(node: node)
+            switch configuration.genericSpace {
+            case .noSpace:
+                violationAndCorrection(
+                    name: node.name,
+                    isNeeded: node.name.trailingTrivia.isNotEmptyWithoutComments,
+                    replacement: ""
+                )
+            case .leadingSpace:
+                violationAndCorrection(
+                    name: node.name,
+                    isNeeded: node.name.trailingTrivia.isNotSingleSpaceWithoutComments,
+                    replacement: " "
+                )
+            case .trailingSpace:
+                violationAndCorrection(
+                    name: node.name,
+                    isNeeded: node.name.trailingTrivia.isNotEmptyWithoutComments,
+                    replacement: ""
+                )
+            case .leadingTrailingSpace:
+                violationAndCorrection(
+                    name: node.name,
+                    isNeeded: node.name.trailingTrivia.isNotSingleSpaceWithoutComments,
+                    replacement: " "
+                )
+            }
+        }
+
+        private func validateFuncKeywordSpacing(for node: FunctionDeclSyntax) {
+            guard node.funcKeyword.trailingTrivia.isNotSingleSpaceWithoutComments else { return }
+
+            violations.append(
+                ReasonedRuleViolation(
+                    position: node.name.positionAfterSkippingLeadingTrivia,
+                    reason: "There should be no space before the function name",
+                    correction: ReasonedRuleViolation.ViolationCorrection(
+                        start: node.funcKeyword.endPositionBeforeTrailingTrivia,
+                        end: node.name.positionAfterSkippingLeadingTrivia,
+                        replacement: " "
+                    )
+                )
+            )
+        }
+
+        private func validateGenericSpacing(node: FunctionDeclSyntax) {
+            guard let genericTrailingTrivia = node.genericParameterClause?.rightAngle.trailingTrivia else { return }
+            switch configuration.genericSpace {
+            case .noSpace:
+                violationAndCorrection(
+                    genericParameterClause: node.genericParameterClause,
+                    isNeeded: genericTrailingTrivia.isNotEmptyWithoutComments,
+                    replacement: ""
+                )
+            case .leadingSpace:
+                violationAndCorrection(
+                    genericParameterClause: node.genericParameterClause,
+                    isNeeded: genericTrailingTrivia.isNotEmptyWithoutComments,
+                    replacement: ""
+                )
+            case .trailingSpace:
+                violationAndCorrection(
+                    genericParameterClause: node.genericParameterClause,
+                    isNeeded: genericTrailingTrivia.isNotSingleSpaceWithoutComments,
+                    replacement: " "
+                )
+            case .leadingTrailingSpace:
+                violationAndCorrection(
+                    genericParameterClause: node.genericParameterClause,
+                    isNeeded: genericTrailingTrivia.isNotSingleSpaceWithoutComments,
+                    replacement: " "
+                )
+            }
+        }
+
+        private func violationAndCorrection(
+            genericParameterClause: GenericParameterClauseSyntax?,
+            isNeeded: Bool,
+            replacement: String
+        ) {
+            guard let clause = genericParameterClause, isNeeded else { return }
+
+            let correctionStart = clause.endPositionBeforeTrailingTrivia
+            let correctionEnd = correctionStart.advanced(
+                by: clause.trailingTriviaLength.utf8Length
+            )
+
+            violations.append(
+                ReasonedRuleViolation(
+                    position: clause.positionAfterSkippingLeadingTrivia,
+                    reason: configuration.genericSpace.reasonForGenericAngleBracket,
+                    correction: ReasonedRuleViolation.ViolationCorrection(
+                        start: correctionStart,
+                        end: correctionEnd,
+                        replacement: replacement
+                    )
+                )
+            )
+        }
+
+        private func violationAndCorrection(
+            name: TokenSyntax,
+            isNeeded: Bool,
+            replacement: String
+        ) {
+            guard isNeeded else { return }
+
+            let correctionStart = name.endPositionBeforeTrailingTrivia
+            let correctionEnd = correctionStart.advanced(
+                by: name.trailingTriviaLength.utf8Length
+            )
+
+            violations.append(
+                ReasonedRuleViolation(
+                    position: name.positionAfterSkippingLeadingTrivia,
+                    reason: configuration.genericSpace.reasonForName,
+                    correction: ReasonedRuleViolation.ViolationCorrection(
+                        start: correctionStart,
+                        end: correctionEnd,
+                        replacement: replacement
+                    )
+                )
+            )
+        }
+
+        private func correctSingleCommentTriviaIfNeeded(
+            trivia: Trivia,
+            correctionStart: AbsolutePosition,
+            position: AbsolutePosition,
+            reason: String
+        ) {
+            guard trivia.containsComments else { return }
+            guard let comment = trivia.singleComment else { return }
+            let expectedTrivia = Trivia.surroundedBySpaces(comment: comment)
+            guard trivia != expectedTrivia else { return }
+
+            let correctionEnd = correctionStart.advanced(
+                by: trivia.description.utf8.count
+            )
+
+            violations.append(
+                ReasonedRuleViolation(
+                    position: position,
+                    reason: reason,
+                    correction: ReasonedRuleViolation.ViolationCorrection(
+                        start: correctionStart,
+                        end: correctionEnd,
+                        replacement: " \(comment) "
+                    )
+                )
+            )
+        }
+    }
+}
+
+private extension FunctionDeclSyntax {
+    var isNamedFunction: Bool {
+        guard case .identifier = name.tokenKind else { return false }
+        return true
+    }
+}
+
+private extension Trivia {
+    var singleComment: TriviaPiece? {
+        filter(\.isComment).onlyElement
+    }
+
+    static func surroundedBySpaces(comment: TriviaPiece) -> Trivia {
+        Trivia(pieces: [.spaces(1), comment, .spaces(1)])
+    }
+
+    var isNotEmptyWithoutComments: Bool {
+        isNotEmpty && !containsComments
+    }
+
+    var isNotSingleSpaceWithoutComments: Bool {
+        !isSingleSpace && !containsComments
+    }
+}

--- a/Source/SwiftLintBuiltInRules/Rules/Style/FunctionNameWhitespaceRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/FunctionNameWhitespaceRuleExamples.swift
@@ -1,0 +1,331 @@
+internal struct FunctionNameWhitespaceRuleExamples {
+    static let nonTriggeringExamples: [Example] = [
+        Example("func abc(lhs: Int, rhs: Int) -> Int {}"),
+        Example(
+            "func abc<T>(lhs: Int, rhs: Int) -> Int {}",
+            configuration: ["generic_space": "no_space"]
+        ),
+        Example(
+            "func abc <T>(lhs: Int, rhs: Int) -> Int {}",
+            configuration: ["generic_space": "leading_space"]
+        ),
+        Example(
+            "func abc<T> (lhs: Int, rhs: Int) -> Int {}",
+            configuration: ["generic_space": "trailing_space"]
+        ),
+        Example(
+            "func abc <T>(lhs: Int, rhs: Int) -> Int {}",
+            configuration: ["generic_space": "leading_space"]
+        ),
+        Example(
+            "func abc /* comment */ <T> /* comment */ (lhs: Int, rhs: Int) -> Int {}",
+            configuration: ["generic_space": "leading_space"]
+        ),
+
+        Example(
+            "func abc /* comment */ <T> /* comment */ (lhs: Int, rhs: Int) -> Int {}",
+            configuration: ["generic_space": "trailing_space"]
+        ),
+        Example(
+            "func abc <T> (lhs: Int, rhs: Int) -> Int {}",
+            configuration: ["generic_space": "leading_trailing_space"]
+        ),
+        Example("func /* comment */ abc(lhs: Int, rhs: Int) -> Int {}"),
+        Example("func /* comment */  abc(lhs: Int, rhs: Int) -> Int {}"),
+        Example("func abc /* comment */ (lhs: Int, rhs: Int) -> Int {}"),
+        Example(
+            "func abc /* comment */ <T>(lhs: Int, rhs: Int) -> Int {}",
+            configuration: ["generic_space": "no_space"]
+        ),
+        Example(
+            "func abc<T> /* comment */ (lhs: Int, rhs: Int) -> Int {}",
+            configuration: ["generic_space": "no_space"]
+        ),
+        Example(
+            "func abc /* comment */ <T> /* comment */ (lhs: Int, rhs: Int) -> Int {}",
+            configuration: ["generic_space": "no_space"]
+        ),
+
+        Example("""
+        func foo<
+           T
+        >(
+           param1: Int,
+           param2: Bool,
+           param3: [String]
+        ) { }
+        """,
+                configuration: ["generic_space": "no_space"]
+               ),
+        Example("""
+        func foo <
+        T
+        > (
+            param1: Int,
+            param2: Bool,
+            param3: [String]
+        ) { }
+        """,
+                configuration: ["generic_space": "leading_trailing_space"]
+               ),
+        Example("""
+        func foo /* comment */ <
+        T
+        > (
+            param1: Int,
+            param2: Bool,
+            param3: [String]
+        ) { }
+        """,
+                configuration: ["generic_space": "leading_trailing_space"]
+               ),
+    ]
+
+    static let triggeringExamples: [Example] = [
+        Example("func  ↓name(lhs: A, rhs: A) -> A {}"),
+        Example("func ↓name (lhs: A, rhs: A) -> A {}"),
+        Example("func  ↓↓name (lhs: A, rhs: A) -> A {}"),
+        Example("func ↓name <T>(lhs: Int, rhs: Int) -> Int {}"),
+        Example(
+            "func ↓name /* comment */  ↓<T>  /* comment */  (lhs: Int, rhs: Int) -> Int {}",
+            configuration: ["generic_space": "no_space"]
+        ),
+        Example(
+            "func name /* comment */ /* comment */  ↓<T>  /* comment */  (lhs: Int, rhs: Int) -> Int {}",
+            configuration: ["generic_space": "no_space"]
+        ),
+        Example("""
+        func foo↓<
+           T
+        > (
+           param1: Int,
+           param2: Bool,
+           param3: [String]
+        ) { }
+        """,
+                configuration: ["generic_space": "no_space"]
+               ),
+        Example("""
+        func ↓foo <
+           T
+        >(
+           param1: Int,
+           param2: Bool,
+           param3: [String]
+        ) { }
+        """,
+                configuration: ["generic_space": "no_space"]
+               ),
+        Example("""
+        func ↓foo ↓<
+          T
+        > (
+           param1: Int,
+           param2: Bool,
+           param3: [String]
+        ) { }
+        """,
+                configuration: ["generic_space": "no_space"]
+               ),
+        Example(
+            "func abc ↓<T> (lhs: Int, rhs: Int) -> Int {}",
+            configuration: ["generic_space": "leading_space"]
+        ),
+        Example("""
+        func foo ↓<
+        T
+        > (
+            param1: Int,
+            param2: Bool,
+            param3: [String]
+        ) { }
+        """,
+                configuration: ["generic_space": "leading_space"]
+               ),
+        Example(
+            "func ↓abc <T> (lhs: Int, rhs: Int) -> Int {}",
+            configuration: ["generic_space": "trailing_space"]
+        ),
+        Example("""
+        func ↓foo <
+        T
+        > (
+            param1: Int,
+            param2: Bool,
+            param3: [String]
+        ) { }
+        """,
+                configuration: ["generic_space": "trailing_space"]
+               ),
+        Example(
+            "func ↓abc<T> (lhs: Int, rhs: Int) -> Int {}",
+            configuration: ["generic_space": "leading_trailing_space"]
+        ),
+        Example(
+            "func abc ↓<T>(lhs: Int, rhs: Int) -> Int {}",
+            configuration: ["generic_space": "leading_trailing_space"]
+        ),
+        Example(
+            "func ↓abc↓<T>(lhs: Int, rhs: Int) -> Int {}",
+            configuration: ["generic_space": "leading_trailing_space"]
+        ),
+        Example("""
+        func ↓foo /* comment */  ↓<
+        T
+        >  (
+            param1: Int,
+            param2: Bool,
+            param3: [String]
+        ) { }
+        """,
+                configuration: ["generic_space": "leading_trailing_space"]
+               ),
+    ]
+
+    static let corrections: [Example: Example] = [
+        Example(
+            "func name /* comment */  <T>  /* comment */  (lhs: Int, rhs: Int) -> Int {}",
+            configuration: ["generic_space": "no_space"]
+        ): Example(
+            "func name /* comment */ <T> /* comment */ (lhs: Int, rhs: Int) -> Int {}"
+        ),
+        Example(
+            "func name /* comment */  <T>(lhs: Int, rhs: Int) -> Int {}",
+            configuration: ["generic_space": "no_space"]
+        ): Example(
+            "func name /* comment */ <T>(lhs: Int, rhs: Int) -> Int {}"
+        ),
+
+        Example("""
+        func foo<
+           T
+        > (
+           param1: Int,
+           param2: Bool,
+           param3: [String]
+        ) { }
+        """,
+                configuration: ["generic_space": "no_space"]
+               ): Example("""
+        func foo<
+           T
+        >(
+           param1: Int,
+           param2: Bool,
+           param3: [String]
+        ) { }
+        """),
+        Example("""
+        func foo <
+           T
+        >(
+           param1: Int,
+           param2: Bool,
+           param3: [String]
+        ) { }
+        """,
+                configuration: ["generic_space": "no_space"]
+               ): Example("""
+        func foo<
+           T
+        >(
+           param1: Int,
+           param2: Bool,
+           param3: [String]
+        ) { }
+        """),
+        Example("""
+        func foo <
+           T
+        > (
+           param0: Int,
+           param1: Bool,
+           param2: [String]
+        ) { }
+        """,
+                configuration: ["generic_space": "no_space"]
+               ): Example("""
+        func foo<
+           T
+        >(
+           param0: Int,
+           param1: Bool,
+           param2: [String]
+        ) { }
+        """),
+        Example("func  name (lhs: A, rhs: A) -> A {}"): Example("func name(lhs: A, rhs: A) -> A {}"),
+        Example("func  name(lhs: A, rhs: A) -> A {}"): Example("func name(lhs: A, rhs: A) -> A {}"),
+        Example("func   name(lhs: A, rhs: A) -> A {}"): Example("func name(lhs: A, rhs: A) -> A {}"),
+        Example("func name (lhs: A, rhs: A) -> A {}"): Example("func name(lhs: A, rhs: A) -> A {}"),
+        Example("func name <T>(lhs: Int) -> Int {}"): Example("func name<T>(lhs: Int) -> Int {}"),
+        Example(
+            "func abc <T> (lhs1: Int, rhs1: Int) -> Int {}",
+            configuration: ["generic_space": "leading_space"]
+        ): Example(
+            "func abc <T>(lhs1: Int, rhs1: Int) -> Int {}"
+        ),
+        Example("""
+        func foo <
+           T
+        > (
+           param1: Int,
+           param2: Bool,
+           param3: [String]
+        ) { }
+        """,
+                configuration: ["generic_space": "leading_space"]
+               ): Example("""
+        func foo <
+           T
+        >(
+           param1: Int,
+           param2: Bool,
+           param3: [String]
+        ) { }
+        """),
+        Example(
+            "func abc <T> (lhs: Int, rhs: Int) -> Int {}",
+            configuration: ["generic_space": "trailing_space"]
+        ): Example(
+            "func abc<T> (lhs: Int, rhs: Int) -> Int {}"
+        ),
+        Example("""
+        func foo <
+        T
+        > (
+            param1: Int,
+            param2: Bool,
+            param3: [String]
+        ) { }
+        """,
+                configuration: ["generic_space": "trailing_space"]
+               ): Example("""
+        func foo<
+        T
+        > (
+            param1: Int,
+            param2: Bool,
+            param3: [String]
+        ) { }
+        """),
+        Example("""
+        func foo  <
+        T
+        >  (
+            param1: Int,
+            param2: Bool,
+            param3: [String]
+        ) { }
+        """,
+                configuration: ["generic_space": "leading_trailing_space"]
+               ): Example("""
+        func foo <
+        T
+        > (
+            param1: Int,
+            param2: Bool,
+            param3: [String]
+        ) { }
+        """),
+    ]
+}

--- a/Source/SwiftLintBuiltInRules/Rules/Style/FunctionNameWhitespaceRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/FunctionNameWhitespaceRuleExamples.swift
@@ -82,22 +82,22 @@ internal struct FunctionNameWhitespaceRuleExamples {
     ]
 
     static let triggeringExamples: [Example] = [
-        Example("func  ↓name(lhs: A, rhs: A) -> A {}"),
-        Example("func ↓name (lhs: A, rhs: A) -> A {}"),
-        Example("func  ↓↓name (lhs: A, rhs: A) -> A {}"),
-        Example("func ↓name <T>(lhs: Int, rhs: Int) -> Int {}"),
+        Example("func↓  name(lhs: A, rhs: A) -> A {}"),
+        Example("func name↓ (lhs: A, rhs: A) -> A {}"),
+        Example("func↓  name↓ (lhs: A, rhs: A) -> A {}"),
+        Example("func name↓ <T>(lhs: Int, rhs: Int) -> Int {}"),
         Example(
-            "func ↓name /* comment */  ↓<T>  /* comment */  (lhs: Int, rhs: Int) -> Int {}",
+            "func name↓ /* comment */  <T>↓  /* comment */  (lhs: Int, rhs: Int) -> Int {}",
             configuration: ["generic_spacing": "no_space"]
         ),
         Example(
-            "func name /* comment */ /* comment */  ↓<T>  /* comment */  (lhs: Int, rhs: Int) -> Int {}",
+            "func name /* comment */ /* comment */  <T>↓  /* comment */  (lhs: Int, rhs: Int) -> Int {}",
             configuration: ["generic_spacing": "no_space"]
         ),
         Example("""
-        func foo↓<
+        func foo<
            T
-        > (
+        >↓ (
            param1: Int,
            param2: Bool,
            param3: [String]
@@ -106,7 +106,7 @@ internal struct FunctionNameWhitespaceRuleExamples {
                 configuration: ["generic_spacing": "no_space"]
                ),
         Example("""
-        func ↓foo <
+        func foo↓ <
            T
         >(
            param1: Int,
@@ -117,9 +117,9 @@ internal struct FunctionNameWhitespaceRuleExamples {
                 configuration: ["generic_spacing": "no_space"]
                ),
         Example("""
-        func ↓foo ↓<
+        func foo↓ <
           T
-        > (
+        >↓ (
            param1: Int,
            param2: Bool,
            param3: [String]
@@ -128,13 +128,13 @@ internal struct FunctionNameWhitespaceRuleExamples {
                 configuration: ["generic_spacing": "no_space"]
                ),
         Example(
-            "func abc ↓<T> (lhs: Int, rhs: Int) -> Int {}",
+            "func abc <T>↓ (lhs: Int, rhs: Int) -> Int {}",
             configuration: ["generic_spacing": "leading_space"]
         ),
         Example("""
-        func foo ↓<
+        func foo <
         T
-        > (
+        >↓ (
             param1: Int,
             param2: Bool,
             param3: [String]
@@ -143,11 +143,11 @@ internal struct FunctionNameWhitespaceRuleExamples {
                 configuration: ["generic_spacing": "leading_space"]
                ),
         Example(
-            "func ↓abc <T> (lhs: Int, rhs: Int) -> Int {}",
+            "func abc↓ <T> (lhs: Int, rhs: Int) -> Int {}",
             configuration: ["generic_spacing": "trailing_space"]
         ),
         Example("""
-        func ↓foo <
+        func foo↓ <
         T
         > (
             param1: Int,
@@ -158,21 +158,21 @@ internal struct FunctionNameWhitespaceRuleExamples {
                 configuration: ["generic_spacing": "trailing_space"]
                ),
         Example(
-            "func ↓abc<T> (lhs: Int, rhs: Int) -> Int {}",
+            "func abc↓<T> (lhs: Int, rhs: Int) -> Int {}",
             configuration: ["generic_spacing": "leading_trailing_space"]
         ),
         Example(
-            "func abc ↓<T>(lhs: Int, rhs: Int) -> Int {}",
+            "func abc <T>↓(lhs: Int, rhs: Int) -> Int {}",
             configuration: ["generic_spacing": "leading_trailing_space"]
         ),
         Example(
-            "func ↓abc↓<T>(lhs: Int, rhs: Int) -> Int {}",
+            "func abc↓<T>↓(lhs: Int, rhs: Int) -> Int {}",
             configuration: ["generic_spacing": "leading_trailing_space"]
         ),
         Example("""
-        func ↓foo /* comment */  ↓<
+        func foo↓ /* comment */  <
         T
-        >  (
+        >↓  (
             param1: Int,
             param2: Bool,
             param3: [String]

--- a/Source/SwiftLintBuiltInRules/Rules/Style/FunctionNameWhitespaceRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/FunctionNameWhitespaceRuleExamples.swift
@@ -3,47 +3,47 @@ internal struct FunctionNameWhitespaceRuleExamples {
         Example("func abc(lhs: Int, rhs: Int) -> Int {}"),
         Example(
             "func abc<T>(lhs: Int, rhs: Int) -> Int {}",
-            configuration: ["generic_space": "no_space"]
+            configuration: ["generic_spacing": "no_space"]
         ),
         Example(
             "func abc <T>(lhs: Int, rhs: Int) -> Int {}",
-            configuration: ["generic_space": "leading_space"]
+            configuration: ["generic_spacing": "leading_space"]
         ),
         Example(
             "func abc<T> (lhs: Int, rhs: Int) -> Int {}",
-            configuration: ["generic_space": "trailing_space"]
+            configuration: ["generic_spacing": "trailing_space"]
         ),
         Example(
             "func abc <T>(lhs: Int, rhs: Int) -> Int {}",
-            configuration: ["generic_space": "leading_space"]
+            configuration: ["generic_spacing": "leading_space"]
         ),
         Example(
             "func abc /* comment */ <T> /* comment */ (lhs: Int, rhs: Int) -> Int {}",
-            configuration: ["generic_space": "leading_space"]
+            configuration: ["generic_spacing": "leading_space"]
         ),
 
         Example(
             "func abc /* comment */ <T> /* comment */ (lhs: Int, rhs: Int) -> Int {}",
-            configuration: ["generic_space": "trailing_space"]
+            configuration: ["generic_spacing": "trailing_space"]
         ),
         Example(
             "func abc <T> (lhs: Int, rhs: Int) -> Int {}",
-            configuration: ["generic_space": "leading_trailing_space"]
+            configuration: ["generic_spacing": "leading_trailing_space"]
         ),
         Example("func /* comment */ abc(lhs: Int, rhs: Int) -> Int {}"),
         Example("func /* comment */  abc(lhs: Int, rhs: Int) -> Int {}"),
         Example("func abc /* comment */ (lhs: Int, rhs: Int) -> Int {}"),
         Example(
             "func abc /* comment */ <T>(lhs: Int, rhs: Int) -> Int {}",
-            configuration: ["generic_space": "no_space"]
+            configuration: ["generic_spacing": "no_space"]
         ),
         Example(
             "func abc<T> /* comment */ (lhs: Int, rhs: Int) -> Int {}",
-            configuration: ["generic_space": "no_space"]
+            configuration: ["generic_spacing": "no_space"]
         ),
         Example(
             "func abc /* comment */ <T> /* comment */ (lhs: Int, rhs: Int) -> Int {}",
-            configuration: ["generic_space": "no_space"]
+            configuration: ["generic_spacing": "no_space"]
         ),
 
         Example("""
@@ -55,7 +55,7 @@ internal struct FunctionNameWhitespaceRuleExamples {
            param3: [String]
         ) { }
         """,
-                configuration: ["generic_space": "no_space"]
+                configuration: ["generic_spacing": "no_space"]
                ),
         Example("""
         func foo <
@@ -66,7 +66,7 @@ internal struct FunctionNameWhitespaceRuleExamples {
             param3: [String]
         ) { }
         """,
-                configuration: ["generic_space": "leading_trailing_space"]
+                configuration: ["generic_spacing": "leading_trailing_space"]
                ),
         Example("""
         func foo /* comment */ <
@@ -77,7 +77,7 @@ internal struct FunctionNameWhitespaceRuleExamples {
             param3: [String]
         ) { }
         """,
-                configuration: ["generic_space": "leading_trailing_space"]
+                configuration: ["generic_spacing": "leading_trailing_space"]
                ),
     ]
 
@@ -88,11 +88,11 @@ internal struct FunctionNameWhitespaceRuleExamples {
         Example("func ↓name <T>(lhs: Int, rhs: Int) -> Int {}"),
         Example(
             "func ↓name /* comment */  ↓<T>  /* comment */  (lhs: Int, rhs: Int) -> Int {}",
-            configuration: ["generic_space": "no_space"]
+            configuration: ["generic_spacing": "no_space"]
         ),
         Example(
             "func name /* comment */ /* comment */  ↓<T>  /* comment */  (lhs: Int, rhs: Int) -> Int {}",
-            configuration: ["generic_space": "no_space"]
+            configuration: ["generic_spacing": "no_space"]
         ),
         Example("""
         func foo↓<
@@ -103,7 +103,7 @@ internal struct FunctionNameWhitespaceRuleExamples {
            param3: [String]
         ) { }
         """,
-                configuration: ["generic_space": "no_space"]
+                configuration: ["generic_spacing": "no_space"]
                ),
         Example("""
         func ↓foo <
@@ -114,7 +114,7 @@ internal struct FunctionNameWhitespaceRuleExamples {
            param3: [String]
         ) { }
         """,
-                configuration: ["generic_space": "no_space"]
+                configuration: ["generic_spacing": "no_space"]
                ),
         Example("""
         func ↓foo ↓<
@@ -125,11 +125,11 @@ internal struct FunctionNameWhitespaceRuleExamples {
            param3: [String]
         ) { }
         """,
-                configuration: ["generic_space": "no_space"]
+                configuration: ["generic_spacing": "no_space"]
                ),
         Example(
             "func abc ↓<T> (lhs: Int, rhs: Int) -> Int {}",
-            configuration: ["generic_space": "leading_space"]
+            configuration: ["generic_spacing": "leading_space"]
         ),
         Example("""
         func foo ↓<
@@ -140,11 +140,11 @@ internal struct FunctionNameWhitespaceRuleExamples {
             param3: [String]
         ) { }
         """,
-                configuration: ["generic_space": "leading_space"]
+                configuration: ["generic_spacing": "leading_space"]
                ),
         Example(
             "func ↓abc <T> (lhs: Int, rhs: Int) -> Int {}",
-            configuration: ["generic_space": "trailing_space"]
+            configuration: ["generic_spacing": "trailing_space"]
         ),
         Example("""
         func ↓foo <
@@ -155,19 +155,19 @@ internal struct FunctionNameWhitespaceRuleExamples {
             param3: [String]
         ) { }
         """,
-                configuration: ["generic_space": "trailing_space"]
+                configuration: ["generic_spacing": "trailing_space"]
                ),
         Example(
             "func ↓abc<T> (lhs: Int, rhs: Int) -> Int {}",
-            configuration: ["generic_space": "leading_trailing_space"]
+            configuration: ["generic_spacing": "leading_trailing_space"]
         ),
         Example(
             "func abc ↓<T>(lhs: Int, rhs: Int) -> Int {}",
-            configuration: ["generic_space": "leading_trailing_space"]
+            configuration: ["generic_spacing": "leading_trailing_space"]
         ),
         Example(
             "func ↓abc↓<T>(lhs: Int, rhs: Int) -> Int {}",
-            configuration: ["generic_space": "leading_trailing_space"]
+            configuration: ["generic_spacing": "leading_trailing_space"]
         ),
         Example("""
         func ↓foo /* comment */  ↓<
@@ -178,20 +178,20 @@ internal struct FunctionNameWhitespaceRuleExamples {
             param3: [String]
         ) { }
         """,
-                configuration: ["generic_space": "leading_trailing_space"]
+                configuration: ["generic_spacing": "leading_trailing_space"]
                ),
     ]
 
     static let corrections: [Example: Example] = [
         Example(
             "func name /* comment */  <T>  /* comment */  (lhs: Int, rhs: Int) -> Int {}",
-            configuration: ["generic_space": "no_space"]
+            configuration: ["generic_spacing": "no_space"]
         ): Example(
             "func name /* comment */ <T> /* comment */ (lhs: Int, rhs: Int) -> Int {}"
         ),
         Example(
             "func name /* comment */  <T>(lhs: Int, rhs: Int) -> Int {}",
-            configuration: ["generic_space": "no_space"]
+            configuration: ["generic_spacing": "no_space"]
         ): Example(
             "func name /* comment */ <T>(lhs: Int, rhs: Int) -> Int {}"
         ),
@@ -205,7 +205,7 @@ internal struct FunctionNameWhitespaceRuleExamples {
            param3: [String]
         ) { }
         """,
-                configuration: ["generic_space": "no_space"]
+                configuration: ["generic_spacing": "no_space"]
                ): Example("""
         func foo<
            T
@@ -224,7 +224,7 @@ internal struct FunctionNameWhitespaceRuleExamples {
            param3: [String]
         ) { }
         """,
-                configuration: ["generic_space": "no_space"]
+                configuration: ["generic_spacing": "no_space"]
                ): Example("""
         func foo<
            T
@@ -243,7 +243,7 @@ internal struct FunctionNameWhitespaceRuleExamples {
            param2: [String]
         ) { }
         """,
-                configuration: ["generic_space": "no_space"]
+                configuration: ["generic_spacing": "no_space"]
                ): Example("""
         func foo<
            T
@@ -260,7 +260,7 @@ internal struct FunctionNameWhitespaceRuleExamples {
         Example("func name <T>(lhs: Int) -> Int {}"): Example("func name<T>(lhs: Int) -> Int {}"),
         Example(
             "func abc <T> (lhs1: Int, rhs1: Int) -> Int {}",
-            configuration: ["generic_space": "leading_space"]
+            configuration: ["generic_spacing": "leading_space"]
         ): Example(
             "func abc <T>(lhs1: Int, rhs1: Int) -> Int {}"
         ),
@@ -273,7 +273,7 @@ internal struct FunctionNameWhitespaceRuleExamples {
            param3: [String]
         ) { }
         """,
-                configuration: ["generic_space": "leading_space"]
+                configuration: ["generic_spacing": "leading_space"]
                ): Example("""
         func foo <
            T
@@ -285,7 +285,7 @@ internal struct FunctionNameWhitespaceRuleExamples {
         """),
         Example(
             "func abc <T> (lhs: Int, rhs: Int) -> Int {}",
-            configuration: ["generic_space": "trailing_space"]
+            configuration: ["generic_spacing": "trailing_space"]
         ): Example(
             "func abc<T> (lhs: Int, rhs: Int) -> Int {}"
         ),
@@ -298,7 +298,7 @@ internal struct FunctionNameWhitespaceRuleExamples {
             param3: [String]
         ) { }
         """,
-                configuration: ["generic_space": "trailing_space"]
+                configuration: ["generic_spacing": "trailing_space"]
                ): Example("""
         func foo<
         T
@@ -317,7 +317,7 @@ internal struct FunctionNameWhitespaceRuleExamples {
             param3: [String]
         ) { }
         """,
-                configuration: ["generic_space": "leading_trailing_space"]
+                configuration: ["generic_spacing": "leading_trailing_space"]
                ): Example("""
         func foo <
         T

--- a/Tests/BuiltInRulesTests/FunctionNameWhitespaceRuleTests.swift
+++ b/Tests/BuiltInRulesTests/FunctionNameWhitespaceRuleTests.swift
@@ -1,0 +1,124 @@
+@testable import SwiftLintBuiltInRules
+import TestHelpers
+import XCTest
+
+final class FunctionNameWhitespaceRuleTests: SwiftLintTestCase {
+    private typealias GenericSpaceType = FunctionNameWhitespaceConfiguration.GenericSpaceType
+
+    // MARK: - Helper
+
+    private func assertReason(
+        _ source: String,
+        configuration: [String: String]? = nil,
+        expected: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let example = configuration == nil
+            ? Example(source)
+            : Example(source, configuration: configuration!)
+
+        let violations = ruleViolations(example)
+        XCTAssertEqual(violations.first?.reason, expected, file: file, line: line)
+    }
+
+    private func ruleViolations(
+        _ example: Example,
+        ruleConfiguration: Any? = nil
+    ) -> [StyleViolation] {
+        guard let config = makeConfig(ruleConfiguration, FunctionNameWhitespaceRule.identifier) else {
+            return []
+        }
+        return violations(example, config: config)
+    }
+
+    ////
+    // MARK: - func keyword spacing
+
+    func test_SpaceBetweenFuncKeywordAndName_ShouldReportReason() {
+        assertReason(
+            "func  abc(lhs: Int, rhs: Int) -> Int {}",
+            expected: "There should be no space before the function name"
+        )
+    }
+
+    // MARK: - generic_space = no_space
+
+    func test_SpaceAfterFuncName_WhenNoSpaceConfigured_ShouldReport() {
+        assertReason(
+            "func abc (lhs: Int) {}",
+            configuration: ["generic_space": "no_space"],
+            expected: GenericSpaceType.noSpace.reasonForName
+        )
+    }
+
+    func test_SpaceAfterGeneric_WhenNoSpaceConfigured_ShouldReport() {
+        assertReason(
+            "func abc<T> (lhs: Int) {}",
+            configuration: ["generic_space": "no_space"],
+            expected: GenericSpaceType.noSpace.reasonForGenericAngleBracket
+        )
+    }
+
+    // MARK: - generic_space = leading_space
+
+    func test_SpaceAfterFuncName_WhenLeadingSpaceConfigured_ShouldReport() {
+        assertReason(
+            "func abc(lhs: Int) {}",
+            configuration: ["generic_space": "leading_space"],
+            expected: GenericSpaceType.leadingSpace.reasonForName
+        )
+    }
+
+    func test_SpaceBeforeGeneric_WhenLeadingSpaceConfigured_ShouldReport() {
+        assertReason(
+            "func abc<T>(lhs: Int) {}",
+            configuration: ["generic_space": "leading_space"],
+            expected: GenericSpaceType.leadingSpace.reasonForName
+        )
+    }
+
+    // MARK: - generic_space = trailing_space
+
+    func test_SpaceAfterFuncName_WhenTrailingSpaceConfigured_ShouldReport() {
+        assertReason(
+            "func abc (lhs: Int) {}",
+            configuration: ["generic_space": "trailing_space"],
+            expected: GenericSpaceType.trailingSpace.reasonForName
+        )
+    }
+
+    func test_SpaceAfterGeneric_WhenTrailingSpaceConfigured_ShouldReport() {
+        assertReason(
+            "func abc<T>(lhs: Int) {}",
+            configuration: ["generic_space": "trailing_space"],
+            expected: GenericSpaceType.trailingSpace.reasonForGenericAngleBracket
+        )
+    }
+
+    // MARK: - generic_space = leading_trailing_space
+
+    func test_SpaceAfterFuncName_WhenLeadingTrailingSpaceConfigured_ShouldReport() {
+        assertReason(
+            "func abc(lhs: Int) {}",
+            configuration: ["generic_space": "leading_trailing_space"],
+            expected: GenericSpaceType.leadingTrailingSpace.reasonForName
+        )
+    }
+
+    func test_SpaceBeforeGeneric_WhenLeadingTrailingSpaceConfigured_ShouldReport() {
+        assertReason(
+            "func abc<T>(lhs: Int) {}",
+            configuration: ["generic_space": "leading_trailing_space"],
+            expected: GenericSpaceType.leadingTrailingSpace.reasonForName
+        )
+    }
+
+    func test_SpaceAfterGeneric_WhenLeadingTrailingSpaceConfigured_ShouldReport() {
+        assertReason(
+            "func abc <T>(lhs: Int) {}",
+            configuration: ["generic_space": "leading_trailing_space"],
+            expected: GenericSpaceType.leadingTrailingSpace.reasonForGenericAngleBracket
+        )
+    }
+}

--- a/Tests/BuiltInRulesTests/FunctionNameWhitespaceRuleTests.swift
+++ b/Tests/BuiltInRulesTests/FunctionNameWhitespaceRuleTests.swift
@@ -3,7 +3,7 @@ import TestHelpers
 import XCTest
 
 final class FunctionNameWhitespaceRuleTests: SwiftLintTestCase {
-    private typealias GenericSpaceType = FunctionNameWhitespaceConfiguration.GenericSpaceType
+    private typealias GenericSpacingType = FunctionNameWhitespaceConfiguration.GenericSpacingType
 
     // MARK: - Helper
 
@@ -32,93 +32,92 @@ final class FunctionNameWhitespaceRuleTests: SwiftLintTestCase {
         return violations(example, config: config)
     }
 
-    ////
     // MARK: - func keyword spacing
 
-    func test_SpaceBetweenFuncKeywordAndName_ShouldReportReason() {
+    func testSpaceBetweenFuncKeywordAndName_ShouldReportReason() {
         assertReason(
             "func  abc(lhs: Int, rhs: Int) -> Int {}",
-            expected: "There should be no space before the function name"
+            expected: "Too many spaces between 'func' and function name"
         )
     }
 
-    // MARK: - generic_space = no_space
+    // MARK: - generic_spacing = no_space
 
-    func test_SpaceAfterFuncName_WhenNoSpaceConfigured_ShouldReport() {
+    func testSpaceAfterFuncName_WhenNoSpaceConfigured_ShouldReport() {
         assertReason(
             "func abc (lhs: Int) {}",
-            configuration: ["generic_space": "no_space"],
-            expected: GenericSpaceType.noSpace.reasonForName
+            configuration: ["generic_spacing": "no_space"],
+            expected: GenericSpacingType.noSpace.beforeGenericViolationReason
         )
     }
 
-    func test_SpaceAfterGeneric_WhenNoSpaceConfigured_ShouldReport() {
+    func testSpaceAfterGeneric_WhenNoSpaceConfigured_ShouldReport() {
         assertReason(
             "func abc<T> (lhs: Int) {}",
-            configuration: ["generic_space": "no_space"],
-            expected: GenericSpaceType.noSpace.reasonForGenericAngleBracket
+            configuration: ["generic_spacing": "no_space"],
+            expected: GenericSpacingType.noSpace.afterGenericViolationReason
         )
     }
 
-    // MARK: - generic_space = leading_space
+    // MARK: - generic_spacing = leading_space
 
-    func test_SpaceAfterFuncName_WhenLeadingSpaceConfigured_ShouldReport() {
+    func testSpaceAfterFuncName_WhenLeadingSpaceConfigured_ShouldReport() {
         assertReason(
             "func abc(lhs: Int) {}",
-            configuration: ["generic_space": "leading_space"],
-            expected: GenericSpaceType.leadingSpace.reasonForName
+            configuration: ["generic_spacing": "leading_space"],
+            expected: GenericSpacingType.leadingSpace.beforeGenericViolationReason
         )
     }
 
-    func test_SpaceBeforeGeneric_WhenLeadingSpaceConfigured_ShouldReport() {
+    func testSpaceBeforeGeneric_WhenLeadingSpaceConfigured_ShouldReport() {
         assertReason(
             "func abc<T>(lhs: Int) {}",
-            configuration: ["generic_space": "leading_space"],
-            expected: GenericSpaceType.leadingSpace.reasonForName
+            configuration: ["generic_spacing": "leading_space"],
+            expected: GenericSpacingType.leadingSpace.beforeGenericViolationReason
         )
     }
 
-    // MARK: - generic_space = trailing_space
+    // MARK: - generic_spacing = trailing_space
 
-    func test_SpaceAfterFuncName_WhenTrailingSpaceConfigured_ShouldReport() {
+    func testSpaceAfterFuncName_WhenTrailingSpaceConfigured_ShouldReport() {
         assertReason(
             "func abc (lhs: Int) {}",
-            configuration: ["generic_space": "trailing_space"],
-            expected: GenericSpaceType.trailingSpace.reasonForName
+            configuration: ["generic_spacing": "trailing_space"],
+            expected: GenericSpacingType.trailingSpace.beforeGenericViolationReason
         )
     }
 
-    func test_SpaceAfterGeneric_WhenTrailingSpaceConfigured_ShouldReport() {
+    func testSpaceAfterGeneric_WhenTrailingSpaceConfigured_ShouldReport() {
         assertReason(
             "func abc<T>(lhs: Int) {}",
-            configuration: ["generic_space": "trailing_space"],
-            expected: GenericSpaceType.trailingSpace.reasonForGenericAngleBracket
+            configuration: ["generic_spacing": "trailing_space"],
+            expected: GenericSpacingType.trailingSpace.afterGenericViolationReason
         )
     }
 
-    // MARK: - generic_space = leading_trailing_space
+    // MARK: - generic_spacing = leading_trailing_space
 
-    func test_SpaceAfterFuncName_WhenLeadingTrailingSpaceConfigured_ShouldReport() {
+    func testSpaceAfterFuncName_WhenLeadingTrailingSpaceConfigured_ShouldReport() {
         assertReason(
             "func abc(lhs: Int) {}",
-            configuration: ["generic_space": "leading_trailing_space"],
-            expected: GenericSpaceType.leadingTrailingSpace.reasonForName
+            configuration: ["generic_spacing": "leading_trailing_space"],
+            expected: GenericSpacingType.leadingTrailingSpace.beforeGenericViolationReason
         )
     }
 
-    func test_SpaceBeforeGeneric_WhenLeadingTrailingSpaceConfigured_ShouldReport() {
+    func testSpaceBeforeGeneric_WhenLeadingTrailingSpaceConfigured_ShouldReport() {
         assertReason(
             "func abc<T>(lhs: Int) {}",
-            configuration: ["generic_space": "leading_trailing_space"],
-            expected: GenericSpaceType.leadingTrailingSpace.reasonForName
+            configuration: ["generic_spacing": "leading_trailing_space"],
+            expected: GenericSpacingType.leadingTrailingSpace.beforeGenericViolationReason
         )
     }
 
-    func test_SpaceAfterGeneric_WhenLeadingTrailingSpaceConfigured_ShouldReport() {
+    func testSpaceAfterGeneric_WhenLeadingTrailingSpaceConfigured_ShouldReport() {
         assertReason(
             "func abc <T>(lhs: Int) {}",
-            configuration: ["generic_space": "leading_trailing_space"],
-            expected: GenericSpaceType.leadingTrailingSpace.reasonForGenericAngleBracket
+            configuration: ["generic_spacing": "leading_trailing_space"],
+            expected: GenericSpacingType.leadingTrailingSpace.afterGenericViolationReason
         )
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_04.swift
+++ b/Tests/GeneratedTests/GeneratedTests_04.swift
@@ -31,6 +31,12 @@ final class FunctionDefaultParameterAtEndRuleGeneratedTests: SwiftLintTestCase {
     }
 }
 
+final class FunctionNameWhitespaceRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(FunctionNameWhitespaceRule.description)
+    }
+}
+
 final class FunctionParameterCountRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(FunctionParameterCountRule.description)
@@ -148,11 +154,5 @@ final class LegacyConstantRuleGeneratedTests: SwiftLintTestCase {
 final class LegacyConstructorRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(LegacyConstructorRule.description)
-    }
-}
-
-final class LegacyHashingRuleGeneratedTests: SwiftLintTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(LegacyHashingRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_05.swift
+++ b/Tests/GeneratedTests/GeneratedTests_05.swift
@@ -7,6 +7,12 @@
 @testable import SwiftLintCore
 import TestHelpers
 
+final class LegacyHashingRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(LegacyHashingRule.description)
+    }
+}
+
 final class LegacyMultipleRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(LegacyMultipleRule.description)
@@ -148,11 +154,5 @@ final class NSObjectPreferIsEqualRuleGeneratedTests: SwiftLintTestCase {
 final class NestingRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(NestingRule.description)
-    }
-}
-
-final class NimbleOperatorRuleGeneratedTests: SwiftLintTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(NimbleOperatorRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_06.swift
+++ b/Tests/GeneratedTests/GeneratedTests_06.swift
@@ -7,6 +7,12 @@
 @testable import SwiftLintCore
 import TestHelpers
 
+final class NimbleOperatorRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(NimbleOperatorRule.description)
+    }
+}
+
 final class NoEmptyBlockRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(NoEmptyBlockRule.description)
@@ -148,11 +154,5 @@ final class PreferConditionListRuleGeneratedTests: SwiftLintTestCase {
 final class PreferKeyPathRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(PreferKeyPathRule.description)
-    }
-}
-
-final class PreferNimbleRuleGeneratedTests: SwiftLintTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(PreferNimbleRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_07.swift
+++ b/Tests/GeneratedTests/GeneratedTests_07.swift
@@ -7,6 +7,12 @@
 @testable import SwiftLintCore
 import TestHelpers
 
+final class PreferNimbleRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(PreferNimbleRule.description)
+    }
+}
+
 final class PreferSelfInStaticReferencesRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(PreferSelfInStaticReferencesRule.description)
@@ -148,11 +154,5 @@ final class RedundantObjcAttributeRuleGeneratedTests: SwiftLintTestCase {
 final class RedundantSelfInClosureRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(RedundantSelfInClosureRule.description)
-    }
-}
-
-final class RedundantSendableRuleGeneratedTests: SwiftLintTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(RedundantSendableRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_08.swift
+++ b/Tests/GeneratedTests/GeneratedTests_08.swift
@@ -7,6 +7,12 @@
 @testable import SwiftLintCore
 import TestHelpers
 
+final class RedundantSendableRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(RedundantSendableRule.description)
+    }
+}
+
 final class RedundantSetAccessControlRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(RedundantSetAccessControlRule.description)
@@ -148,11 +154,5 @@ final class SuperfluousElseRuleGeneratedTests: SwiftLintTestCase {
 final class SwitchCaseAlignmentRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(SwitchCaseAlignmentRule.description)
-    }
-}
-
-final class SwitchCaseOnNewlineRuleGeneratedTests: SwiftLintTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(SwitchCaseOnNewlineRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_09.swift
+++ b/Tests/GeneratedTests/GeneratedTests_09.swift
@@ -7,6 +7,12 @@
 @testable import SwiftLintCore
 import TestHelpers
 
+final class SwitchCaseOnNewlineRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(SwitchCaseOnNewlineRule.description)
+    }
+}
+
 final class SyntacticSugarRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(SyntacticSugarRule.description)
@@ -148,11 +154,5 @@ final class UnusedClosureParameterRuleGeneratedTests: SwiftLintTestCase {
 final class UnusedControlFlowLabelRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(UnusedControlFlowLabelRule.description)
-    }
-}
-
-final class UnusedDeclarationRuleGeneratedTests: SwiftLintTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(UnusedDeclarationRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_10.swift
+++ b/Tests/GeneratedTests/GeneratedTests_10.swift
@@ -7,6 +7,12 @@
 @testable import SwiftLintCore
 import TestHelpers
 
+final class UnusedDeclarationRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(UnusedDeclarationRule.description)
+    }
+}
+
 final class UnusedEnumeratedRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(UnusedEnumeratedRule.description)

--- a/Tests/IntegrationTests/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/default_rule_configurations.yml
@@ -446,6 +446,12 @@ function_default_parameter_at_end:
   meta:
     opt-in: true
     correctable: false
+function_name_whitespace:
+  severity: warning
+  generic_space: no_space
+  meta:
+    opt-in: true
+    correctable: true
 function_parameter_count:
   warning: 5
   error: 8

--- a/Tests/IntegrationTests/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/default_rule_configurations.yml
@@ -448,7 +448,7 @@ function_default_parameter_at_end:
     correctable: false
 function_name_whitespace:
   severity: warning
-  generic_space: no_space
+  generic_spacing: no_space
   meta:
     opt-in: true
     correctable: true


### PR DESCRIPTION
This PR introduces a new SwiftLint rule: `function_name_whitespace`.  
It enforces spacing consistency for named function declarations:

- Exactly **one space** must follow the `func` keyword.
- **No whitespace** is allowed after the function name and before the parameter list.