### PR TITLE
Add `only_in_closures` option to `redundant_self` to maintain old behavior

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -88,6 +88,7 @@ number_separator:
   minimum_length: 5
 redundant_self:
   keep_in_initializers: true
+  only_in_closures: false
 redundant_type_annotation:
   consider_default_literal_types_redundant: true
 single_test_class: *unit_test_configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,10 @@
 ### Breaking
 
 * The `redundant_self_in_closure` rule has been renamed to `redundant_self` (with
-  `redundant_self_in_closure` as a deprecated alias) to reflect its now broader scope.  
+  `redundant_self_in_closure` as a deprecated alias) to reflect its now broader scope,
+  while by default still maintaining the previous behavior of only checking closures.
+  To enable checking for all redundant `self` usages, set the new `only_in_closures`
+  option to `false`.  
   [SimplyDanny](https://github.com/SimplyDanny)
 
 ### Experimental

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/RedundantSelfConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/RedundantSelfConfiguration.swift
@@ -6,4 +6,6 @@ struct RedundantSelfConfiguration: SeverityBasedRuleConfiguration {
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "keep_in_initializers")
     private(set) var keepInInitializers = false
+    @ConfigurationElement(key: "only_in_closures")
+    private(set) var onlyInClosures = true
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/RedundantSelfRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/RedundantSelfRule.swift
@@ -116,6 +116,9 @@ private extension RedundantSelfRule {
             if closureExprScopes.isNotEmpty, !isSelfRedundant {
                 return
             }
+            if configuration.onlyInClosures, closureExprScopes.isEmpty {
+                return
+            }
             if typeDeclarations.peek() == .extension, node.isBaseSelf, hasSeenDeclaration(for: "self") {
                 return
             }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/RedundantSelfRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/RedundantSelfRuleExamples.swift
@@ -3,6 +3,13 @@ struct RedundantSelfRuleExamples {
         Example("""
             struct S {
                 var x = 0
+                init() { self.x = 1 }
+                func foo() { self.x = 1 }
+            }
+            """),
+        Example("""
+            struct S {
+                var x = 0
                 func f(_ work: @escaping () -> Void) { work() }
                 func g() {
                     f {
@@ -113,6 +120,13 @@ struct RedundantSelfRuleExamples {
     ]
 
     static let triggeringExamples = [
+        Example("""
+            struct S {
+                var x = 0
+                init() { ↓self.x = 1 }
+                func foo() { ↓self.x = 1 }
+            }
+            """, configuration: ["only_in_closures": false]),
         Example("""
             struct S {
                 var x = 0
@@ -250,7 +264,7 @@ struct RedundantSelfRuleExamples {
             extension String {
                 func foo() -> String { ↓self.uppercased() }
             }
-            """),
+            """, configuration: ["only_in_closures": false]),
     ]
 
     static let corrections = [
@@ -285,7 +299,7 @@ struct RedundantSelfRuleExamples {
                     ↓self.y = 1
                 }
             }
-            """): Example("""
+            """, configuration: ["only_in_closures": false]): Example("""
                 struct S {
                     var x = 0, y = 0
                     init(x: Int) {

--- a/Tests/IntegrationTests/Resources/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/Resources/default_rule_configurations.yml
@@ -1017,6 +1017,7 @@ redundant_objc_attribute:
 redundant_self:
   severity: warning
   keep_in_initializers: false
+  only_in_closures: true
   meta:
     opt-in: true
     correctable: true


### PR DESCRIPTION
Resolves #6389.