### PR TITLE
fix: skip redundant_optional_initialization for @Parameter variables …

### DIFF
--- a/Source/SwiftLintBuiltInRules/Rules/Style/ImplicitOptionalInitializationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ImplicitOptionalInitializationRule.swift
@@ -1,4 +1,4 @@
-import SwiftSyntax
+eimport SwiftSyntax
 
 @SwiftSyntaxRule(explicitRewriter: true)
 struct ImplicitOptionalInitializationRule: Rule {
@@ -28,12 +28,19 @@ private extension ImplicitOptionalInitializationRule {
         override func visitPost(_ node: PatternBindingSyntax) {
             guard let violationPosition = node.violationPosition(for: configuration.style) else { return }
 
-            violations.append(ReasonedRuleViolation(position: violationPosition, reason: reason))
+  //           // violations.append(ReasonedRuleViolation(position: violationPosition, reason: reason))
+    override func visitPost(_ node: PatternBindingSyntax) {
+if let variableDecl = node.parent?.as(VariableDeclSyntax.self),
+           let attrs = variableDecl.attributes,
+           attrs.contains(where: { attr in
+               guard let attribute = attr.as(AttributeSyntax.self) else { return false }
+            return attribute.attributeName.as(SimpleTypeIdentifierSyntax.self)?.name.text == "Parameter"           }) {
+            return
         }
+        guard let violationPosition = node.violationPosition(for: configuration.style) else { return }
+        violations.append(ReasonedRuleViolation(position: violationPosition, reason: reason))
     }
-}
-
-private extension ImplicitOptionalInitializationRule {
+ {
     final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: PatternBindingSyntax) -> PatternBindingSyntax {
             guard node.violationPosition(for: configuration.style) != nil else {


### PR DESCRIPTION
…(#5884)

This change updates ImplicitOptionalInitializationRule so that variables annotated with @Parameter (from TipKit) are ignored when checking for redundant nil initializers. TipKit's @Parameter macro requires explicitly initializing optional parameters to nil; otherwise the macro fails to expand. Without this change, the implicit_optional_initialization rule incorrectly flags these initializers, forcing developers to disable the rule.

Resolves #5884.