### PR TITLE
Let Copilot build and test with SPM

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,6 +4,6 @@ Linting rules are defined in `Source/SwiftLintBuiltInRules/Rules`. If someone me
 
 User-facing changes must be documented in the `CHANGELOG.md` file, which is organized by version. New entries always go into the "Main" section. They give credit to the person who has made the change and they reference the issue which has been fixed by the change.
 
-All changes on configuration options must be reflected in `Tests/IntegrationTests/default_rule_configurations.yml`. This can be achieved by running `make --always-make bazel_register`. Running this command is also necessary when new rules got added or removed to (un-)register them from/in the list of built-in rules and tests verifying all examples in rule descriptions.
+All changes on configuration options must be reflected in `Tests/IntegrationTests/default_rule_configurations.yml`. This can be achieved by running `swift run swiftlint-dev rules register`. Running this command is also necessary when new rules got added or removed to (un-)register them from/in the list of built-in rules and tests verifying all examples in rule descriptions.
 
-All changes need to pass `make bazel_test` as well as running SwiftLint on itself. The command `bazel run //:swiftlint` run in the root directory of the project does that.
+All changes need to pass `swift test --parallel` as well as running SwiftLint on itself. The command `swift run swiftlint` run in the root directory of the project does that.

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,23 +1,25 @@
-name: "Copilot Setup Steps"
+name: Copilot Setup Steps
 
 on:
   workflow_dispatch:
   push:
     paths:
       - .github/workflows/copilot-setup-steps.yml
-  pull_request:
-    paths:
-      - .github/workflows/copilot-setup-steps.yml
 
 jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
   copilot-setup-steps:
+    name: Perform
     runs-on: ubuntu-24.04
+    container: swift:6.1-noble
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/bazel-linux-build
-        name: Build SwiftLint with Bazel
-        env:
-          CI_BAZELRC_FILE_CONTENT: ${{ secrets.CI_BAZELRC_FILE_CONTENT }}
+      - uses: actions/cache@v4
+        with:
+          key: ${{ runner.os }}-swift-spm-${{ hashFiles('Package.resolved') }}
+          restore-keys: ${{ runner.os }}-swift-spm-
+          path: .build
+      - name: Build everything
+        run: swift build --build-tests


### PR DESCRIPTION
Bazel doesn't work well on Linux, especially in non-release mode and when building tests. This partially reverts a809480d4a87fad9d38f6800acbd314b7f8579b7.
