### PR TITLE
Add static Linux binaries to release archives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,6 +119,41 @@ jobs:
           name: ${{ matrix.artifact_name }}
           path: .build/release/swiftlint
 
+  build-static-linux:
+    name: Build Static Linux ${{ matrix.arch }} Binary
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: ARM64
+            runner: ubuntu-24.04-arm
+            swift_sdk: aarch64-swift-linux-musl
+            artifact_name: swiftlint-static-arm64
+          - arch: AMD64
+            runner: ubuntu-24.04
+            swift_sdk: x86_64-swift-linux-musl
+            artifact_name: swiftlint-static-amd64
+    permissions:
+      contents: read
+    env:
+      BINARY_PATH: .build/${{ matrix.swift_sdk }}/release/swiftlint
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false
+      - name: Install SDK
+        run: swift sdk install https://download.swift.org/swift-6.1.2-release/static-sdk/swift-6.1.2-RELEASE/swift-6.1.2-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz --checksum df0b40b9b582598e7e3d70c82ab503fd6fbfdff71fd17e7f1ab37115a0665b3b
+      - name: Build static binary
+        run: swift build -c release --product swiftlint --swift-sdk ${{ matrix.swift_sdk }} -Xswiftc -DSWIFTLINT_DISABLE_SOURCEKIT
+      - name: Strip binary
+        run: strip -s "$BINARY_PATH"
+      - name: Upload artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: ${{ env.BINARY_PATH }}
+
   build-macos:
     name: Build macOS Binaries
     needs: prepare-release
@@ -149,6 +184,7 @@ jobs:
       - setup-credentials
       - prepare-release
       - build-linux
+      - build-static-linux
       - build-macos
     runs-on: macOS-14
     permissions:
@@ -173,8 +209,10 @@ jobs:
           mv -f swiftlint-macos/bazel.* .
           mv -f swiftlint-linux-amd64/swiftlint ${{ env.LINUX_BUILD_DIR }}/swiftlint_linux_amd64
           mv -f swiftlint-linux-arm64/swiftlint ${{ env.LINUX_BUILD_DIR }}/swiftlint_linux_arm64
+          mv -f swiftlint-static-amd64/swiftlint ${{ env.LINUX_BUILD_DIR }}/swiftlint_static_amd64
+          mv -f swiftlint-static-arm64/swiftlint ${{ env.LINUX_BUILD_DIR }}/swiftlint_static_arm64
       - name: Make binaries executable
-        run: chmod +x ${{ env.MACOS_BUILD_DIR }}/swiftlint ${{ env.LINUX_BUILD_DIR }}/swiftlint_linux_*
+        run: chmod +x ${{ env.MACOS_BUILD_DIR }}/swiftlint ${{ env.LINUX_BUILD_DIR }}/swiftlint_linux_* ${{ env.LINUX_BUILD_DIR }}/swiftlint_static_*
       - name: Create artifacts
         run: |
           make --debug spm_artifactbundle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,15 @@
 
 ### Experimental
 
-* None.
+* Both Linux release archives (for AMD64 and ARM64) now contain two binaries:
+  * A dynamically linked binary that requires `libsourcekitdInProc.so` together with its
+    transitive dependencies to be present on the system at runtime. It is named `swiftlint`
+    and the same binary as before. It supports all built-in rules.
+  * A fully statically linked binary named `swiftlint-static` that does not require
+    any dynamic libraries at runtime. Rules requiring SourceKit will be disabled and
+    reported to the console when running this binary.
+  <!-- Keep empty line to have the contributors on a separate line. -->
+  [SimplyDanny](https://github.com/SimplyDanny)
 
 ### Enhancements
 

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ SWIFTLINT_EXECUTABLE=$(SWIFTLINT_EXECUTABLE_PARENT)/swiftlint
 SWIFTLINT_EXECUTABLE_LINUX_PARENT=.build/linux
 SWIFTLINT_EXECUTABLE_LINUX_AMD64=$(SWIFTLINT_EXECUTABLE_LINUX_PARENT)/swiftlint_linux_amd64
 SWIFTLINT_EXECUTABLE_LINUX_ARM64=$(SWIFTLINT_EXECUTABLE_LINUX_PARENT)/swiftlint_linux_arm64
+SWIFTLINT_EXECUTABLE_STATIC_AMD64=$(SWIFTLINT_EXECUTABLE_LINUX_PARENT)/swiftlint_static_amd64
+SWIFTLINT_EXECUTABLE_STATIC_ARM64=$(SWIFTLINT_EXECUTABLE_LINUX_PARENT)/swiftlint_static_arm64
 
 ARTIFACT_BUNDLE_PATH=$(TEMPORARY_FOLDER)/SwiftLintBinary.artifactbundle
 
@@ -136,13 +138,15 @@ spm_artifactbundle: $(SWIFTLINT_EXECUTABLE) $(SWIFTLINT_EXECUTABLE_LINUX_AMD64) 
 	cp -f "$(LICENSE_PATH)" "$(ARTIFACT_BUNDLE_PATH)"
 	(cd "$(TEMPORARY_FOLDER)"; zip -yr - "SwiftLintBinary.artifactbundle") > "./SwiftLintBinary.artifactbundle.zip"
 
-zip_linux_release: $(SWIFTLINT_EXECUTABLE_LINUX_AMD64) $(SWIFTLINT_EXECUTABLE_LINUX_ARM64)
+zip_linux_release: $(SWIFTLINT_EXECUTABLE_LINUX_AMD64) $(SWIFTLINT_EXECUTABLE_LINUX_ARM64) $(SWIFTLINT_EXECUTABLE_STATIC_AMD64) $(SWIFTLINT_EXECUTABLE_STATIC_ARM64)
 	$(eval TMP_FOLDER := $(shell mktemp -d))
 	cp -f "$(SWIFTLINT_EXECUTABLE_LINUX_AMD64)" "$(TMP_FOLDER)/swiftlint"
+	cp -f "$(SWIFTLINT_EXECUTABLE_STATIC_AMD64)" "$(TMP_FOLDER)/swiftlint-static"
 	cp -f "$(LICENSE_PATH)" "$(TMP_FOLDER)"
-	(cd "$(TMP_FOLDER)"; zip -yr - "swiftlint" "LICENSE") > "./swiftlint_linux_amd64.zip"
+	(cd "$(TMP_FOLDER)"; zip -yr - "swiftlint" "swiftlint-static" "LICENSE") > "./swiftlint_linux_amd64.zip"
 	cp -f "$(SWIFTLINT_EXECUTABLE_LINUX_ARM64)" "$(TMP_FOLDER)/swiftlint"
-	(cd "$(TMP_FOLDER)"; zip -yr - "swiftlint" "LICENSE") > "./swiftlint_linux_arm64.zip"
+	cp -f "$(SWIFTLINT_EXECUTABLE_LINUX_AMD64)" "$(TMP_FOLDER)/swiftlint-static"
+	(cd "$(TMP_FOLDER)"; zip -yr - "swiftlint" "swiftlint-static" "LICENSE") > "./swiftlint_linux_arm64.zip"
 
 package: $(SWIFTLINT_EXECUTABLE)
 	$(eval PACKAGE_ROOT := $(shell mktemp -d))


### PR DESCRIPTION
With the adaptions made in #6211, we are now able to build fully statically linked binaries that restrict the set of rules to the ones not relying on SourceKit.