### PR TITLE
Enable a fully statically linked Linux executable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ### Breaking
 
-* None.
+* If `SWIFTLINT_DISABLE_SOURCEKIT` is set to prohibit loading `libsourcekitdInProc` at runtime,
+  rules requiring SourceKit will be disabled and a warning will be printed once per rule.  
+  [SimplyDanny](https://github.com/SimplyDanny)
 
 ### Experimental
 
@@ -12,7 +14,12 @@
 
 ### Enhancements
 
-* None.
+* A fully statically linked Linux binary can now be built with the Swift SDK and
+  the compiler options `-Xswiftc -DSWIFTLINT_DISABLE_SOURCEKIT`. This binary does not
+  require `libsourcekitdInProc.so` or any other dynamic libraries to be present on the
+  system at runtime. Rules requiring SourceKit will be disabled and reported to the console
+  when running this binary.  
+  [SimplyDanny](https://github.com/SimplyDanny)
 
 ### Bug Fixes
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/QuickDiscouragedCallRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/QuickDiscouragedCallRule.swift
@@ -1,5 +1,6 @@
 import SourceKittenFramework
 
+@DisabledWithoutSourceKit
 struct QuickDiscouragedCallRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedImportRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedImportRule.swift
@@ -3,6 +3,7 @@ import SourceKittenFramework
 
 private let moduleToLog = ProcessInfo.processInfo.environment["SWIFTLINT_LOG_MODULE_USAGE"]
 
+@DisabledWithoutSourceKit
 struct UnusedImportRule: CorrectableRule, AnalyzerRule {
     var configuration = UnusedImportConfiguration()
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/FileTypesOrderRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/FileTypesOrderRule.swift
@@ -3,6 +3,7 @@ import SourceKittenFramework
 
 private typealias FileTypeOffset = (fileType: FileTypesOrderConfiguration.FileType, offset: ByteCount)
 
+@DisabledWithoutSourceKit
 struct FileTypesOrderRule: OptInRule {
     var configuration = FileTypesOrderConfiguration()
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/IndentationWidthRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/IndentationWidthRule.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
+@DisabledWithoutSourceKit
 struct IndentationWidthRule: OptInRule {
     // MARK: - Subtypes
     private enum Indentation: Equatable {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/LiteralExpressionEndIndentationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/LiteralExpressionEndIndentationRule.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
+@DisabledWithoutSourceKit
 struct LiteralExpressionEndIndentationRule: Rule, OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ModifierOrderRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ModifierOrderRule.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
+@DisabledWithoutSourceKit
 struct ModifierOrderRule: ASTRule, OptInRule, CorrectableRule {
     var configuration = ModifierOrderConfiguration()
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/MultilineFunctionChainsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/MultilineFunctionChainsRule.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
+@DisabledWithoutSourceKit
 struct MultilineFunctionChainsRule: ASTRule, OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/MultilineParametersBracketsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/MultilineParametersBracketsRule.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
+@DisabledWithoutSourceKit
 struct MultilineParametersBracketsRule: OptInRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SortedImportsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SortedImportsRule.swift
@@ -52,6 +52,7 @@ private extension Sequence where Element == Line {
     }
 }
 
+@DisabledWithoutSourceKit
 struct SortedImportsRule: CorrectableRule, OptInRule {
     var configuration = SortedImportsConfiguration()
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/StatementPositionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/StatementPositionRule.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
+@DisabledWithoutSourceKit
 struct StatementPositionRule: CorrectableRule {
     var configuration = StatementPositionConfiguration()
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/VerticalWhitespaceBetweenCasesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/VerticalWhitespaceBetweenCasesRule.swift
@@ -7,6 +7,7 @@ private extension SwiftLintFile {
     }
 }
 
+@DisabledWithoutSourceKit
 struct VerticalWhitespaceBetweenCasesRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/VerticalWhitespaceClosingBracesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/VerticalWhitespaceClosingBracesRule.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SourceKittenFramework
 
+@DisabledWithoutSourceKit
 struct VerticalWhitespaceClosingBracesRule: CorrectableRule, OptInRule {
     var configuration = VerticalWhitespaceClosingBracesConfiguration()
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/VerticalWhitespaceOpeningBracesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/VerticalWhitespaceOpeningBracesRule.swift
@@ -7,6 +7,7 @@ private extension SwiftLintFile {
     }
 }
 
+@DisabledWithoutSourceKit
 struct VerticalWhitespaceOpeningBracesRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 

--- a/Source/SwiftLintCore/Extensions/Request+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/Request+SwiftLint.swift
@@ -2,7 +2,15 @@ import Foundation
 import SourceKittenFramework
 
 public extension Request {
-    static let disableSourceKit = ProcessInfo.processInfo.environment["SWIFTLINT_DISABLE_SOURCEKIT"] != nil
+    static let disableSourceKit = {
+        #if SWIFTLINT_DISABLE_SOURCEKIT
+        // Compile-time
+        true
+        #else
+        // Runtime
+        ProcessInfo.processInfo.environment["SWIFTLINT_DISABLE_SOURCEKIT"] != nil
+        #endif
+    }()
 
     func sendIfNotDisabled() throws -> [String: any SourceKitRepresentable] {
         // Skip safety checks if explicitly allowed (e.g., for testing or specific operations)
@@ -37,7 +45,7 @@ public extension Request {
         }
 
         guard !Self.disableSourceKit else {
-            throw Self.Error.connectionInterrupted("SourceKit is disabled by `SWIFTLINT_DISABLE_SOURCEKIT`.")
+            queuedFatalError("SourceKit is disabled by `SWIFTLINT_DISABLE_SOURCEKIT`.")
         }
         return try send()
     }

--- a/Source/SwiftLintCore/Helpers/Macros.swift
+++ b/Source/SwiftLintCore/Helpers/Macros.swift
@@ -31,6 +31,15 @@ public macro AcceptableByConfigurationElement() = #externalMacro(
     type: "AcceptableByConfigurationElement"
 )
 
+@attached(
+    extension,
+    names: named(notifyRuleDisabledOnce), named(postMessage)
+)
+public macro DisabledWithoutSourceKit() = #externalMacro(
+    module: "SwiftLintCoreMacros",
+    type: "DisabledWithoutSourceKit"
+)
+
 /// Deprecated. Use `AcceptableByConfigurationElement` instead.
 @available(*, deprecated, renamed: "AcceptableByConfigurationElement")
 @attached(

--- a/Source/SwiftLintCore/Models/CurrentRule.swift
+++ b/Source/SwiftLintCore/Models/CurrentRule.swift
@@ -1,8 +1,8 @@
-/// A task-local value that holds the identifier of the currently executing rule.
-/// This allows SourceKit request handling to determine if the current rule
-/// is a SourceKitFreeRule without modifying function signatures throughout the codebase.
+/// This allows SourceKit request handling to determine certain properties without
+/// modifying function signatures throughout the codebase.
 public enum CurrentRule {
-    /// The Rule ID for the currently executing rule.
+    /// A task-local value that holds the identifier of the currently executing rule, e.g., to check whether the rule
+    /// is allowed to make SourceKit requests.
     @TaskLocal public static var identifier: String?
 
     /// Allows specific SourceKit requests to be made outside of rule execution context.

--- a/Source/SwiftLintCore/Protocols/Rule.swift
+++ b/Source/SwiftLintCore/Protocols/Rule.swift
@@ -94,6 +94,10 @@ public protocol Rule: Sendable {
     ///
     /// - Returns: A boolean value indicating whether the rule is enabled in the given region.
     func isEnabled(in region: Region, for ruleID: String) -> Bool
+
+    /// Prints a warning to the console once about the rule being disabled due to SourceKit being unavailable. The
+    /// default implementation does nothing. Rules that depend on SourceKit should override this appropriately.
+    func notifyRuleDisabledOnce()
 }
 
 public extension Rule {
@@ -147,6 +151,10 @@ public extension Rule {
 
     func isEnabled(in region: Region, for ruleID: String) -> Bool {
         !Self.description.allIdentifiers.contains(ruleID) || region.isRuleEnabled(self)
+    }
+
+    func notifyRuleDisabledOnce() {
+        // Intentionally empty by default.
     }
 }
 

--- a/Source/SwiftLintCoreMacros/DisabledWithoutSourceKit.swift
+++ b/Source/SwiftLintCoreMacros/DisabledWithoutSourceKit.swift
@@ -1,0 +1,34 @@
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+enum DisabledWithoutSourceKit: ExtensionMacro {
+    static func expansion(
+        of _: AttributeSyntax,
+        attachedTo declaration: some DeclGroupSyntax,
+        providingExtensionsOf type: some TypeSyntaxProtocol,
+        conformingTo _: [TypeSyntax],
+        in context: some MacroExpansionContext
+    ) throws -> [ExtensionDeclSyntax] {
+        guard declaration.is(StructDeclSyntax.self) else {
+            context.diagnose(SwiftLintCoreMacroError.notStruct.diagnose(at: declaration))
+            return []
+        }
+        let message = #"""
+        "Skipping enabled rule '\(Self.identifier)' because it requires SourceKit and SourceKit access is prohibited."
+        """#
+        return [
+            try ExtensionDeclSyntax("""
+                extension \(type) {
+                    private static let postMessage: Void = {
+                        Issue.genericWarning(\(raw: message)).print()
+                    }()
+
+                    func notifyRuleDisabledOnce() {
+                        _ = Self.postMessage
+                    }
+                }
+                """),
+        ]
+    }
+}

--- a/Source/SwiftLintCoreMacros/SwiftLintCoreMacros.swift
+++ b/Source/SwiftLintCoreMacros/SwiftLintCoreMacros.swift
@@ -8,6 +8,7 @@ struct SwiftLintCoreMacros: CompilerPlugin {
     let providingMacros: [any Macro.Type] = [
         AutoConfigParser.self,
         AcceptableByConfigurationElement.self,
+        DisabledWithoutSourceKit.self,
         SwiftSyntaxRule.self,
     ]
 }

--- a/Source/SwiftLintFramework/Models/Linter.swift
+++ b/Source/SwiftLintFramework/Models/Linter.swift
@@ -78,13 +78,20 @@ private extension Rule {
             return false
         }
 
-        // Only check sourcekitdFailed if the rule requires SourceKit.
-        // This avoids triggering SourceKit initialization for SourceKit-free rules.
-        if requiresSourceKit, file.sourcekitdFailed {
-            warnSourceKitFailedOnce()
-            return false
+        if requiresSourceKit {
+            // If SourceKit is disabled, we skip running the rule and post a warning once.
+            if Request.disableSourceKit {
+                notifyRuleDisabledOnce()
+                return false
+            }
+            // Only check `sourcekitdFailed` if the rule requires SourceKit. This avoids triggering SourceKit
+            // initialization for effectively SourceKit-free rules.
+            if file.sourcekitdFailed {
+                warnSourceKitFailedOnce()
+                return false
+            }
+            return true
         }
-
         return true
     }
 

--- a/Source/SwiftLintFramework/Rules/CustomRules.swift
+++ b/Source/SwiftLintFramework/Rules/CustomRules.swift
@@ -50,6 +50,7 @@ struct CustomRulesConfiguration: RuleConfiguration, CacheDescriptionProvider {
 
 // MARK: - CustomRules
 
+@DisabledWithoutSourceKit
 struct CustomRules: Rule, CacheDescriptionProvider, ConditionallySourceKitFree {
     var cacheDescription: String {
         configuration.cacheDescription


### PR DESCRIPTION
If SwiftLint is built from this state using the Swift SDK, we'll get a large self-contained Linux executable that runs without loading SourceKit. It can do that by disabling any rule that requires SourceKit.

With `SWIFTLINT_DISABLE_SOURCEKIT` set on a normally (dynamically linked) binary, the behavior is the same. That's different from the previously reported more serious warnings.

This step makes sense now that there's only a handful of SourceKit-based rules left. The most critical one would be `custom_rules`. With #6129, there's a solution in sight, though.

I'm yet undecided whether to additionally provide these full static binaries as release artifacts from now on ...