### PR TITLE
Ensure that headers matched against always end in a newline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,10 @@
 
 ### Bug Fixes
 
+* Ensure that header matched against always end in a newline in `file_header` rule.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#6227](https://github.com/realm/SwiftLint/issues/6227)
+
 * Fix `closure_end_indentation` rule reporting violations when the called base
   involves chained optional expressions.  
   [SimplyDanny](https://github.com/SimplyDanny)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/FileHeaderRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/FileHeaderRule.swift
@@ -151,6 +151,8 @@ private extension FileHeaderRule {
             )
 
             return file.stringView.substringWithByteRange(headerByteRange)
+                .map { $0 + "\n" } // Ensure there's a newline at the end since YAML will always add it to the regex
+                                   // when a `|` block is used to define the pattern.
         }
 
         private func checkForbiddenPattern(in headerContent: String, startingAt headerStart: AbsolutePosition) {

--- a/Tests/BuiltInRulesTests/FileHeaderRuleTests.swift
+++ b/Tests/BuiltInRulesTests/FileHeaderRuleTests.swift
@@ -200,4 +200,71 @@ final class FileHeaderRuleTests: SwiftLintTestCase {
         XCTAssertEqual(try validate(fileName: "FileNameMismatch.swift", using: configuration).count, 1)
         XCTAssertEqual(try validate(fileName: "FileNameMissing.swift", using: configuration).count, 1)
     }
+
+    func testSimplePattern() {
+        let description = FileHeaderRule.description
+            .with(nonTriggeringExamples: [
+                Example("""
+                    // Test
+
+                    enum Test {}
+                    """),
+                Example("""
+                    // Test
+                    """),
+                Example("""
+                    // Test
+
+                    """),
+            ])
+            .with(triggeringExamples: [])
+
+        verifyRule(
+            description,
+            ruleConfiguration: [
+                "required_pattern": #"""
+                    \/\/ Test
+
+                    """#, // The empty line at the end is important since YAML adds it as well in `|` blocks.
+            ],
+            skipCommentTests: true,
+            testMultiByteOffsets: false
+        )
+    }
+
+    func testPattern() {
+        let description = FileHeaderRule.description
+            .with(nonTriggeringExamples: [
+                Example("""
+                    //
+                    //  Test.swift
+                    //  Dummy App
+                    //
+                    //  Created by Alice Bob on 3.9.2025.
+                    //  Copyright © 2025 Dummy Corporation. All rights reserved.
+                    //
+
+                    enum Test {}
+                    """),
+            ])
+            .with(triggeringExamples: [])
+
+        verifyRule(
+            description,
+            ruleConfiguration: [
+                "required_pattern": #"""
+                    \/\/
+                    \/\/  Test\.swift
+                    \/\/  .*?
+                    \/\/
+                    \/\/  Created by .*? on \d{1,2}[\.\/]\d{1,2}[\.\/]\d{2,4}\.
+                    \/\/  Copyright © \d{4} Dummy Corporation\. All rights reserved\.
+                    \/\/
+
+                    """#, // The empty line at the end is important since YAML adds it as well in `|` blocks.
+            ],
+            skipCommentTests: true,
+            testMultiByteOffsets: false
+        )
+    }
 }


### PR DESCRIPTION
Fixes #6227.