### PR TITLE
Maintain SourceKit-mode as long as custom rules don't support SwiftSyntax

### DIFF
--- a/Source/SwiftLintFramework/Rules/CustomRules.swift
+++ b/Source/SwiftLintFramework/Rules/CustomRules.swift
@@ -75,7 +75,7 @@ struct CustomRules: Rule, CacheDescriptionProvider, ConditionallySourceKitFree {
     var isEffectivelySourceKitFree: Bool {
         configuration.customRuleConfigurations.allSatisfy { config in
             let effectiveMode = config.executionMode == .default
-                ? (configuration.defaultExecutionMode ?? .swiftsyntax)
+                ? (configuration.defaultExecutionMode ?? .sourcekit)
                 : config.executionMode
             return effectiveMode == .swiftsyntax
         }

--- a/Tests/FrameworkTests/CustomRulesTests.swift
+++ b/Tests/FrameworkTests/CustomRulesTests.swift
@@ -685,7 +685,7 @@ final class CustomRulesTests: SwiftLintTestCase {
         XCTAssertEqual(violations[1].location.character, 18)
     }
 
-    func testCustomRuleDefaultsToSwiftSyntaxWhenNoModeSpecified() throws {
+    func testCustomRuleDefaultsToSourceKitWhenNoModeSpecified() throws {
         // When NO execution mode is specified (neither default nor per-rule), it should default to swiftsyntax
         let customRules: [String: Any] = [
             "no_foo": [
@@ -713,8 +713,8 @@ final class CustomRulesTests: SwiftLintTestCase {
             return
         }
 
-        XCTAssertTrue(customRule.isEffectivelySourceKitFree,
-                      "Rule should be effectively SourceKit-free when defaulting to swiftsyntax")
+        XCTAssertFalse(customRule.isEffectivelySourceKitFree,
+                       "Rule depends on SourceKit")
     }
 
     func testCustomRuleWithMatchKindsUsesSwiftSyntaxWhenConfigured() throws {
@@ -740,8 +740,8 @@ final class CustomRulesTests: SwiftLintTestCase {
         XCTAssertEqual(violations[0].location.character, 23) // Position of 'foo' in comment
     }
 
-    func testCustomRuleWithKindFilteringDefaultsToSwiftSyntax() throws {
-        // When using kind filtering without specifying mode, it should default to swiftsyntax
+    func testCustomRuleWithKindFilteringDefaultsToSourceKit() throws {
+        // When using kind filtering without specifying mode, it should default to sourcekit
         let customRules: [String: Any] = [
             "no_keywords": [
                 "regex": "\\b\\w+\\b",
@@ -769,8 +769,8 @@ final class CustomRulesTests: SwiftLintTestCase {
             return
         }
 
-        XCTAssertTrue(customRule.isEffectivelySourceKitFree,
-                      "Rule with kind filtering should default to swiftsyntax mode")
+        XCTAssertFalse(customRule.isEffectivelySourceKitFree,
+                       "Rule with kind filtering should default to sourcekit mode")
     }
 
     func testCustomRuleWithExcludedMatchKindsUsesSwiftSyntaxWithDefaultMode() throws {


### PR DESCRIPTION
#6129 is required for `.swiftsyntax` to become the default.