### PR TITLE
Add `legacy_uigraphics_functions` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,8 @@
 
 * Add new default `invisible_character` rule that detects invisible characters
   like zero-width space (U+200B), zero-width non-joiner (U+200C),
-  and FEFF formatting character (U+FEFF) in string literals, which can cause hard-to-debug issues.  
+  and FEFF formatting character (U+FEFF) in string literals, which can cause
+  hard-to-debug issues.  
   [kapitoshka438](https://github.com/kapitoshka438)
   [#6045](https://github.com/realm/SwiftLint/issues/6045)
 
@@ -64,6 +65,12 @@
   an identifier from an outer scope.  
   [nadeemnali](https://github.com/nadeemnali)
   [#6228](https://github.com/realm/SwiftLint/issues/6228)
+  
+* Add `legacy_uigraphics_functions` rule to encourage the use of modern
+  `UIGraphicsImageRenderer` instead of the legacy `UIGraphics{Begin|End}ImageContext`.
+  The modern replacement is safer, cleaner, Retina-aware and more performant.  
+  [Dimitri Dupuis-Latour](https://github.com/DimDL)
+  [#6268](https://github.com/realm/SwiftLint/issues/6268)
 
 ### Bug Fixes
 

--- a/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
+++ b/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
@@ -110,6 +110,7 @@ public let builtInRules: [any Rule.Type] = [
     LegacyNSGeometryFunctionsRule.self,
     LegacyObjcTypeRule.self,
     LegacyRandomRule.self,
+    LegacyUIGraphicsFunctionRule.self,
     LetVarWhitespaceRule.self,
     LineLengthRule.self,
     LiteralExpressionEndIndentationRule.self,

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyUIGraphicsFunctionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/LegacyUIGraphicsFunctionRule.swift
@@ -1,0 +1,74 @@
+import SwiftSyntax
+
+@SwiftSyntaxRule(optIn: true)
+struct LegacyUIGraphicsFunctionRule: Rule {
+    var configuration = SeverityConfiguration<Self>(.warning)
+
+    static let description = RuleDescription(
+        identifier: "legacy_uigraphics_function",
+        name: "Legacy UIGraphics Function",
+        description: "Prefer using `UIGraphicsImageRenderer` over legacy functions",
+        rationale: "The modern replacement is safer, cleaner, Retina-aware and more performant.",
+        kind: .idiomatic,
+        nonTriggeringExamples: [
+            Example("""
+            let renderer = UIGraphicsImageRenderer(size: bounds.size)
+            let screenshot = renderer.image { _ in
+                myUIView.drawHierarchy(in: bounds, afterScreenUpdates: true)
+            }
+            """),
+
+            Example("""
+            let renderer = UIGraphicsImageRenderer(size: newSize)
+            let combined = renderer.image { _ in
+                background.draw(in: CGRect(origin: .zero, size: newSize))
+                watermark.draw(in: CGRect(origin: .zero, size: watermarkSize))
+            }
+            """),
+
+            Example("""
+            UIGraphicsImageRenderer(size: newSize, format: UIGraphicsImageRendererFormat()).image { _ in
+                image.draw(in: CGRect(origin: .zero, size: newSize))
+            }
+            """),
+        ],
+        triggeringExamples: [
+            Example("""
+            ↓UIGraphicsBeginImageContext(newSize)
+            myUIView.drawHierarchy(in: bounds, afterScreenUpdates: false)
+            let optionalScreenshot = ↓UIGraphicsGetImageFromCurrentImageContext()
+            ↓UIGraphicsEndImageContext()
+            """),
+
+            Example("""
+            ↓UIGraphicsBeginImageContext(newSize)
+            background.draw(in: CGRect(origin: .zero, size: newSize))
+            watermark.draw(in: CGRect(origin: .zero, size: watermarkSize))
+            let optionalOutput = ↓UIGraphicsGetImageFromCurrentImageContext()
+            ↓UIGraphicsEndImageContext()
+            """),
+
+            Example("""
+            ↓UIGraphicsBeginImageContextWithOptions(newSize, true, 1.0)
+            image.draw(in: CGRect(origin: .zero, size: newSize))
+            let optionalOutput = ↓UIGraphicsGetImageFromCurrentImageContext()
+            ↓UIGraphicsEndImageContext()
+            """),
+        ]
+    )
+}
+
+private extension LegacyUIGraphicsFunctionRule {
+    final class Visitor: LegacyFunctionVisitor<ConfigurationType> {
+        private static let legacyUIGraphicsFunctions: [String: LegacyFunctionRewriteStrategy] = [
+            "UIGraphicsBeginImageContext": .noRewrite,
+            "UIGraphicsBeginImageContextWithOptions": .noRewrite,
+            "UIGraphicsGetImageFromCurrentImageContext": .noRewrite,
+            "UIGraphicsEndImageContext": .noRewrite,
+        ]
+
+        init(configuration: ConfigurationType, file: SwiftLintFile) {
+            super.init(configuration: configuration, file: file, legacyFunctions: Self.legacyUIGraphicsFunctions)
+        }
+    }
+}

--- a/Source/SwiftLintCore/Visitors/LegacyFunctionVisitor+Rewriter.swift
+++ b/Source/SwiftLintCore/Visitors/LegacyFunctionVisitor+Rewriter.swift
@@ -27,7 +27,9 @@ open class LegacyFunctionVisitor<Configuration: RuleConfiguration>: ViolationsSy
 }
 
 /// Strategy to apply when rewriting a legacy function call.
-public enum LegacyFunctionRewriteStrategy: Sendable {
+public enum LegacyFunctionRewriteStrategy: Equatable, Sendable {
+    /// Don't rewrite the function call, just report it as a violation.
+    case noRewrite
     /// Replace with equality check between the two arguments.
     case equal
     /// Replace with property access with name ``name`` on the argument.
@@ -39,6 +41,7 @@ public enum LegacyFunctionRewriteStrategy: Sendable {
 
     fileprivate var expectedInitialArguments: Int {
         switch self {
+        case .noRewrite: -1
         case .equal: 2
         case .property: 1
         case .function(name: _, argumentLabels: let argumentLabels, reversed: _): argumentLabels.count + 1
@@ -84,7 +87,7 @@ open class LegacyFunctionRewriter<Configuration: RuleConfiguration>: ViolationsS
                 .map { $0.isEmpty ? "\($1)" : "\($0): \($1)" }
                 .joined(separator: ", ")
             expr = "\(arguments[0]).\(raw: functionName)(\(raw: params))"
-        case .none:
+        case .none, .noRewrite:
             return super.visit(node)
         }
 
@@ -97,11 +100,10 @@ open class LegacyFunctionRewriter<Configuration: RuleConfiguration>: ViolationsS
 private extension FunctionCallExprSyntax {
     func isLegacyFunctionExpression(legacyFunctions: [String: LegacyFunctionRewriteStrategy]) -> Bool {
         guard let calledExpression = calledExpression.as(DeclReferenceExprSyntax.self),
-              let rewriteStrategy = legacyFunctions[calledExpression.baseName.text],
-              arguments.count == rewriteStrategy.expectedInitialArguments else {
+              let rewriteStrategy = legacyFunctions[calledExpression.baseName.text] else {
             return false
         }
-        return true
+        return rewriteStrategy == .noRewrite || arguments.count == rewriteStrategy.expectedInitialArguments
     }
 }
 

--- a/Tests/GeneratedTests/GeneratedTests_05.swift
+++ b/Tests/GeneratedTests/GeneratedTests_05.swift
@@ -55,6 +55,12 @@ final class LegacyRandomRuleGeneratedTests: SwiftLintTestCase {
     }
 }
 
+final class LegacyUIGraphicsFunctionRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(LegacyUIGraphicsFunctionRule.description)
+    }
+}
+
 final class LetVarWhitespaceRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(LetVarWhitespaceRule.description)
@@ -148,11 +154,5 @@ final class MultilineParametersRuleGeneratedTests: SwiftLintTestCase {
 final class MultipleClosuresWithTrailingClosureRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(MultipleClosuresWithTrailingClosureRule.description)
-    }
-}
-
-final class NSLocalizedStringKeyRuleGeneratedTests: SwiftLintTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(NSLocalizedStringKeyRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_06.swift
+++ b/Tests/GeneratedTests/GeneratedTests_06.swift
@@ -7,6 +7,12 @@
 @testable import SwiftLintCore
 import TestHelpers
 
+final class NSLocalizedStringKeyRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(NSLocalizedStringKeyRule.description)
+    }
+}
+
 final class NSLocalizedStringRequireBundleRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(NSLocalizedStringRequireBundleRule.description)
@@ -148,11 +154,5 @@ final class OverriddenSuperCallRuleGeneratedTests: SwiftLintTestCase {
 final class OverrideInExtensionRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(OverrideInExtensionRule.description)
-    }
-}
-
-final class PatternMatchingKeywordsRuleGeneratedTests: SwiftLintTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(PatternMatchingKeywordsRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_07.swift
+++ b/Tests/GeneratedTests/GeneratedTests_07.swift
@@ -7,6 +7,12 @@
 @testable import SwiftLintCore
 import TestHelpers
 
+final class PatternMatchingKeywordsRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(PatternMatchingKeywordsRule.description)
+    }
+}
+
 final class PeriodSpacingRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(PeriodSpacingRule.description)
@@ -148,11 +154,5 @@ final class RawValueForCamelCasedCodableEnumRuleGeneratedTests: SwiftLintTestCas
 final class ReduceBooleanRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ReduceBooleanRule.description)
-    }
-}
-
-final class ReduceIntoRuleGeneratedTests: SwiftLintTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(ReduceIntoRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_08.swift
+++ b/Tests/GeneratedTests/GeneratedTests_08.swift
@@ -7,6 +7,12 @@
 @testable import SwiftLintCore
 import TestHelpers
 
+final class ReduceIntoRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(ReduceIntoRule.description)
+    }
+}
+
 final class RedundantDiscardableLetRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(RedundantDiscardableLetRule.description)
