### PR TITLE
Test release archive in build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,22 @@ jobs:
         name: Build SwiftLint with Bazel
         env:
           CI_BAZELRC_FILE_CONTENT: ${{ secrets.CI_BAZELRC_FILE_CONTENT }}
+      - name: Prepare release workspace
+        run: |
+          cp bazel-bin/swiftlint .
+          make bazel_release
+          mkdir -p bazel-workspace
+          tar -czvf bazel.tar.gz bazel-workspace
+          cd bazel-workspace
+          sed -i '/-warnings-as-errors/d' bazel/copts.bzl
+      - name: Build release archive
+        uses: ./.github/actions/bazel-linux-build
+        env:
+          CI_BAZELRC_FILE_CONTENT: ${{ secrets.CI_BAZELRC_FILE_CONTENT }}
+      - name: Run tests for extra rules
+        run: |
+          bazel run //:swiftlint -- version
+          bazel test //Tests/ExtraRulesTests --test_output=errors
 
   plugins_linux:
     name: SPM plugins, Linux, Swift ${{ matrix.version }}

--- a/BUILD
+++ b/BUILD
@@ -225,7 +225,6 @@ filegroup(
     ],
 )
 
-# TODO: Use rules_pkg
 genrule(
     name = "release",
     srcs = [":release_files"],
@@ -233,17 +232,17 @@ genrule(
         "bazel.tar.gz",
         "bazel.tar.gz.sha256",
     ],
-    cmd = """\
-set -euo pipefail
+    cmd = """
+        set -euo pipefail
 
-outs=($(OUTS))
+        outs=($(OUTS))
 
-COPYFILE_DISABLE=1 tar czvfh "$${outs[0]}" \
-  --exclude ^bazel-out/ \
-  --exclude ^external/ \
-  *
-shasum -a 256 "$${outs[0]}" > "$${outs[1]}"
+        export COPYFILE_DISABLE=1
+        tar -czf "$${outs[0]}" --exclude=bazel-out --exclude=external .
+
+        "$(location @bazel_tools//tools/build_defs/hash:sha256)" $${outs[0]} $${outs[1]}
     """,
+    tools = ["@bazel_tools//tools/build_defs/hash:sha256"],
 )
 
 # Analyze

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ bazel_test_tsan:
 	bazel test --test_output=errors --build_tests_only --features=tsan --test_timeout=1000 //Tests/...
 
 bazel_release: swiftlint
-	bazel build :release
+	bazel build :release --verbose_failures
 	mv -f bazel-bin/bazel.tar.gz bazel-bin/bazel.tar.gz.sha256 .
 
 docker_image:


### PR DESCRIPTION
Make sure that SwiftLint can be built from the archive and tests for extra rules run.