### PR TITLE
Revert back to building Linux binaries with Docker

### DIFF
--- a/.github/actions/docker-build/action.yml
+++ b/.github/actions/docker-build/action.yml
@@ -30,12 +30,9 @@ runs:
       with:
         context: .
         platforms: linux/${{ inputs.platform }}
-        outputs: >-
-          type=image,
-          name=ghcr.io/${{ env.REPOSITORY_LC }},
-          push-by-digest=true,
-          name-canonical=true,
-          push=true
+        outputs:
+          - "type=registry, name=ghcr.io/${{ env.REPOSITORY_LC }}, push-by-digest=true, name-canonical=true"
+          - type=local,dest=artifacts
         cache-from: >-
           type=gha,
           scope=build-${{ inputs.platform }}
@@ -54,5 +51,15 @@ runs:
       with:
         name: digests-${{ inputs.platform }}
         path: /tmp/digests/*
+        if-no-files-found: error
+        retention-days: 1
+    - name: Move binary
+      run: mv artifacts/usr/bin/swiftlint_linux_${{ inputs.platform }} .
+      shell: bash
+    - name: Upload binary
+      uses: actions/upload-artifact@v4
+      with:
+        name: swiftlint-linux-${{ inputs.platform }}
+        path: swiftlint_linux_${{ inputs.platform }}
         if-no-files-found: error
         retention-days: 1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,6 +15,11 @@ on:
         description: 'Docker tag'
         required: true
         type: string
+      ref:
+        description: 'Git reference'
+        required: false
+        default: ${{ inputs.tag }}
+        type: string
 
 jobs:
   set-context:
@@ -41,7 +46,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
         else
           {
-            echo "checkout-ref=${{ inputs.tag }}"
+            echo "checkout-ref=${{ inputs.ref }}"
             echo "docker-tag=${{ inputs.tag }}"
           } >> "$GITHUB_OUTPUT"
         fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,45 +84,17 @@ jobs:
         env:
           DEVELOPER_DIR: /Applications/Xcode_15.0.1.app # Supports iOS 17.0 simulator selected by CocoaPods.
 
-  build-linux-amd64:
-    name: Build Linux AMD64 Binary
+  build-linux-binaries:
+    name: Build Linux Binaries
     needs: prepare-release
-    runs-on: ubuntu-24.04
+    uses: ./.github/workflows/docker.yml
     permissions:
       contents: read
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ env.RELEASE_BRANCH }}
-      - uses: ./.github/actions/bazel-linux-build
-        name: Build SwiftLint with Bazel
-        env:
-          CI_BAZELRC_FILE_CONTENT: ${{ secrets.CI_BAZELRC_FILE_CONTENT }}
-      - name: Upload Bazel build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: swiftlint_linux_amd64
-          path: bazel-bin/swiftlint
-
-  build-linux-arm64:
-    name: Build Linux ARM64 Binary
-    needs: prepare-release
-    runs-on: ubuntu-24.04-arm
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ env.RELEASE_BRANCH }}
-      - uses: ./.github/actions/bazel-linux-build
-        name: Build SwiftLint with Bazel
-        env:
-          CI_BAZELRC_FILE_CONTENT: ${{ secrets.CI_BAZELRC_FILE_CONTENT }}
-      - name: Upload Bazel build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: swiftlint_linux_arm64
-          path: bazel-bin/swiftlint
+      packages: write
+    secrets: inherit
+    with:
+      tag: ${{ inputs.version }}
+      ref: release/${{ inputs.version }}
 
   build-macos:
     name: Build macOS Binaries
@@ -152,8 +124,7 @@ jobs:
     needs:
       - setup-credentials
       - prepare-release
-      - build-linux-amd64
-      - build-linux-arm64
+      - build-linux-binaries
       - build-macos
     runs-on: macOS-14
     permissions:
@@ -173,6 +144,8 @@ jobs:
         uses: actions/download-artifact@v4
       - name: Move artifacts
         run: |
+          ls -l
+          ls -l ./*
           mv -f swiftlint ${{ env.MACOS_BUILD_DIR }}
           mv -f swiftlint_linux_* ${{ env.LINUX_BUILD_DIR }}
       - name: Make binaries executable


### PR DESCRIPTION
The binaries built with Bazel are not statically linked. That means that they require a different set of shared libraries to be available at runtime. This would be a breaking change. As an alternative, would could find out how to statically link in the Bazel build or build with SPM.