### PR TITLE
Add prefer_asset_symbols rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@
 
 ### Enhancements
 
+* Add new `prefer_asset_symbols` rule that suggests using asset symbols over 
+  string-based image initialization to avoid typos and enable compile-time 
+  checking. This rule detects `UIImage(named:)` and `SwiftUI.Image(_:)` calls 
+  with string literals and suggests using asset symbols instead.  
+  [417-72KI](https://github.com/417-72KI)
+  [#5939](https://github.com/realm/SwiftLint/issues/5939)
+
 * None.
 
 ### Bug Fixes

--- a/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
+++ b/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
@@ -149,6 +149,7 @@ public let builtInRules: [any Rule.Type] = [
     OverrideInExtensionRule.self,
     PatternMatchingKeywordsRule.self,
     PeriodSpacingRule.self,
+    PreferAssetSymbolsRule.self,
     PreferConditionListRule.self,
     PreferKeyPathRule.self,
     PreferNimbleRule.self,

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferAssetSymbolsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferAssetSymbolsRule.swift
@@ -1,0 +1,119 @@
+import SwiftLintCore
+import SwiftSyntax
+
+@SwiftSyntaxRule(optIn: false)
+struct PreferAssetSymbolsRule: Rule {
+    var configuration = SeverityConfiguration<Self>(.warning)
+
+    static let description = RuleDescription(
+        identifier: "prefer_asset_symbols",
+        name: "Prefer Asset Symbols",
+        description: "Prefer using asset symbols over string-based image initialization to avoid typos and enable compile-time checking",
+        rationale: """
+            UIKit.UIImage(named:) and SwiftUI.Image(_:) contain the risk of bugs due to typos. \
+            Since Xcode 15, Xcode generates codes for images in the Asset Catalog and it can avoid typos by providing compile-time checking.
+            """,
+        kind: .idiomatic,
+        minSwiftVersion: .fiveDotNine,
+        nonTriggeringExamples: [
+            // UIKit - using asset symbols
+            Example("UIImage(resource: .someImage)"),
+            Example("UIImage(systemName: \"trash\")"),
+            // SwiftUI - using asset symbols  
+            Example("Image(.someImage)"),
+            Example("Image(systemName: \"trash\")"),
+            // Dynamic strings (variables or interpolated)
+            Example("UIImage(named: imageName)"),
+            Example("UIImage(named: \"image_\\(suffix)\")"),
+            Example("Image(imageName)"),
+            Example("Image(\"image_\\(suffix)\")"),
+            // Bundle-specific initializers
+            Example("UIImage(named: \"someImage\", in: Bundle.main, compatibleWith: nil)"),
+            Example("Image(\"someImage\", bundle: Bundle.main)"),
+        ],
+        triggeringExamples: [
+            // UIKit examples
+            Example("↓UIImage(named: \"some_image\")"),
+            Example("↓UIImage(named: \"some image\")"),
+            Example("↓UIImage.init(named: \"someImage\")"),
+            // SwiftUI examples  
+            Example("↓Image(\"some_image\")"),
+            Example("↓Image(\"some image\")"),
+            Example("↓Image.init(\"someImage\")"),
+        ]
+    )
+}
+
+private extension PreferAssetSymbolsRule {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
+        override func visitPost(_ node: FunctionCallExprSyntax) {
+            let calledExpression = node.calledExpression.trimmedDescription
+            
+            // Check for UIImage(named:) calls
+            if isUIImageNamedInit(node: node, name: calledExpression) {
+                violations.append(node.positionAfterSkippingLeadingTrivia)
+            }
+            // Check for SwiftUI Image(_:) calls
+            else if isSwiftUIImageInit(node: node, name: calledExpression) {
+                violations.append(node.positionAfterSkippingLeadingTrivia)
+            }
+        }
+        
+        private func isUIImageNamedInit(node: FunctionCallExprSyntax, name: String) -> Bool {
+            // Check if this is a UIImage or UIImage.init call
+            guard uiImageInits().contains(name) else {
+                return false
+            }
+            
+            // Check if it has a "named" parameter with a string literal
+            guard let namedArgument = node.arguments.first(where: { $0.label?.text == "named" }),
+                  let stringLiteral = namedArgument.expression.as(StringLiteralExprSyntax.self),
+                  stringLiteral.isConstantString else {
+                return false
+            }
+            
+            // Don't trigger if there are additional parameters like "in:" (bundle parameter)
+            let argumentLabels = node.arguments.compactMap(\.label?.text)
+            return argumentLabels == ["named"]
+        }
+        
+        private func isSwiftUIImageInit(node: FunctionCallExprSyntax, name: String) -> Bool {
+            // Check if this is an Image or Image.init call
+            guard swiftUIImageInits().contains(name) else {
+                return false
+            }
+            
+            // For SwiftUI Image, the first parameter is unlabeled for the image name
+            guard let firstArgument = node.arguments.first,
+                  firstArgument.label == nil,
+                  let stringLiteral = firstArgument.expression.as(StringLiteralExprSyntax.self),
+                  stringLiteral.isConstantString else {
+                return false
+            }
+            
+            // Don't trigger if there are additional parameters like "bundle:"
+            let argumentLabels = node.arguments.compactMap(\.label?.text)
+            return argumentLabels.isEmpty || (argumentLabels.count == 1 && argumentLabels.first == nil)
+        }
+        
+        private func uiImageInits() -> [String] {
+            return [
+                "UIImage",
+                "UIImage.init"
+            ]
+        }
+        
+        private func swiftUIImageInits() -> [String] {
+            return [
+                "Image", 
+                "Image.init"
+            ]
+        }
+    }
+}
+
+private extension StringLiteralExprSyntax {
+    var isConstantString: Bool {
+        segments.allSatisfy { $0.is(StringSegmentSyntax.self) }
+    }
+}

--- a/Tests/GeneratedTests/GeneratedTests_06.swift
+++ b/Tests/GeneratedTests/GeneratedTests_06.swift
@@ -139,6 +139,12 @@ final class PeriodSpacingRuleGeneratedTests: SwiftLintTestCase {
     }
 }
 
+final class PreferAssetSymbolsRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(PreferAssetSymbolsRule.description)
+    }
+}
+
 final class PreferConditionListRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(PreferConditionListRule.description)
