### PR TITLE
Keep unwrapped `self` in extensions for optional types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@
 
 ### Bug Fixes
 
+* Keep `self` in extensions for optional types in `redundant_self` rule
+  when the optional instance was unwrapped somewhere in the current scope.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#6390](https://github.com/realm/SwiftLint/issues/6390)
+
 * Treat closures in the branches of ternary expressions as escaping
   when the whole expression is escaping in the `unneeded_escaping` rule.  
   [SimplyDanny](https://github.com/SimplyDanny)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/RedundantSelfRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/RedundantSelfRuleExamples.swift
@@ -102,6 +102,14 @@ struct RedundantSelfRuleExamples {
                 }
             }
             """, configuration: ["keep_in_initializers": true]),
+        Example("""
+            extension String? {
+                func foo() -> String {
+                    guard let self else { return "" }
+                    return self.uppercased()
+                }
+            }
+            """),
     ]
 
     static let triggeringExamples = [
@@ -238,6 +246,11 @@ struct RedundantSelfRuleExamples {
                 }()
             }
             """, excludeFromDocumentation: true),
+        Example("""
+            extension String {
+                func foo() -> String { ↓self.uppercased() }
+            }
+            """),
     ]
 
     static let corrections = [

--- a/Source/SwiftLintCore/Extensions/SwiftSyntax+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/SwiftSyntax+SwiftLint.swift
@@ -372,6 +372,18 @@ public extension ClosureCaptureSyntax {
     }
 }
 
+public extension TypeSyntax {
+    var isOptionalType: Bool {
+        if `is`(OptionalTypeSyntax.self) {
+            return true
+        }
+        if let type = `as`(IdentifierTypeSyntax.self) {
+            return type.name.text == "Optional" && type.genericArgumentClause?.arguments.count == 1
+        }
+        return false
+    }
+}
+
 private extension String {
     var isZero: Bool {
         if self == "0" { // fast path


### PR DESCRIPTION
Resolves #6390.