### PR TITLE
Introduce mimalloc to static Linux binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,7 +175,9 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ matrix.artifact_name }}
-          path: ${{ env.BINARY_PATH }}
+          path: |
+            ${{ env.BINARY_PATH }}
+            mimalloc-build/LICENSE
 
   build-macos:
     name: Build macOS Binaries
@@ -231,6 +233,9 @@ jobs:
           mv -f swiftlint-linux-arm64/swiftlint swiftlint_linux_arm64
           mv -f swiftlint-static-amd64/swiftlint swiftlint_static_amd64
           mv -f swiftlint-static-arm64/swiftlint swiftlint_static_arm64
+
+          # Just pick one of the licenses.
+          mv -f swiftlint-static-amd64/LICENSE LICENSE.mimalloc
       - name: Make binaries executable
         run: chmod +x swiftlint*
       - name: Create artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
   [#6161](https://github.com/realm/SwiftLint/issues/6161)
 
 * Adopt [mimalloc](https://github.com/microsoft/mimalloc) for static Linux binary
-  to improve performance.
+  to improve performance.  
   [ainame](https://github.com/ainame)
   [#6298](https://github.com/realm/SwiftLint/issues/6298)
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 TEMPORARY_FOLDER?=/tmp/SwiftLint.dst
 PREFIX?=/usr/local
 BUILD_TOOL?=xcodebuild
-MIMALLOC_VERSION?=3.0.10
 
 XCODEFLAGS=-scheme 'swiftlint' \
 	-destination 'platform=macOS' \
@@ -120,12 +119,11 @@ zip_linux_release: swiftlint_linux_amd64 swiftlint_linux_arm64 swiftlint_static_
 	$(eval TMP_FOLDER := $(shell mktemp -d))
 	cp -f swiftlint_linux_amd64 "$(TMP_FOLDER)/swiftlint"
 	cp -f swiftlint_static_amd64 "$(TMP_FOLDER)/swiftlint-static"
-	cp -f LICENSE "$(TMP_FOLDER)"
-	curl -sSfL "https://github.com/microsoft/mimalloc/archive/refs/tags/v$(MIMALLOC_VERSION).tar.gz" | tar xzO "mimalloc-$(MIMALLOC_VERSION)/LICENSE" > "$(TMP_FOLDER)/mimalloc-LICENSE"
-	(cd "$(TMP_FOLDER)"; zip -yr - "swiftlint" "swiftlint-static" "LICENSE" "mimalloc-LICENSE") > "./swiftlint_linux_amd64.zip"
+	cp -f LICENSE LICENSE.mimalloc "$(TMP_FOLDER)"
+	(cd "$(TMP_FOLDER)"; zip -yr - "swiftlint" "swiftlint-static" "LICENSE" "LICENSE.mimalloc") > "./swiftlint_linux_amd64.zip"
 	cp -f swiftlint_linux_arm64 "$(TMP_FOLDER)/swiftlint"
 	cp -f swiftlint_static_arm64 "$(TMP_FOLDER)/swiftlint-static"
-	(cd "$(TMP_FOLDER)"; zip -yr - "swiftlint" "swiftlint-static" "LICENSE" "mimalloc-LICENSE") > "./swiftlint_linux_arm64.zip"
+	(cd "$(TMP_FOLDER)"; zip -yr - "swiftlint" "swiftlint-static" "LICENSE" "LICENSE.mimalloc") > "./swiftlint_linux_arm64.zip"
 
 package: swiftlint
 	$(eval PACKAGE_ROOT := $(shell mktemp -d))


### PR DESCRIPTION
# Background 

Closes https://github.com/realm/SwiftLint/issues/6298

Currently static Linux binary distributed isn't as performant as expected. This is because `malloc` in musl libc, which is used in Static Linux SDK, doesn't work well with multiple threaded execution. It uses `futex` syscalls to safely access memory, which in turns, decrease performance in multi-threaded env.

https://git.musl-libc.org/cgit/musl/tree/src/thread/__wait.c?h=v1.1.23&id=7e399fabd3db2c528b5982803eeba2841f547695
http://git.musl-libc.org/cgit/musl/tree/src/malloc/malloc.c?h=v1.1.23&id=7e399fabd3db2c528b5982803eeba2841f547695

# What

To address this issue, I introduced mimalloc for static Linux binary in this PR.
https://github.com/microsoft/mimalloc

mimalloc is performant memory allocator written in C that works as drop-in replacement for `malloc` and supports builds for musl. Compared with other popular allocators like jemalloc or tcmalloc, It think it's fair option. Also, in Swift compiler project (swiftlang/swift), mimaloc has been adopted for the allocator in Windows's toolchain (not runtime!). 
 
https://forums.swift.org/t/se-454-adopt-mimalloc-for-windows-toolchain/

# How 

Since mimalloc is only necessary when building static Linux binary, I added a new step that compiles `libmimalloc.a` to `release.yml` and updated `swift build` command.

```
swift build \
    -c release \
    --product swiftlint \
    --swift-sdk ${{ matrix.swift_sdk }} \
    -Xswiftc -DSWIFTLINT_DISABLE_SOURCEKIT \
    -Xlinker -z -Xlinker stack-size=0x80000 \
    -Xlinker --whole-archive \
    -Xlinker $(pwd)/libmimalloc.a \
    -Xlinker --no-whole-archive
```

The mimalloc README recommends placing mimalloc.o (instead of the .a) at the very beginning of the linker input so its malloc overrides the standard one. With swift build, we can’t reliably force an absolute “first” position.
https://github.com/microsoft/mimalloc?tab=readme-ov-file#static-override

As a practical alternative, I link against libmimalloc.a and wrap it with --whole-archive/--no-whole-archive so all relevant objects are included, provided the library is built with the malloc override enabled. To be fair, the .o approach works fine for now. I just wanted to make sure it will keep linking correctly in the future.

Since mimalloc is MIT license, I've also updated `Makefile` to include mimalloc's license file into the zip files for Linux binary.  `third_party_licenses/mimalloc-LICENSE` is now bundled in repo.

# Test

## GitHub Actions

I ran release.yml on my fork and worked successfully.
https://github.com/ainame/SwiftLint/actions/runs/18823390591 

## Artefacts 

It runs faster with mimalloc. 

[swiftlint-static-arm64](https://github.com/ainame/SwiftLint/actions/runs/18823390591/artifacts/4375891318) with mimalloc from https://github.com/ainame/SwiftLint/actions/runs/18823390591

```
ainame@ainame-vm:~/repos/SwiftLint$ time /home/ainame/Downloads/swiftlint-static-arm64/swiftlint . --no-cache
Linting Swift files at paths .
Linting 'Path+Helpers.swift' (1/670)
...
real	0m1.342s
user	0m6.289s
sys	0m0.088s
```

[swiftlint-static-arm64](https://github.com/ainame/SwiftLint/actions/runs/18819592629/artifacts/4374908255) built from main branch synced with upstream from https://github.com/ainame/SwiftLint/actions/runs/18819592629/artifacts/4374908255

```
ainame@ainame-vm:~/repos/SwiftLint$ time '/home/ainame/Downloads/swiftlint-static-arm64(1)/swiftlint' . --no-cache
Linting Swift files at paths .
Linting 'Path+Helpers.swift' (1/670)
Linting 'SwiftLintCommandPlugin.swift' (2/670)
....
real	0m4.445s
user	0m14.040s
sys	0m9.510s
```

## Symbols

`nm` suggests that malloc/free/calloc/realloc are resolved from mimalloc. They are defined in the final binary (symbol type T).

```
ainame@ainame-vm:~/repos/SwiftLint$ nm -C --defined-only .build/aarch64-swift-linux-musl/release/swiftlint | grep --color=auto -E "(T|W) (malloc|free|calloc|realloc)$"
0000000002878df0 T calloc
0000000002877de0 T free
0000000002878b70 T malloc
0000000002879870 T realloc
```