### PR TITLE
Use 1-based line/column indexing for GitHub Actions

### DIFF
--- a/Source/SwiftLintFramework/Reporters/GitHubActionsLoggingReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/GitHubActionsLoggingReporter.swift
@@ -20,8 +20,8 @@ struct GitHubActionsLoggingReporter: Reporter {
         [
             "::\(violation.severity.rawValue) ",
             "file=\(violation.location.relativeFile ?? ""),",
-            "line=\(violation.location.line ?? 1),",
-            "col=\(violation.location.character ?? 1)::",
+            "line=\((violation.location.line ?? 0) + 1),",
+            "col=\((violation.location.character ?? 0) + 1)::",
             violation.reason,
             " (\(violation.ruleIdentifier))",
         ].joined()


### PR DESCRIPTION
I noticed that errors were being reported on the wrong line, and, sure enough:

> Column number, starting at 1
> Line number, starting at 1

https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-an-error-message