### PR TITLE
Keep closures assigned to wildcard variables as non-escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@
 
 ### Enhancements
 
-* None.
+* Do not consider closures assigned to wildcard variables (`_`) as captures
+  of escaping closures in `unneeded_escaping` rule.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#6385](https://github.com/realm/SwiftLint/issues/6385)
 
 ### Bug Fixes
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnneededEscapingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnneededEscapingRule.swift
@@ -150,6 +150,11 @@ struct UnneededEscapingRule: Rule {
                 local()
             }
             """),
+            Example("""
+            func assignToLocal(completion: ↓@escaping () -> Void) {
+                _ = completion
+            }
+            """),
         ],
         corrections: [
             Example("""
@@ -344,6 +349,9 @@ private extension ExprSyntax {
     }
 
     var isLocalVariable: Bool {
+        guard !`is`(DiscardAssignmentExprSyntax.self) else {
+            return true
+        }
         if let baseNameToken {
             let results = lookup(.init(baseNameToken))
             return results.isNotEmpty && results.allSatisfy {


### PR DESCRIPTION
Resolves #6385.