### PR TITLE
Ignore locally defined `count` identifiers in `empty_count` rule

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -123,6 +123,7 @@ swift_library(
     visibility = ["//visibility:public"],
     deps = [
         ":SwiftLintCore",
+        "@SwiftSyntax//:SwiftLexicalLookup_opt",
     ],
 )
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@
   improvements done in the [SwiftSyntax](https://github.com/swiftlang/swift-syntax)
   library.
 
+* Ignore locally defined `count` identifiers in `empty_count` rule.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#5326](https://github.com/realm/SwiftLint/issues/5326)
+
 * The `private_swiftui_state` rule now applies to `ViewModifier` types.  
   [mt00chikin](https://github.com/mt00chikin)
 

--- a/Package.swift
+++ b/Package.swift
@@ -107,7 +107,10 @@ let package = Package(
         ),
         .target(
             name: "SwiftLintBuiltInRules",
-            dependencies: ["SwiftLintCore"],
+            dependencies: [
+                .product(name: "SwiftLexicalLookup", package: "swift-syntax"),
+                "SwiftLintCore",
+            ],
             swiftSettings: swiftFeatures + strictConcurrency
         ),
         .target(


### PR DESCRIPTION
Fixes #5326.