### PR TITLE
Exclude explicit system modules from `duplicate_imports` analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,12 @@
   types as needed.  
   [SimplyDanny](https://github.com/SimplyDanny)
 
+* Exclude explicit system modules from `duplicate_imports` analysis, that is, modules
+  that are part of the system frameworks but need to be imported explicitly due to being
+  declared as `explicit module` in their module map.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#6098](https://github.com/realm/SwiftLint/issues/6098)
+
 * Ignore various assignment operators like `=`, `+=`, `&=`, etc. with right-hand side
   ternary expressions otherwise violating the `void_function_in_ternary` rule.  
   [SimplyDanny](https://github.com/SimplyDanny)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DuplicateImportsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DuplicateImportsRule.swift
@@ -96,6 +96,86 @@ private struct ImportPathUsage: Hashable {
     let path: [String]
 }
 
+private let explicitSystemModules = Set([
+    "AddressBook.ABActions",
+    "AddressBook.ABPeoplePicker",
+    "AddressBook.ABPeoplePickerView",
+    "AddressBook.ABPersonPicker",
+    "AddressBook.ABPersonPickerDelegate",
+    "AddressBook.ABPersonView",
+    "AGL.Context",
+    "AGL.GLM",
+    "AGL.Macro",
+    "AGL.Renderers",
+    "AppKit.NSNibConnector",
+    "AppKit.NSNibControlConnector",
+    "AppKit.NSNibOutletConnector",
+    "AudioToolbox.AUCocoaUIView",
+    "AudioToolbox.AudioUnitCarbonView",
+    "AudioToolbox.DefaultAudioOutput",
+    "AudioUnit.AUCocoaUIView",
+    "AudioUnit.AudioUnitCarbonView",
+    "CoreAudio.AudioServerPlugIn",
+    "CoreData.CloudKit",
+    "CoreFoundation.CFPlugInCOM",
+    "CoreImage.CIFilterBuiltins",
+    "CoreMediaIO.CMIOHardwarePlugIn",
+    "CoreMediaIO.CMIOSampleBuffer",
+    "CoreVideo.CVHostTime",
+    "DirectoryService.DirServicesCustom",
+    "ForceFeedback.IOForceFeedbackLib",
+    "Foundation.NSDebug",
+    "GSS.krb5",
+    "IOKit.ata",
+    "IOKit.audio",
+    "IOKit.avc",
+    "IOKit.firewire",
+    "IOKit.graphics",
+    "IOKit.hid",
+    "IOKit.hidsystem",
+    "IOKit.i2c",
+    "IOKit.kext",
+    "IOKit.ndrvsupport",
+    "IOKit.network",
+    "IOKit.ps",
+    "IOKit.pwr_mgt",
+    "IOKit.sbp2",
+    "IOKit.scsi",
+    "IOKit.serial",
+    "IOKit.storage",
+    "IOKit.stream",
+    "IOKit.usb",
+    "IOKit.video",
+    "Kerberos.CredentialsCache2",
+    "Kerberos.locate_plugin",
+    "Kerberos.preauth_plugin",
+    "LDAP.lber",
+    "NetFS.NetFSPlugin",
+    "NetFS.NetFSUtil",
+    "Network.FoundationExtension",
+    "OpenGL.Ext",
+    "OpenGL.GL",
+    "OpenGL.GL3",
+    "OpenGL.GLU",
+    "OpenGL.IOSurface",
+    "OpenGL.Macro",
+    "SceneKit.ModelIO",
+    "Security.AuthorizationPlugin",
+    "Security.AuthSession",
+    "Security.CodeSigning",
+    "Security.eisl",
+    "Security.SecAsn1Coder",
+    "Security.SecAsn1Templates",
+    "Security.SecKey",
+    "Security.SecRandom",
+    "Security.SecureDownload",
+    "Security.SecureTransport",
+    "SecurityFoundation.SFAuthorization",
+    "SystemConfiguration.CaptiveNetwork",
+    "SystemConfiguration.DHCPClientPreferences",
+    "SystemConfiguration.SCDynamicStoreCopyDHCPInfo",
+].map { $0.split(separator: ".").map(String.init) })
+
 private extension SwiftLintFile {
     func duplicateImportsViolationPositions() -> [AbsolutePosition] {
         let importPaths = ImportPathVisitor(viewMode: .sourceAccurate)
@@ -142,7 +222,7 @@ private extension SwiftLintFile {
         }
 
         // Partial matches
-        for `import` in importPaths where !`import`.hasAttributes {
+        for `import` in importPaths where !`import`.hasAttributes && !explicitSystemModules.contains(`import`.path) {
             let path = `import`.path
             let position = `import`.position
             let violation = importPaths.contains { other in

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DuplicateImportsRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/DuplicateImportsRuleExamples.swift
@@ -37,6 +37,10 @@ internal struct DuplicateImportsRuleExamples {
         import Foo
         @testable import struct Foo.Bar
         """),
+        Example("""
+        import CoreImage
+        import CoreImage.CIFilterBuiltins
+        """),
     ]
 
     static let triggeringExamples = Array(corrections.keys.sorted())
@@ -180,6 +184,12 @@ internal struct DuplicateImportsRuleExamples {
             """, excludeFromDocumentation: true): Example("""
                 import A
 
+                """),
+            Example("""
+            import CoreImage.CIFilterBuiltins
+            import CoreImage.CIFilterBuiltins
+            """, excludeFromDocumentation: true): Example("""
+                import CoreImage.CIFilterBuiltins
                 """),
         ]
 


### PR DESCRIPTION
Resolves #6098.