@@ -148,11 +154,5 @@ final class SortedImportsRuleGeneratedTests: SwiftLintTestCase {
 final class StatementPositionRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(StatementPositionRule.description)
-    }
-}
-
-final class StaticOperatorRuleGeneratedTests: SwiftLintTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(StaticOperatorRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_09.swift
+++ b/Tests/GeneratedTests/GeneratedTests_09.swift
@@ -7,6 +7,12 @@
 @testable import SwiftLintCore
 import TestHelpers
 
+final class StaticOperatorRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(StaticOperatorRule.description)
+    }
+}
+
 final class StaticOverFinalClassRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(StaticOverFinalClassRule.description)
@@ -148,11 +154,5 @@ final class UnneededBreakInSwitchRuleGeneratedTests: SwiftLintTestCase {
 final class UnneededEscapingRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(UnneededEscapingRule.description)
-    }
-}
-
-final class UnneededOverrideRuleGeneratedTests: SwiftLintTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(UnneededOverrideRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_10.swift
+++ b/Tests/GeneratedTests/GeneratedTests_10.swift
@@ -7,6 +7,12 @@
 @testable import SwiftLintCore
 import TestHelpers
 
+final class UnneededOverrideRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(UnneededOverrideRule.description)
+    }
+}
+
 final class UnneededParenthesesInClosureArgumentRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(UnneededParenthesesInClosureArgumentRule.description)
