### PR TITLE
Warn about missing explicit target dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ spm_build_plugins:
 	swift build -c release --product SwiftLintBuildToolPlugin
 
 spm_test:
-	swift test --parallel -Xswiftc -DDISABLE_FOCUSED_EXAMPLES
+	swift test --parallel --explicit-target-dependency-import-check warn -Xswiftc -DDISABLE_FOCUSED_EXAMPLES
 
 write_xcodebuild_log:
 	xcodebuild -scheme swiftlint clean build-for-testing -destination "platform=macOS" > xcodebuild.log


### PR DESCRIPTION
Don't err as `SwiftWarningControl` would currently cause a failure.