### PR TITLE
Improve detection of comment-only lines in `file_length` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,10 @@
   [#6220](https://github.com/realm/SwiftLint/issues/6220)
   [#6219](https://github.com/realm/SwiftLint/issues/6219)
 
+* Improve detection of comment-only lines in `file_length` rule.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#6219](https://github.com/realm/SwiftLint/issues/6219)
+
 ### Bug Fixes
 
 * Fix `closure_end_indentation` rule reporting violations when the called base

--- a/Source/SwiftLintCore/Visitors/CommentLinesVisitor.swift
+++ b/Source/SwiftLintCore/Visitors/CommentLinesVisitor.swift
@@ -5,7 +5,9 @@ public final class CommentLinesVisitor: SyntaxVisitor {
     private let locationConverter: SourceLocationConverter
 
     private var linesWithComments = Set<Int>()
-    private var linesWithCode = Set<Int>()
+
+    /// Lines that contain actual code (not comments).
+    public private(set) var linesWithCode = Set<Int>()
 
     /// Lines that contain only comments (and whitespace).
     public var commentOnlyLines: Set<Int> {


### PR DESCRIPTION
Addresses https://github.com/realm/SwiftLint/issues/6219#issuecomment-3245098369.