### PR TITLE
Replace colon with underscore in caching filePath (and a few other characters)

### DIFF
--- a/Source/SwiftLintFramework/Configuration/Configuration+Remote.swift
+++ b/Source/SwiftLintFramework/Configuration/Configuration+Remote.swift
@@ -200,9 +200,12 @@ internal extension Configuration.FileGraph.FilePath {
     }
 
     private func filePath(for urlString: String, rootDirectory: String) -> String {
-        let adjustedUrlString = urlString
-            .replacingOccurrences(of: "/", with: "_")
-            .replacingOccurrences(of: ":", with: "_")
+        let invalidCharacters = [":", "<", ">", "\"", "/", "\\", "|", "?", "*"]
+        var adjustedUrlString = urlString
+        for char in invalidCharacters {
+            adjustedUrlString = adjustedUrlString.replacingOccurrences(of: char, with: "_")
+        }
+        adjustedUrlString = adjustedUrlString.trimmingCharacters(in: CharacterSet(charactersIn: "."))
         let path = Configuration.FileGraph.FilePath.versionedRemoteCachePath + "/\(adjustedUrlString).yml"
         return path.bridge().absolutePathRepresentation(rootDirectory: rootDirectory)
     }


### PR DESCRIPTION
Without this we end up with a file name `http__:site` which doesn't work on Windows and crashes `ConfigurationTests.testValidRemoteChildConfig` with abort() which fast-exits resulting in partial test results
```
Subcode: 0x7 FAST_FAIL_FATAL_APP_EXIT 
ucrtbase!abort+0x4e
```

With this change I'm able to run swift test on Windows to completion (x64 6.2.1):
```
Test Suite 'All tests' failed at 2025-11-24 18:23:31.026
         Executed 1025 tests, with 91 failures (1 unexpected) in 365.412 (365.412) seconds
```

cc @compnerd 