@@ -148,11 +154,5 @@ final class PreferConditionListRuleGeneratedTests: SwiftLintTestCase {
 final class PreferKeyPathRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(PreferKeyPathRule.description)
-    }
-}
-
-final class PreferNimbleRuleGeneratedTests: SwiftLintTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(PreferNimbleRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_07.swift
+++ b/Tests/GeneratedTests/GeneratedTests_07.swift
@@ -7,6 +7,12 @@
 @testable import SwiftLintCore
 import TestHelpers
 
+final class PreferNimbleRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(PreferNimbleRule.description)
+    }
+}
+
 final class PreferSelfInStaticReferencesRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(PreferSelfInStaticReferencesRule.description)
@@ -148,11 +154,5 @@ final class RedundantObjcAttributeRuleGeneratedTests: SwiftLintTestCase {
 final class RedundantSelfInClosureRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(RedundantSelfInClosureRule.description)
-    }
-}
-
-final class RedundantSendableRuleGeneratedTests: SwiftLintTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(RedundantSendableRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_08.swift
+++ b/Tests/GeneratedTests/GeneratedTests_08.swift
@@ -7,6 +7,12 @@
 @testable import SwiftLintCore
 import TestHelpers
 
+final class RedundantSendableRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(RedundantSendableRule.description)
+    }
+}
+
 final class RedundantSetAccessControlRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(RedundantSetAccessControlRule.description)
@@ -148,11 +154,5 @@ final class SuperfluousElseRuleGeneratedTests: SwiftLintTestCase {
 final class SwitchCaseAlignmentRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(SwitchCaseAlignmentRule.description)
-    }
-}
-
-final class SwitchCaseOnNewlineRuleGeneratedTests: SwiftLintTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(SwitchCaseOnNewlineRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_09.swift
+++ b/Tests/GeneratedTests/GeneratedTests_09.swift
@@ -7,6 +7,12 @@
 @testable import SwiftLintCore
 import TestHelpers
 
+final class SwitchCaseOnNewlineRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(SwitchCaseOnNewlineRule.description)
+    }
+}
+
 final class SyntacticSugarRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(SyntacticSugarRule.description)
@@ -148,11 +154,5 @@ final class UnusedClosureParameterRuleGeneratedTests: SwiftLintTestCase {
 final class UnusedControlFlowLabelRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(UnusedControlFlowLabelRule.description)
-    }
-}
-
-final class UnusedDeclarationRuleGeneratedTests: SwiftLintTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(UnusedDeclarationRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_10.swift
+++ b/Tests/GeneratedTests/GeneratedTests_10.swift
@@ -7,6 +7,12 @@
 @testable import SwiftLintCore
 import TestHelpers
 
+final class UnusedDeclarationRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(UnusedDeclarationRule.description)
+    }
+}
+
 final class UnusedEnumeratedRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(UnusedEnumeratedRule.description)

--- a/Tests/IntegrationTests/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/default_rule_configurations.yml
@@ -857,6 +857,11 @@ period_spacing:
   meta:
     opt-in: true
     correctable: true
+prefer_asset_symbols:
+  severity: warning
+  meta:
+    opt-in: false
+    correctable: false
 prefer_condition_list:
   severity: warning
   meta:


### PR DESCRIPTION
Implements a new SwiftLint rule that suggests using asset symbols over string-based image initialization to avoid typos and enable compile-time checking.

The rule detects:
- UIImage(named: "string") calls
- SwiftUI Image("string") calls

And suggests using asset symbols like:
- UIImage(resource: .imageName)
- Image(.imageName)

Resolves #5939