### PR TITLE
Chore: add `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.swift]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
Adds a barebones `.editorconfig` file so I can edit the swift code without the indentation changing because my Xcode settings are different to what is used for this project.