@@ -148,11 +154,5 @@ final class VoidReturnRuleGeneratedTests: SwiftLintTestCase {
 final class WeakDelegateRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(WeakDelegateRule.description)
-    }
-}
-
-final class XCTFailMessageRuleGeneratedTests: SwiftLintTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(XCTFailMessageRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_11.swift
+++ b/Tests/GeneratedTests/GeneratedTests_11.swift
@@ -7,6 +7,12 @@
 @testable import SwiftLintCore
 import TestHelpers
 
+final class XCTFailMessageRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(XCTFailMessageRule.description)
+    }
+}
+
 final class XCTSpecificMatcherRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(XCTSpecificMatcherRule.description)

--- a/Tests/IntegrationTests/Resources/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/Resources/default_rule_configurations.yml
@@ -628,6 +628,11 @@ legacy_random:
   meta:
     opt-in: false
     correctable: false
+legacy_uigraphics_function:
+  severity: warning
+  meta:
+    opt-in: true
+    correctable: false
 let_var_whitespace:
   severity: warning
   meta:


### PR DESCRIPTION
Add new `legacy_uigraphics_functions` rule to encourage the use of modern UIGraphicsImageRenderer instead of legacy UIGraphics{Begin|End}ImageContext.

The modern replacement is safer, cleaner, Retina-aware and more performant.
The legacy API is deprecated

Resolves [#6268](https://github.com/realm/SwiftLint/issues/6268)