### PR TITLE
Fix non-excluded bool literal in optional_enum_case_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
   [SimplyDanny](https://github.com/SimplyDanny)
   [#6410](https://github.com/realm/SwiftLint/issues/6410)
 
+* Fix non-excluded bool literal in `optional_enum_case_name` when used inside a tuple.  
+  [tristan-burnside-anz](https://github.com/tristan-burnside-anz)
+
 ## 0.63.0: High-Speed Extraction
 
 ### Breaking

--- a/Source/SwiftLintBuiltInRules/Rules/Style/OptionalEnumCaseMatchingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/OptionalEnumCaseMatchingRule.swift
@@ -151,6 +151,21 @@ struct OptionalEnumCaseMatchingRule: Rule {
              default: break
             }
             """),
+            Example("""
+            switch foo {
+             case (true?, false?): break
+             case (true?, _): break
+             case (_, false?): break
+             default: break
+            }
+            """): Example("""
+            switch foo {
+             case (true?, false?): break
+             case (true?, _): break
+             case (_, false?): break
+             default: break
+            }
+            """),
         ]
     )
 }
@@ -198,7 +213,7 @@ private extension OptionalEnumCaseMatchingRule {
                 for element in expression.elements {
                     guard
                         let optionalChainingExpression = element.expression.as(OptionalChainingExprSyntax.self),
-                        !optionalChainingExpression.expression.is(DiscardAssignmentExprSyntax.self)
+                        !optionalChainingExpression.expression.isDiscardAssignmentOrBoolLiteral
                     else {
                         continue
                     }


### PR DESCRIPTION
When running with `--fix`, this rule would catch:

```
case (true?, false?)
```

but it should not be catching this case, according to the documentation, and it does not report it in lint mode.
