### PR TITLE
Treat strings with opening and closing quotes in the same line as single-line strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@
   on top.  
   [SimplyDanny](https://github.com/SimplyDanny)
 
+* In `line_length` rule, treat strings with opening and closing quotes in the same line as
+  single-line strings no matter if they are enclosed by triple quotes or not.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#6220](https://github.com/realm/SwiftLint/issues/6220)
+
 ### Bug Fixes
 
 * Fix `closure_end_indentation` rule reporting violations when the called base

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/LineLengthRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/LineLengthRule.swift
@@ -224,17 +224,15 @@ private final class MultilineStringLiteralVisitor: SyntaxVisitor {
     }
 
     override func visitPost(_ node: StringLiteralExprSyntax) {
-        guard node.openingQuote.tokenKind == .multilineStringQuote ||
-                (node.openingPounds != nil && node.openingQuote.tokenKind == .stringQuote) else {
+        guard node.openingQuote.tokenKind == .multilineStringQuote else {
             return
         }
-
         let startLocation = locationConverter.location(for: node.positionAfterSkippingLeadingTrivia)
         let endLocation = locationConverter.location(for: node.endPositionBeforeTrailingTrivia)
-
-        for line in startLocation.line...endLocation.line {
-            linesSpanned.insert(line)
+        guard startLocation.line < endLocation.line else {
+            return
         }
+        linesSpanned.formUnion(startLocation.line...endLocation.line)
     }
 }
 

--- a/Tests/BuiltInRulesTests/LineLengthRuleTests.swift
+++ b/Tests/BuiltInRulesTests/LineLengthRuleTests.swift
@@ -24,6 +24,10 @@ final class LineLengthRuleTests: SwiftLintTestCase {
     private let multilineString = Example("let multilineString = \"\"\"\n" +
         String(repeating: "A", count: 121) + "\n" +
         "\"\"\"\n")
+    private let tripleStringSingleLine = Example("let tripleString = \"\"\""
+        + String(repeating: "A", count: 121) + "\"\"\"\n")
+    private let poundStringSingleLine = Example("let poundString = #\""
+        + String(repeating: "A", count: 121) + "\"#\n")
     private let multilineStringWithExpression = Example("let multilineString = \"\"\"\n" +
         String(repeating: "A", count: 121) + "\n\n\"\"\"; let a = 1")
     private let multilineStringWithNewlineExpression = Example("let multilineString = \"\"\"\n" +
@@ -94,7 +98,11 @@ final class LineLengthRuleTests: SwiftLintTestCase {
     }
 
     func testLineLengthWithIgnoreMultilineStringsTrue() {
-        let triggeringLines = [multilineStringFail]
+        let triggeringLines = [
+            multilineStringFail,
+            tripleStringSingleLine,
+            poundStringSingleLine,
+        ]
         let nonTriggeringLines = [
             multilineString,
             multilineStringWithExpression,


### PR DESCRIPTION
Fixes #6220.