### PR TITLE
Retain `async` initializers in actors in `async_without_await`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
 
 ### Bug Fixes
 
+* Retain `async` initializers in actors in `async_without_await` rule.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#6423](https://github.com/realm/SwiftLint/issues/6423)
+
 * Ignore `override` functions in `async_without_await` rule.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#6416](https://github.com/realm/SwiftLint/issues/6416)

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AsyncWithoutAwaitRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AsyncWithoutAwaitRuleExamples.swift
@@ -1,6 +1,14 @@
 internal struct AsyncWithoutAwaitRuleExamples {
     static let nonTriggeringExamples = [
         Example("""
+        actor A {
+            init() async {
+                foo()
+            }
+            func foo() {}
+        }
+        """),
+        Example("""
         func test() {
             func test() async {
                 await test()


### PR DESCRIPTION
Resolves #6423.