### PR TITLE
Include bzl dependency files in release package

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -237,6 +237,8 @@ filegroup(
         "//:DyldWarningWorkaroundSources",
         "//:LintInputs",
         "//Tests:BUILD",
+        "//Tests:generated_tests.bzl",
+        "//Tests:test_macros.bzl",
         "//bazel:release_files",
     ],
 )

--- a/Tests/BUILD
+++ b/Tests/BUILD
@@ -1,7 +1,11 @@
 load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library", "swift_test")
 load(":generated_tests.bzl", "generated_tests")
 
-exports_files(["BUILD"])
+exports_files([
+    "BUILD",
+    "generated_tests.bzl",
+    "test_macros.bzl",
+])
 
 copts = [
     "-warnings-as-errors",


### PR DESCRIPTION
Bumping to `0.60.0` and trying to run `bazel test "@SwiftLint//Tests:ExtraRulesTests"` revealed the issue
```
ERROR: error loading package '@@swiftlint~//Tests': cannot load '@@swiftlint~//Tests:generated_tests.bzl': no such file
```

as these files aren't packaged into the release. I went ahead and added them as a part of the release package but let me know if there's a better approach instead.