### PR TITLE
Add Sendable conformance to Rule.Type for building with Swift 6.2 / Xcode 26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@
 
 ### Enhancements
 
+* Add Sendable conformance to Rule.Type for building with Swift 6.  
+  [erikkerber](https://github.com/erikkerber)
+  [#issue_number](https://github.com/realm/SwiftLint/issues/issue_number)
+
 * Fix false positives for `Actor`-conforming delegate protocols in the
   `class_delegate_protocol` rule.  
   [imsonalbajaj](https://github.com/imsonalbajaj)

--- a/Source/SwiftLintCore/Models/AccessControlLevel.swift
+++ b/Source/SwiftLintCore/Models/AccessControlLevel.swift
@@ -1,7 +1,7 @@
 /// The accessibility of a Swift source declaration.
 ///
 /// - SeeAlso: https://github.com/apple/swift/blob/main/docs/AccessControl.md
-public enum AccessControlLevel: String, CustomStringConvertible {
+public enum AccessControlLevel: String, CustomStringConvertible, Sendable {
     /// Accessible by the declaration's immediate lexical scope.
     case `private` = "source.lang.swift.accessibility.private"
     /// Accessible by the declaration's same file.

--- a/Source/SwiftLintCore/Models/RuleParameter.swift
+++ b/Source/SwiftLintCore/Models/RuleParameter.swift
@@ -1,5 +1,5 @@
 /// A configuration parameter for rules.
-public struct RuleParameter<T: Equatable>: Equatable {
+public struct RuleParameter<T: Equatable>: Equatable, Sendable where T: Sendable {
     /// The severity that should be assigned to the violation of this parameter's value is met.
     public let severity: ViolationSeverity
     /// The value to configure the rule.

--- a/Source/SwiftLintCore/Protocols/Rule.swift
+++ b/Source/SwiftLintCore/Protocols/Rule.swift
@@ -2,7 +2,7 @@ import Foundation
 import SourceKittenFramework
 
 /// An executable value that can identify issues (violations) in Swift source code.
-public protocol Rule {
+public protocol Rule: Sendable {
     /// The type of the configuration used to configure this rule.
     associatedtype ConfigurationType: RuleConfiguration
 

--- a/Source/SwiftLintCore/Protocols/RuleConfiguration.swift
+++ b/Source/SwiftLintCore/Protocols/RuleConfiguration.swift
@@ -1,5 +1,5 @@
 /// A configuration value for a rule to allow users to modify its behavior.
-public protocol RuleConfiguration: Equatable {
+public protocol RuleConfiguration: Equatable, Sendable {
     /// The type of the rule that's using this configuration.
     associatedtype Parent: Rule
 

--- a/Source/SwiftLintCore/RuleConfigurations/RegexConfiguration.swift
+++ b/Source/SwiftLintCore/RuleConfigurations/RegexConfiguration.swift
@@ -1,5 +1,5 @@
 import Foundation
-import SourceKittenFramework
+@preconcurrency import SourceKittenFramework
 
 /// A rule configuration used for defining custom rules in yaml.
 public struct RegexConfiguration<Parent: Rule>: SeverityBasedRuleConfiguration, Hashable,


### PR DESCRIPTION
Helps build with Xcode 26. 

A quick fix for our setup. Open to alternatives too!