### PR TITLE
Fix multiline_call_arguments with enum-case patterns.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,10 @@
   [SimplyDanny](https://github.com/SimplyDanny)
   [#6080](https://github.com/realm/SwiftLint/issues/6080)
 
+* `multiline_call_arguments` no longer reports violations for enum-case patterns in
+  pattern matching (e.g. if case, switch case, for case, catch).  
+  [GandaLF2006](https://github.com/GandaLF2006)
+
 ## 0.63.2: High-Speed Extraction
 
 ### Breaking

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/MultilineCallArgumentsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/MultilineCallArgumentsRule.swift
@@ -5,105 +5,179 @@ import SwiftSyntax
 struct MultilineCallArgumentsRule: Rule {
     var configuration = MultilineCallArgumentsConfiguration()
 
+    enum Reason {
+        static let singleLineMultipleArgumentsNotAllowed =
+            "Single-line calls with multiple arguments are not allowed"
+
+        static func tooManyArgumentsOnSingleLine(max: Int) -> String {
+            "Too many arguments on a single line (max: \(max))"
+        }
+
+        static let eachArgumentMustStartOnOwnLine =
+            "In multi-line calls, each argument must start on its own line"
+    }
+
     static let description = RuleDescription(
         identifier: "multiline_call_arguments",
         name: "Multiline Call Arguments",
-        description: "Call should have each parameter on a separate line",
+        description: """
+                     Enforces one-argument-per-line for multi-line calls; \
+                     optionally limits or forbids multi-argument single-line calls via configuration
+                     """,
         kind: .style,
-        nonTriggeringExamples: [
-            Example("""
-                foo(
-                param1: "param1",
-                    param2: false,
-                    param3: []
-                )
-                """,
-                configuration: ["max_number_of_single_line_parameters": 2]),
-            Example("""
-                foo(param1: 1,
-                    param2: false,
-                    param3: [])
-                """,
-                configuration: ["max_number_of_single_line_parameters": 1]),
-            Example(
-                "foo(param1: 1, param2: false)",
-                configuration: ["max_number_of_single_line_parameters": 2]),
-            Example(
-                "Enum.foo(param1: 1, param2: false)",
-                configuration: ["max_number_of_single_line_parameters": 2]),
-            Example("foo(param1: 1)", configuration: ["allows_single_line": false]),
-            Example("Enum.foo(param1: 1)", configuration: ["allows_single_line": false]),
-            Example(
-                "Enum.foo(param1: 1, param2: 2, param3: 3)",
-                configuration: ["allows_single_line": true]),
-            Example("""
-                foo(
-                    param1: 1,
-                    param2: 2,
-                    param3: 3
-                )
-                """,
-                configuration: ["allows_single_line": false]),
-        ],
-        triggeringExamples: [
-            Example(
-                "↓foo(param1: 1, param2: false, param3: [])",
-                configuration: ["max_number_of_single_line_parameters": 2]),
-            Example(
-                "↓Enum.foo(param1: 1, param2: false, param3: [])",
-                configuration: ["max_number_of_single_line_parameters": 2]),
-            Example("""
-                ↓foo(param1: 1, param2: false,
-                        param3: [])
-                """,
-                configuration: ["max_number_of_single_line_parameters": 3]),
-            Example("""
-                ↓Enum.foo(param1: 1, param2: false,
-                        param3: [])
-                """,
-                configuration: ["max_number_of_single_line_parameters": 3]),
-            Example("↓foo(param1: 1, param2: false)", configuration: ["allows_single_line": false]),
-            Example("↓Enum.foo(param1: 1, param2: false)", configuration: ["allows_single_line": false]),
-        ]
+        nonTriggeringExamples: MultilineCallArgumentsRuleExamples.nonTriggeringExamples,
+        triggeringExamples: MultilineCallArgumentsRuleExamples.triggeringExamples
     )
 }
 
 private extension MultilineCallArgumentsRule {
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
+        /// Cache line lookups by utf8Offset (stable, cheap key)
+        private var lineCache: [Int: Int] = [:]
+
+        override init(configuration: ConfigurationType, file: SwiftLintFile) {
+            super.init(configuration: configuration, file: file)
+
+            // Most files trigger O(10–100) unique line lookups for this rule.
+            // Reserving a small initial capacity reduces rehashing; it is NOT a hard limit.
+            lineCache.reserveCapacity(64)
+        }
+
         override func visitPost(_ node: FunctionCallExprSyntax) {
-            if containsViolation(parameterPositions: node.arguments.map(\.positionAfterSkippingLeadingTrivia)) {
-                violations.append(node.calledExpression.positionAfterSkippingLeadingTrivia)
-            }
+            // Ignore calls that are part of pattern-matching syntax (patterns only, not bodies).
+            guard !node.isInPatternMatchingPatternPosition else { return }
+
+            let args = node.arguments
+            guard args.count > 1 else { return }
+
+            let argumentPositions = args.map(\.positionAfterSkippingLeadingTrivia)
+            guard let violation = reasonedViolation(argumentPositions: argumentPositions) else { return }
+            violations.append(violation)
         }
 
-        private func containsViolation(parameterPositions: [AbsolutePosition]) -> Bool {
-            var numberOfParameters = 0
-            var linesWithParameters: Set<Int> = []
-            var hasMultipleParametersOnSameLine = false
+        private func reasonedViolation(argumentPositions: [AbsolutePosition]) -> ReasonedRuleViolation? {
+            guard let firstPos = argumentPositions.first else { return nil }
 
-            for position in parameterPositions {
-                let line = locationConverter.location(for: position).line
+            let firstLine = line(for: firstPos)
+            var allOnSameLine = true
 
-                if !linesWithParameters.insert(line).inserted {
-                    hasMultipleParametersOnSameLine = true
-                }
-
-                numberOfParameters += 1
+            for pos in argumentPositions.dropFirst() where line(for: pos) != firstLine {
+                allOnSameLine = false
+                break
             }
 
-            if linesWithParameters.count == 1 {
-                guard configuration.allowsSingleLine else {
-                    return numberOfParameters > 1
+            if allOnSameLine {
+                if !configuration.allowsSingleLine {
+                    return ReasonedRuleViolation(
+                        position: argumentPositions[1],
+                        reason: Reason.singleLineMultipleArgumentsNotAllowed
+                    )
                 }
 
-                if let maxNumberOfSingleLineParameters = configuration.maxNumberOfSingleLineParameters {
-                    return numberOfParameters > maxNumberOfSingleLineParameters
+                if let max = configuration.maxNumberOfSingleLineParameters,
+                   argumentPositions.count > max {
+                    return ReasonedRuleViolation(
+                        position: argumentPositions[max],
+                        reason: Reason.tooManyArgumentsOnSingleLine(max: max)
+                    )
                 }
 
-                return false
+                return nil
             }
 
-            return hasMultipleParametersOnSameLine
+            var seen: Set<Int> = []
+            for pos in argumentPositions {
+                let line = line(for: pos)
+                if !seen.insert(line).inserted {
+                    return ReasonedRuleViolation(
+                        position: pos,
+                        reason: Reason.eachArgumentMustStartOnOwnLine
+                    )
+                }
+            }
+
+            return nil
         }
+
+        private func line(for position: AbsolutePosition) -> Int {
+            let key = position.utf8Offset
+            if let cached = lineCache[key] { return cached }
+            let line = locationConverter.location(for: position).line
+            lineCache[key] = line
+            return line
+        }
+    }
+}
+
+// MARK: - Pattern filtering (precise, pattern-part only)
+
+private extension FunctionCallExprSyntax {
+    /// `true` only when this FunctionCall is used inside a *pattern* (e.g. `.caseOne(...)`),
+    /// not just somewhere inside `if case` / `switch case` bodies.
+    var isInPatternMatchingPatternPosition: Bool {
+        let selfSyntax = Syntax(self)
+        var current: Syntax? = parent
+
+        // Low-level pattern nodes can appear inside multiple contexts; we only need to check each once.
+        var checkedExpressionPattern = false
+        var checkedValueBindingPattern = false
+
+        while let node = current {
+            if !checkedExpressionPattern, let expressionPattern = node.as(ExpressionPatternSyntax.self) {
+                checkedExpressionPattern = true
+                if selfSyntax.isInside(Syntax(expressionPattern.expression)) { return true }
+            }
+
+            if !checkedValueBindingPattern, let valueBindingPattern = node.as(ValueBindingPatternSyntax.self) {
+                checkedValueBindingPattern = true
+                if selfSyntax.isInside(Syntax(valueBindingPattern.pattern)) { return true }
+            }
+
+            // Once we reach a *top-level* pattern container (if/switch/for/catch),
+            // we can safely stop walking up the parent chain after checking its pattern subtree.
+
+            if let condition = node.as(MatchingPatternConditionSyntax.self) {
+                if selfSyntax.isInside(Syntax(condition.pattern)) { return true }
+                break
+            }
+
+            if let caseItem = node.as(SwitchCaseItemSyntax.self) {
+                if selfSyntax.isInside(Syntax(caseItem.pattern)) { return true }
+                break
+            }
+
+            if let forStmt = node.as(ForStmtSyntax.self) {
+                if selfSyntax.isInside(Syntax(forStmt.pattern)) { return true }
+                break
+            }
+
+            if let catchClause = node.as(CatchClauseSyntax.self) {
+                for item in catchClause.catchItems {
+                    if let pattern = item.pattern,
+                       selfSyntax.isInside(Syntax(pattern)) {
+                        return true
+                    }
+                }
+                break
+            }
+
+            current = node.parent
+        }
+
+        return false
+    }
+}
+
+// MARK: - Generic helpers
+
+private extension Syntax {
+    /// Returns `true` if `self` is the `ancestor` node itself or is located inside its subtree.
+    func isInside(_ ancestor: Syntax) -> Bool {
+        var current: Syntax? = self
+        while let node = current {
+            if node.id == ancestor.id { return true }
+            current = node.parent
+        }
+        return false
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/MultilineCallArgumentsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/MultilineCallArgumentsRule.swift
@@ -15,15 +15,19 @@ struct MultilineCallArgumentsRule: Rule {
 
         static let eachArgumentMustStartOnOwnLine =
             "In multi-line calls, each argument must start on its own line"
+
+        static let newlineRequiredAfterCommaInMultilineCall =
+            "In multi-line calls, a newline is required after each comma"
     }
 
     static let description = RuleDescription(
         identifier: "multiline_call_arguments",
         name: "Multiline Call Arguments",
         description: """
-                     Enforces one-argument-per-line for multi-line calls; \
-                     optionally limits or forbids multi-argument single-line calls via configuration
-                     """,
+        Enforces one-argument-per-line for multi-line calls and requires a newline after commas \
+        when arguments are split across lines;
+        optionally limits or forbids multi-argument single-line calls via configuration.
+        """,
         kind: .style,
         nonTriggeringExamples: MultilineCallArgumentsRuleExamples.nonTriggeringExamples,
         triggeringExamples: MultilineCallArgumentsRuleExamples.triggeringExamples
@@ -51,16 +55,20 @@ private extension MultilineCallArgumentsRule {
             guard args.count > 1 else { return }
 
             let argumentPositions = args.map(\.positionAfterSkippingLeadingTrivia)
-            guard let violation = reasonedViolation(argumentPositions: argumentPositions) else { return }
+            guard let violation = reasonedViolation(argumentPositions: argumentPositions, arguments: args) else {
+                return
+            }
             violations.append(violation)
         }
 
-        private func reasonedViolation(argumentPositions: [AbsolutePosition]) -> ReasonedRuleViolation? {
+        private func reasonedViolation(
+            argumentPositions: [AbsolutePosition],
+            arguments: LabeledExprListSyntax
+        ) -> ReasonedRuleViolation? {
             guard let firstPos = argumentPositions.first else { return nil }
 
             let firstLine = line(for: firstPos)
             var allOnSameLine = true
-
             for pos in argumentPositions.dropFirst() where line(for: pos) != firstLine {
                 allOnSameLine = false
                 break
@@ -85,18 +93,79 @@ private extension MultilineCallArgumentsRule {
                 return nil
             }
 
+            if let startLineViolation = duplicateArgumentStartLineViolation(in: arguments) {
+                return startLineViolation
+            }
+
+            if let commaViolation = newlineAfterCommaViolation(in: arguments) {
+                return commaViolation
+            }
+
+            return nil
+        }
+
+        private func duplicateArgumentStartLineViolation(
+            in arguments: LabeledExprListSyntax
+        ) -> ReasonedRuleViolation? {
+            let args = Array(arguments)
+            guard args.count > 1 else { return nil }
+
             var seen: Set<Int> = []
-            for pos in argumentPositions {
-                let line = line(for: pos)
+            for arg in args {
+                let startPos = startPosition(of: arg)
+                let line = line(for: startPos)
                 if !seen.insert(line).inserted {
                     return ReasonedRuleViolation(
-                        position: pos,
+                        position: startPos,
                         reason: Reason.eachArgumentMustStartOnOwnLine
                     )
                 }
             }
 
             return nil
+        }
+
+        private func newlineAfterCommaViolation(in arguments: LabeledExprListSyntax) -> ReasonedRuleViolation? {
+            let args = Array(arguments)
+            guard args.count > 1 else { return nil }
+
+            for index in args.indices.dropLast() {
+                let current = args[index]
+                let next = args[index + 1]
+
+                guard let comma = current.trailingComma, comma.presence != .missing else { continue }
+
+                if let lastToken = current.expression.lastToken(viewMode: .sourceAccurate) {
+                    switch lastToken.tokenKind {
+                    case .rightBrace,
+                        .rightSquare:
+                        continue
+                    default:
+                        break
+                    }
+                }
+
+                let commaLine = line(for: comma.positionAfterSkippingLeadingTrivia)
+                let currentStartLine = line(for: startPosition(of: current))
+                let nextStartPos = startPosition(of: next)
+                let nextStartLine = line(for: nextStartPos)
+
+                if commaLine == nextStartLine, currentStartLine != nextStartLine {
+                    return ReasonedRuleViolation(
+                        position: nextStartPos,
+                        reason: Reason.newlineRequiredAfterCommaInMultilineCall
+                    )
+                }
+            }
+
+            return nil
+        }
+
+        private func startPosition(of argument: LabeledExprSyntax) -> AbsolutePosition {
+            if let label = argument.label, label.presence != .missing {
+                return label.positionAfterSkippingLeadingTrivia
+            }
+            return argument.expression.positionAfterSkippingLeadingTrivia
         }
 
         private func line(for position: AbsolutePosition) -> Int {
@@ -118,7 +187,6 @@ private extension FunctionCallExprSyntax {
         let selfSyntax = Syntax(self)
         var current: Syntax? = parent
 
-        // Low-level pattern nodes can appear inside multiple contexts; we only need to check each once.
         var checkedExpressionPattern = false
         var checkedValueBindingPattern = false
 
@@ -132,9 +200,6 @@ private extension FunctionCallExprSyntax {
                 checkedValueBindingPattern = true
                 if selfSyntax.isInside(Syntax(valueBindingPattern.pattern)) { return true }
             }
-
-            // Once we reach a *top-level* pattern container (if/switch/for/catch),
-            // we can safely stop walking up the parent chain after checking its pattern subtree.
 
             if let condition = node.as(MatchingPatternConditionSyntax.self) {
                 if selfSyntax.isInside(Syntax(condition.pattern)) { return true }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/MultilineCallArgumentsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/MultilineCallArgumentsRule.swift
@@ -178,71 +178,15 @@ private extension MultilineCallArgumentsRule {
     }
 }
 
-// MARK: - Pattern filtering (precise, pattern-part only)
-
 private extension FunctionCallExprSyntax {
-    /// `true` only when this FunctionCall is used inside a *pattern* (e.g. `.caseOne(...)`),
-    /// not just somewhere inside `if case` / `switch case` bodies.
+    /// Returns `true` if this call appears in a pattern position (e.g., `case .foo(a)`).
+    ///
+    /// Works because SwiftSyntax wraps pattern expressions in `ExpressionPatternSyntax`:
+    /// - `if case let .foo(a) = x` → parent is ExpressionPatternSyntax
+    /// - `switch x { case let .foo(a): }` → parent is ExpressionPatternSyntax
+    /// - `for case let .foo(a) in items` → parent is ExpressionPatternSyntax
+    /// - `catch .foo(1, 2)` → parent is ExpressionPatternSyntax
     var isInPatternMatchingPatternPosition: Bool {
-        let selfSyntax = Syntax(self)
-        var current: Syntax? = parent
-
-        var checkedExpressionPattern = false
-        var checkedValueBindingPattern = false
-
-        while let node = current {
-            if !checkedExpressionPattern, let expressionPattern = node.as(ExpressionPatternSyntax.self) {
-                checkedExpressionPattern = true
-                if selfSyntax.isInside(Syntax(expressionPattern.expression)) { return true }
-            }
-
-            if !checkedValueBindingPattern, let valueBindingPattern = node.as(ValueBindingPatternSyntax.self) {
-                checkedValueBindingPattern = true
-                if selfSyntax.isInside(Syntax(valueBindingPattern.pattern)) { return true }
-            }
-
-            if let condition = node.as(MatchingPatternConditionSyntax.self) {
-                if selfSyntax.isInside(Syntax(condition.pattern)) { return true }
-                break
-            }
-
-            if let caseItem = node.as(SwitchCaseItemSyntax.self) {
-                if selfSyntax.isInside(Syntax(caseItem.pattern)) { return true }
-                break
-            }
-
-            if let forStmt = node.as(ForStmtSyntax.self) {
-                if selfSyntax.isInside(Syntax(forStmt.pattern)) { return true }
-                break
-            }
-
-            if let catchClause = node.as(CatchClauseSyntax.self) {
-                for item in catchClause.catchItems {
-                    if let pattern = item.pattern,
-                       selfSyntax.isInside(Syntax(pattern)) {
-                        return true
-                    }
-                }
-                break
-            }
-
-            current = node.parent
-        }
-
-        return false
-    }
-}
-
-// MARK: - Generic helpers
-
-private extension Syntax {
-    /// Returns `true` if `self` is the `ancestor` node itself or is located inside its subtree.
-    func isInside(_ ancestor: Syntax) -> Bool {
-        var current: Syntax? = self
-        while let node = current {
-            if node.id == ancestor.id { return true }
-            current = node.parent
-        }
-        return false
+        parent?.is(ExpressionPatternSyntax.self) == true
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/MultilineCallArgumentsRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/MultilineCallArgumentsRuleExamples.swift
@@ -1,0 +1,510 @@
+// swiftlint:disable file_length
+// swiftlint:disable type_body_length
+internal struct MultilineCallArgumentsRuleExamples {
+    static let nonTriggeringExamples: [Example] = [
+        // MARK: - Baseline: multi-line OK
+        Example("""
+            foo(param1: 1,
+                param2: false,
+                param3: [])
+            """,
+                configuration: ["max_number_of_single_line_parameters": 1]
+               ),
+        Example("""
+            foo(
+                param1: 1,
+                param2: 2,
+                param3: 3
+            )
+            """,
+                configuration: ["allows_single_line": false]
+               ),
+
+        // MARK: - Baseline: single-line OK
+        Example(
+            "foo(param1: 1, param2: false)",
+            configuration: ["max_number_of_single_line_parameters": 2]
+        ),
+        Example(
+            "Enum.foo(param1: 1, param2: false)",
+            configuration: ["max_number_of_single_line_parameters": 2]
+        ),
+
+        // allows_single_line=false does NOT affect 0/1-arg calls
+        Example("foo()", configuration: ["allows_single_line": false]),
+        Example("foo(param1: 1)", configuration: ["allows_single_line": false]),
+        Example("Enum.foo(param1: 1)", configuration: ["allows_single_line": false]),
+
+        // MARK: - Unlabeled / mixed arguments
+        Example("foo(1, 2)", configuration: ["max_number_of_single_line_parameters": 2]),
+        Example("foo(1, b: 2)", configuration: ["max_number_of_single_line_parameters": 2]),
+        Example("foo(1, b: 2, c: 3)", configuration: ["max_number_of_single_line_parameters": 3]),
+
+        // MARK: - Enum-case constructor calls are normal calls (stable by declaring the enum)
+        Example("""
+            enum EnumCase {
+                case first(one: Int, two: Int, three: Int, four: Int)
+            }
+            EnumCase.first(one: 1, two: 2, three: 3, four: 4)
+            """,
+                configuration: ["allows_single_line": true]
+               ),
+        Example("""
+            enum EnumCase {
+                case first(one: Int, two: Int, three: Int, four: Int)
+            }
+            let test = EnumCase.first(
+                one: 1,
+                two: 2,
+                three: 3,
+                four: 4
+            )
+            """,
+                configuration: ["allows_single_line": false]
+               ),
+
+        // MARK: - Trailing closures are ignored by this rule (args-only)
+        // Single-line args still use max_number_of_single_line_parameters
+        Example("""
+            foo(a: 1, b: 2) { value in
+                print(value)
+            }
+            """,
+                configuration: ["max_number_of_single_line_parameters": 2]
+               ),
+        // Multi-line args remain valid regardless of closure placement
+        Example("""
+            foo(
+                a: 1,
+                b: 2
+            ) { value in
+                print(value)
+            }
+            """,
+                configuration: ["allows_single_line": false]
+               ),
+        Example("""
+            foo(
+                a: 1,
+                b: 2
+            )
+            { value in
+                print(value)
+            }
+            """,
+                configuration: ["allows_single_line": false]
+               ),
+        // No-parens form: no arguments list -> never violates
+        Example("""
+            foo { value in
+                print(value)
+            }
+            """,
+                configuration: ["max_number_of_single_line_parameters": 1]
+               ),
+        // Multiple trailing closures: still args-only
+        Example("""
+            foo(a: 1, b: 2) { _ in
+                print("main")
+            } trailing: { _ in
+                print("extra")
+            }
+            """,
+                configuration: ["max_number_of_single_line_parameters": 2]
+               ),
+
+        // MARK: - Trivia / comments
+        Example("""
+            foo(
+                a: 1,
+                // comment
+                b: 2,
+                c: 3
+            )
+            """),
+
+        Example("""
+            foo(
+                a: (
+                    1,
+                    2
+                ), b: 3
+            )
+            """,
+                configuration: ["max_number_of_single_line_parameters": 10]
+               ),
+        Example("""
+            foo(
+                a: 1, // comment
+                b: 2,
+                c: 3
+            )
+            """,
+                configuration: ["max_number_of_single_line_parameters": 10]
+               ),
+
+        Example("""
+            enum EnumCase {
+                case caseOne(Int, Int, Int, Int)
+            }
+            let enumCase: EnumCase = .caseOne(
+                1,
+                2,
+                3,
+                4
+            )
+            if case let .caseOne(_, _, three, _) = enumCase {
+            }
+            """,
+                configuration: ["max_number_of_single_line_parameters": 2]
+               ),
+        Example("""
+            enum EnumCase {
+                case caseOne(one: Int, two: Int, three: Int, four: Int)
+            }
+            let enumCase: EnumCase = .caseOne(
+                one: 1,
+                two: 2,
+                three: 3,
+                four: 4
+            )
+            switch enumCase {
+            case let .caseOne(one: _, two: _, three: three, four: _):
+            }
+            """,
+                configuration: ["max_number_of_single_line_parameters": 2]
+               ),
+        Example("""
+            enum EnumCase { case caseOne(Int, Int, Int, Int) }
+            let array: [EnumCase] = [
+                .caseOne(
+                    1,
+                    2,
+                    3,
+                    4
+                )
+            ]
+            for case let .caseOne(_, _, three, _) in array {
+            }
+            """,
+                configuration: ["max_number_of_single_line_parameters": 2]
+               ),
+        Example("""
+            enum EnumCase {
+                case caseOne(Int, Int, Int, Int)
+            }
+            let enumCase: EnumCase = .caseOne(
+                1,
+                2,
+                3,
+                4
+            )
+            guard case let .caseOne(_, _, three, _) = enumCase else { return }
+            """,
+                configuration: ["max_number_of_single_line_parameters": 2]
+               ),
+        Example("""
+            enum EnumCase {
+                case caseOne(Int, Int, Int, Int)
+            }
+            let enumCase: EnumCase = .caseOne(
+                1,
+                2,
+                3,
+                4
+            )
+            while case let .caseOne(_, _, three, _) = enumCase {
+            }
+            """,
+                configuration: ["max_number_of_single_line_parameters": 2]
+               ),
+
+        // MARK: - Pattern matching MUST be ignored: catch patterns
+        Example("""
+            enum EnumCase: Error {
+                case caseOne(Int, Int, Int, Int)
+            }
+
+            func mayThrow() throws {
+            }
+
+            do {
+                try mayThrow()
+            } catch let EnumCase.caseOne(_, _, three, _) {
+            }
+            """,
+                configuration: ["max_number_of_single_line_parameters": 2]
+               ),
+        Example("""
+            enum EnumCase: Error {
+                case caseOne(one: Int, two: Int, three: Int, four: Int)
+            }
+
+            func mayThrow() throws {
+            }
+
+            do {
+                try mayThrow()
+            } catch let EnumCase.caseOne(one: _, two: _, three: three, four: _) {
+            }
+            """,
+                configuration: ["max_number_of_single_line_parameters": 2]
+               ),
+
+        // MARK: - Regular calls near patterns are still linted
+        Example("""
+            func foo(a: Int, b: Int, c: Int) -> Int { a + b + c }
+            enum EnumCase { case caseOne(Int, Int, Int, Int) }
+
+            if case let .caseOne(_, _, _, _) = EnumCase.caseOne(
+                1,
+                2,
+                3,
+                4
+            ) {
+                _ = foo(
+                    a: 1,
+                    b: 2,
+                    c: 3
+                )
+            }
+            """,
+                configuration: ["max_number_of_single_line_parameters": 2]
+               ),
+        // MARK: - Pattern matching MUST be ignored: enum-case patterns with literal subpatterns
+        Example("""
+            enum EnumCase {
+                case caseOne(Int, Int, Int, Int)
+            }
+
+            // Real call is written multi-line to avoid noise for max=2
+            let enumCase: EnumCase = .caseOne(
+                0,
+                0,
+                0,
+                0
+            )
+
+            // This is a PATTERN, not a call, and must be ignored even though it looks like `.caseOne(1,2,3,4)`
+            if case .caseOne(1, 2, 3, 4) = enumCase {
+                // no-op
+            }
+            """,
+                configuration: ["max_number_of_single_line_parameters": 2]
+               ),
+
+        Example("""
+            enum EnumCase {
+                case caseOne(one: Int, two: Int, three: Int, four: Int)
+            }
+
+            let enumCase: EnumCase = .caseOne(
+                one: 0,
+                two: 0,
+                three: 0,
+                four: 0
+            )
+
+            switch enumCase {
+            case .caseOne(one: 1, two: 2, three: 3, four: 4):
+                break
+            default:
+                break
+            }
+            """,
+                configuration: ["max_number_of_single_line_parameters": 2]
+               ),
+
+        Example("""
+            enum EnumCase: Error {
+                case caseOne(Int, Int, Int, Int)
+            }
+
+            func mayThrow() throws {}
+
+            do {
+                try mayThrow()
+            } catch EnumCase.caseOne(1, 2, 3, 4) {
+                // pattern — must be ignored
+            }
+            """,
+                configuration: ["max_number_of_single_line_parameters": 2]
+               ),
+    ]
+
+    static let triggeringExamples: [Example] = [
+        // MARK: - Single-line: too many args
+        Example(
+            "foo(param1: 1, param2: false, ↓param3: [])",
+            configuration: ["max_number_of_single_line_parameters": 2]
+        ),
+        Example(
+            "Enum.foo(param1: 1, param2: false, ↓param3: [])",
+            configuration: ["max_number_of_single_line_parameters": 2]
+        ),
+        Example("foo(1, 2, ↓3)", configuration: ["max_number_of_single_line_parameters": 2]),
+        Example("foo(1, b: 2, ↓3)", configuration: ["max_number_of_single_line_parameters": 2]),
+
+        // allows_single_line=false: any 2+ single-line call violates at 2nd argument
+        Example("foo(param1: 1, ↓param2: false)", configuration: ["allows_single_line": false]),
+        Example("Enum.foo(param1: 1, ↓param2: false)", configuration: ["allows_single_line": false]),
+
+        // MARK: - Multi-line: two args start on the same line
+        Example("""
+            foo(
+                a: 1, ↓b: 2,
+                c: 3
+            )
+            """,
+                configuration: ["max_number_of_single_line_parameters": 10]
+               ),
+        Example("""
+            foo(
+                a: 1,
+                b: 2, ↓c: 3
+            )
+            """,
+                configuration: ["max_number_of_single_line_parameters": 10]
+               ),
+        Example("""
+            foo(
+                a: 1,
+                b: 2,
+                c: 3, ↓d: 4,
+                e: 5
+            )
+            """,
+                configuration: ["max_number_of_single_line_parameters": 10]
+               ),
+        Example("""
+            foo(
+                a: 1, /* comment */ ↓b: 2,
+                c: 3
+            )
+            """,
+                configuration: ["max_number_of_single_line_parameters": 10]
+               ),
+
+        // MARK: - Enum-case constructor calls are linted like normal calls
+        Example("""
+            enum EnumCase {
+                case first(one: Int, two: Int, three: Int, four: Int)
+            }
+            EnumCase.first(one: 1, ↓two: 2, three: 3, four: 4)
+            """,
+                configuration: ["allows_single_line": false]
+               ),
+        Example("""
+            enum EnumCase {
+                case first(one: Int, two: Int, three: Int, four: Int)
+            }
+            let test = EnumCase.first(one: 1, two: 2, ↓three: 3, four: 4)
+            """,
+                configuration: ["max_number_of_single_line_parameters": 2]
+               ),
+
+        // MARK: - Trailing closure: parentheses args still checked
+        Example("""
+            foo(a: 1, ↓b: 2) { _ in
+                print("x")
+            }
+            """,
+                configuration: ["max_number_of_single_line_parameters": 1]
+               ),
+
+        // MARK: - Targeted tests
+
+        // Targeted: real `.caseOne(1,2,3,4)` call MUST be linted (not a pattern)
+        Example("""
+            enum EnumCase { case caseOne(Int, Int, Int, Int) }
+            let x: EnumCase = .caseOne(1, 2, ↓3, 4)
+            _ = x
+            """,
+                configuration: ["max_number_of_single_line_parameters": 2]
+               ),
+
+        // Targeted: labeled enum-case constructor call MUST be linted
+        Example("""
+            enum EnumCase {
+                case caseOne(one: Int, two: Int, three: Int, four: Int)
+            }
+            let x: EnumCase = .caseOne(one: 1, two: 2, ↓three: 3, four: 4)
+            _ = x
+            """,
+                configuration: ["max_number_of_single_line_parameters": 2]
+               ),
+
+        // Targeted: pattern-part ignored, RHS call linted
+        Example("""
+            func foo(a: Int, b: Int, c: Int) -> Int { a + b + c }
+            enum EnumCase { case caseOne(Int, Int, Int, Int) }
+            let enumCase: EnumCase = .caseOne(
+                1,
+                2,
+                3,
+                4
+            )
+            if case let .caseOne(_, _, _, _) = enumCase {
+                _ = foo(a: 1, b: 2, ↓c: 3)
+            }
+            """,
+                configuration: ["max_number_of_single_line_parameters": 2]
+               ),
+
+        // Targeted: switch-where RHS call linted, pattern ignored
+        Example("""
+            func foo(a: Int, b: Int, c: Int) -> Bool { a + b == c }
+            enum EnumCase { case caseOne(Int, Int, Int, Int) }
+            let enumCase: EnumCase = .caseOne(
+                1,
+                2,
+                3,
+                4
+            )
+            switch enumCase {
+            case .caseOne where foo(a: 1, b: 2, ↓c: 3):
+                break
+            default:
+                break
+            }
+            """,
+                configuration: ["max_number_of_single_line_parameters": 2]
+               ),
+
+        // Targeted: for-case pattern ignored, body call linted
+        Example("""
+            func foo(a: Int, b: Int, c: Int) -> Int { a + b + c }
+            enum EnumCase { case caseOne(Int, Int, Int, Int) }
+            let array: [EnumCase] = [
+                .caseOne(
+                    1,
+                    2,
+                    3,
+                    4
+                )
+            ]
+            for case let .caseOne(_, _, _, _) in array {
+                _ = foo(a: 1, b: 2, ↓c: 3)
+            }
+            """,
+                configuration: ["max_number_of_single_line_parameters": 2]
+               ),
+        Example("""
+            func foo(a: Int, b: Int, c: Int) -> Int { a + b + c }
+            enum EnumCase: Error { case caseOne(Int, Int, Int, Int) }
+
+            func mayThrow() throws {
+            }
+
+            do {
+                try mayThrow()
+            } catch let EnumCase.caseOne(_, _, _, _) {
+                _ = foo(a: 1, b: 2, ↓c: 3)
+            }
+            """,
+                configuration: ["max_number_of_single_line_parameters": 2]
+               ),
+    ]
+}
+// swiftlint:enable type_body_length
+// swiftlint:enable file_length

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/MultilineCallArgumentsRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/MultilineCallArgumentsRuleExamples.swift
@@ -11,6 +11,14 @@ internal struct MultilineCallArgumentsRuleExamples {
                 configuration: ["max_number_of_single_line_parameters": 1]
                ),
         Example("""
+            func foo(one: [Int], animated: Bool) {}
+            add(one: [
+                1,
+                2,
+                3
+            ], animated: true)
+            """),
+        Example("""
             foo(
                 param1: 1,
                 param2: 2,
@@ -112,6 +120,13 @@ internal struct MultilineCallArgumentsRuleExamples {
             """,
                 configuration: ["max_number_of_single_line_parameters": 2]
                ),
+        Example("""
+            foo(with: { _ in
+                9_999
+            }, and: { _ in
+                nil
+            })
+            """),
 
         // MARK: - Trivia / comments
         Example("""
@@ -122,16 +137,20 @@ internal struct MultilineCallArgumentsRuleExamples {
                 c: 3
             )
             """),
-
+        // Note: arguments start on the same line, so this is treated as a single-line-args call;
+        // the comma-newline check applies only when argument start lines are already split.
         Example("""
             foo(
-                a: (
-                    1,
-                    2
-                ), b: 3
+                a: (1, 2), b: 3
+            )
+            """),
+        Example("""
+            foo(
+                a: (1, 2),
+                b: 3
             )
             """,
-                configuration: ["max_number_of_single_line_parameters": 10]
+                configuration: ["allows_single_line": false]
                ),
         Example("""
             foo(
@@ -139,9 +158,7 @@ internal struct MultilineCallArgumentsRuleExamples {
                 b: 2,
                 c: 3
             )
-            """,
-                configuration: ["max_number_of_single_line_parameters": 10]
-               ),
+            """),
 
         Example("""
             enum EnumCase {
@@ -355,17 +372,13 @@ internal struct MultilineCallArgumentsRuleExamples {
                 a: 1, ↓b: 2,
                 c: 3
             )
-            """,
-                configuration: ["max_number_of_single_line_parameters": 10]
-               ),
+            """),
         Example("""
             foo(
                 a: 1,
                 b: 2, ↓c: 3
             )
-            """,
-                configuration: ["max_number_of_single_line_parameters": 10]
-               ),
+            """),
         Example("""
             foo(
                 a: 1,
@@ -373,17 +386,23 @@ internal struct MultilineCallArgumentsRuleExamples {
                 c: 3, ↓d: 4,
                 e: 5
             )
+            """),
+        Example("""
+            foo(
+                a: (
+                    1,
+                    2
+                ), ↓b: 3
+            )
             """,
-                configuration: ["max_number_of_single_line_parameters": 10]
-               ),
+            configuration: ["max_number_of_single_line_parameters": 1]
+        ),
         Example("""
             foo(
                 a: 1, /* comment */ ↓b: 2,
                 c: 3
             )
-            """,
-                configuration: ["max_number_of_single_line_parameters": 10]
-               ),
+            """),
 
         // MARK: - Enum-case constructor calls are linted like normal calls
         Example("""

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/MultilineCallArgumentsRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/MultilineCallArgumentsRuleExamples.swift
@@ -1,6 +1,6 @@
 // swiftlint:disable file_length
 // swiftlint:disable type_body_length
-internal struct MultilineCallArgumentsRuleExamples {
+struct MultilineCallArgumentsRuleExamples {
     static let nonTriggeringExamples: [Example] = [
         // MARK: - Baseline: multi-line OK
         Example("""

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MultilineCallArgumentsConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MultilineCallArgumentsConfiguration.swift
@@ -4,19 +4,20 @@ import SwiftLintCore
 struct MultilineCallArgumentsConfiguration: SeverityBasedRuleConfiguration {
     @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+
     @ConfigurationElement(key: "allows_single_line")
     private(set) var allowsSingleLine = true
+
     @ConfigurationElement(key: "max_number_of_single_line_parameters")
     private(set) var maxNumberOfSingleLineParameters: Int?
 
     func validate() throws(Issue) {
-        guard let maxNumberOfSingleLineParameters else {
-            return
-        }
+        guard let maxNumberOfSingleLineParameters else { return }
+
         guard maxNumberOfSingleLineParameters >= 1 else {
             throw Issue.inconsistentConfiguration(
                 ruleID: Parent.identifier,
-                message: "Option '\($maxNumberOfSingleLineParameters.key)' should be >= 1."
+                message: "Option '\($maxNumberOfSingleLineParameters.key)' should be >= 1"
             )
         }
 
@@ -25,7 +26,7 @@ struct MultilineCallArgumentsConfiguration: SeverityBasedRuleConfiguration {
                 ruleID: Parent.identifier,
                 message: """
                          Option '\($maxNumberOfSingleLineParameters.key)' has no effect when \
-                         '\($allowsSingleLine.key)' is false.
+                         '\($allowsSingleLine.key)' is false
                          """
             )
         }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MultilineCallArgumentsConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MultilineCallArgumentsConfiguration.swift
@@ -17,7 +17,7 @@ struct MultilineCallArgumentsConfiguration: SeverityBasedRuleConfiguration {
         guard maxNumberOfSingleLineParameters >= 1 else {
             throw Issue.inconsistentConfiguration(
                 ruleID: Parent.identifier,
-                message: "Option '\($maxNumberOfSingleLineParameters.key)' should be >= 1"
+                message: "Option '\($maxNumberOfSingleLineParameters.key)' should be >= 1."
             )
         }
 

--- a/Tests/BuiltInRulesTests/MultilineCallArgumentsRuleTests.swift
+++ b/Tests/BuiltInRulesTests/MultilineCallArgumentsRuleTests.swift
@@ -1,0 +1,102 @@
+@testable import SwiftLintBuiltInRules
+import TestHelpers
+import XCTest
+
+final class MultilineCallArgumentsRuleTests: XCTestCase {
+    func testReason_singleLineMultipleArgumentsNotAllowed() throws {
+        let rule = try makeRule(["allows_single_line": false])
+        let violations = validate(rule, contents: "foo(a: 1, b: 2)")
+
+        XCTAssertEqual(violations.count, 1)
+        XCTAssertEqual(
+            violations.first?.reason,
+            MultilineCallArgumentsRule.Reason.singleLineMultipleArgumentsNotAllowed
+        )
+    }
+
+    func testReason_tooManyArgumentsOnASingleLine() throws {
+        let max = 2
+        let rule = try makeRule(["max_number_of_single_line_parameters": max])
+        let violations = validate(rule, contents: "foo(a: 1, b: 2, c: 3)")
+
+        XCTAssertEqual(violations.count, 1)
+        XCTAssertEqual(
+            violations.first?.reason,
+            MultilineCallArgumentsRule.Reason.tooManyArgumentsOnSingleLine(max: max)
+        )
+    }
+
+    func testReason_multilineEachArgumentMustStartOnItsOwnLine() throws {
+        let rule = try makeRule(["max_number_of_single_line_parameters": 10])
+        let violations = validate(rule, contents: """
+        foo(
+            a: 1, b: 2,
+            c: 3
+        )
+        """)
+
+        XCTAssertEqual(violations.count, 1)
+        XCTAssertEqual(
+            violations.first?.reason,
+            MultilineCallArgumentsRule.Reason.eachArgumentMustStartOnOwnLine
+        )
+    }
+
+    func testReason_tooManyArgumentsOnASingleLine_worksWithTrailingClosure() throws {
+        let max = 1
+        let rule = try makeRule(["max_number_of_single_line_parameters": max])
+        let violations = validate(rule, contents: """
+        foo(a: 1, b: 2) { _ in
+            print("x")
+        }
+        """)
+
+        XCTAssertEqual(violations.count, 1)
+        XCTAssertEqual(
+            violations.first?.reason,
+            MultilineCallArgumentsRule.Reason.tooManyArgumentsOnSingleLine(max: max)
+        )
+    }
+
+    func testReason_singleLineNotAllowed_hasPriorityOverMaxNumberOfSingleLineParameters() throws {
+        let rule = try makeRule([
+            "allows_single_line": false,
+            "max_number_of_single_line_parameters": 1,
+        ])
+
+        let violations = validate(rule, contents: "foo(a: 1, b: 2, c: 3)")
+
+        XCTAssertEqual(violations.count, 1)
+        XCTAssertEqual(
+            violations.first?.reason,
+            MultilineCallArgumentsRule.Reason.singleLineMultipleArgumentsNotAllowed
+        )
+    }
+
+    func testReason_multilineEachArgumentMustStartOnItsOwnLine_detectsSameLineAfterNewline() throws {
+        let rule = try makeRule(["max_number_of_single_line_parameters": 10])
+        let violations = validate(rule, contents: """
+        foo(
+            a: 1,
+            b: 2, c: 3
+        )
+        """)
+
+        XCTAssertEqual(violations.count, 1)
+        XCTAssertEqual(
+            violations.first?.reason,
+            MultilineCallArgumentsRule.Reason.eachArgumentMustStartOnOwnLine
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func makeRule(_ config: [String: Any]) throws -> MultilineCallArgumentsRule {
+        try MultilineCallArgumentsRule(configuration: config)
+    }
+
+    private func validate(_ rule: some Rule, contents: String) -> [StyleViolation] {
+        let file = SwiftLintFile(contents: contents)
+        return rule.validate(file: file)
+    }
+}

--- a/Tests/BuiltInRulesTests/MultilineCallArgumentsRuleTests.swift
+++ b/Tests/BuiltInRulesTests/MultilineCallArgumentsRuleTests.swift
@@ -4,8 +4,10 @@ import XCTest
 
 final class MultilineCallArgumentsRuleTests: XCTestCase {
     func testReason_singleLineMultipleArgumentsNotAllowed() throws {
-        let rule = try makeRule(["allows_single_line": false])
-        let violations = validate(rule, contents: "foo(a: 1, b: 2)")
+        let violations = try validate(
+            "foo(a: 1, b: 2)",
+            config: ["allows_single_line": false]
+        )
 
         XCTAssertEqual(violations.count, 1)
         XCTAssertEqual(
@@ -16,8 +18,10 @@ final class MultilineCallArgumentsRuleTests: XCTestCase {
 
     func testReason_tooManyArgumentsOnASingleLine() throws {
         let max = 2
-        let rule = try makeRule(["max_number_of_single_line_parameters": max])
-        let violations = validate(rule, contents: "foo(a: 1, b: 2, c: 3)")
+        let violations = try validate(
+            "foo(a: 1, b: 2, c: 3)",
+            config: ["max_number_of_single_line_parameters": max]
+        )
 
         XCTAssertEqual(violations.count, 1)
         XCTAssertEqual(
@@ -27,13 +31,13 @@ final class MultilineCallArgumentsRuleTests: XCTestCase {
     }
 
     func testReason_multilineEachArgumentMustStartOnItsOwnLine() throws {
-        let rule = try makeRule(["max_number_of_single_line_parameters": 10])
-        let violations = validate(rule, contents: """
-        foo(
-            a: 1, b: 2,
-            c: 3
+        let violations = try validate("""
+            foo(
+                a: 1, b: 2,
+                c: 3
+            )
+            """
         )
-        """)
 
         XCTAssertEqual(violations.count, 1)
         XCTAssertEqual(
@@ -42,14 +46,49 @@ final class MultilineCallArgumentsRuleTests: XCTestCase {
         )
     }
 
+    func testReason_multilineEachArgumentMustStartOnItsOwnLine_detectsSameLineAfterNewline() throws {
+        let violations = try validate("""
+            foo(
+                a: 1,
+                b: 2, c: 3
+            )
+            """
+        )
+
+        XCTAssertEqual(violations.count, 1)
+        XCTAssertEqual(
+            violations.first?.reason,
+            MultilineCallArgumentsRule.Reason.eachArgumentMustStartOnOwnLine
+        )
+    }
+
+    func testReason_multilineRequiresNewlineAfterCommaInSplitLayout() throws {
+        let violations = try validate("""
+            foo(
+                a: (
+                    1,
+                    2
+                ), b: 3
+            )
+            """
+        )
+
+        XCTAssertEqual(violations.count, 1)
+        XCTAssertEqual(
+            violations.first?.reason,
+            MultilineCallArgumentsRule.Reason.newlineRequiredAfterCommaInMultilineCall
+        )
+    }
+
     func testReason_tooManyArgumentsOnASingleLine_worksWithTrailingClosure() throws {
         let max = 1
-        let rule = try makeRule(["max_number_of_single_line_parameters": max])
-        let violations = validate(rule, contents: """
-        foo(a: 1, b: 2) { _ in
-            print("x")
-        }
-        """)
+        let violations = try validate("""
+            foo(a: 1, b: 2) { _ in
+                print("x")
+            }
+            """,
+            config: ["max_number_of_single_line_parameters": max]
+        )
 
         XCTAssertEqual(violations.count, 1)
         XCTAssertEqual(
@@ -59,12 +98,13 @@ final class MultilineCallArgumentsRuleTests: XCTestCase {
     }
 
     func testReason_singleLineNotAllowed_hasPriorityOverMaxNumberOfSingleLineParameters() throws {
-        let rule = try makeRule([
-            "allows_single_line": false,
-            "max_number_of_single_line_parameters": 1,
-        ])
-
-        let violations = validate(rule, contents: "foo(a: 1, b: 2, c: 3)")
+        let violations = try validate(
+            "foo(a: 1, b: 2, c: 3)",
+            config: [
+                "allows_single_line": false,
+                "max_number_of_single_line_parameters": 1,
+            ]
+        )
 
         XCTAssertEqual(violations.count, 1)
         XCTAssertEqual(
@@ -73,30 +113,10 @@ final class MultilineCallArgumentsRuleTests: XCTestCase {
         )
     }
 
-    func testReason_multilineEachArgumentMustStartOnItsOwnLine_detectsSameLineAfterNewline() throws {
-        let rule = try makeRule(["max_number_of_single_line_parameters": 10])
-        let violations = validate(rule, contents: """
-        foo(
-            a: 1,
-            b: 2, c: 3
-        )
-        """)
+    // MARK: - Helper
 
-        XCTAssertEqual(violations.count, 1)
-        XCTAssertEqual(
-            violations.first?.reason,
-            MultilineCallArgumentsRule.Reason.eachArgumentMustStartOnOwnLine
-        )
-    }
-
-    // MARK: - Helpers
-
-    private func makeRule(_ config: [String: Any]) throws -> MultilineCallArgumentsRule {
-        try MultilineCallArgumentsRule(configuration: config)
-    }
-
-    private func validate(_ rule: some Rule, contents: String) -> [StyleViolation] {
-        let file = SwiftLintFile(contents: contents)
-        return rule.validate(file: file)
+    private func validate(_ contents: String, config: [String: Any] = [:]) throws -> [StyleViolation] {
+        let rule = try MultilineCallArgumentsRule(configuration: config)
+        return rule.validate(file: SwiftLintFile(contents: contents))
     }
 }


### PR DESCRIPTION
### Summary

This PR fixes false positives in multiline_call_arguments when enum-case patterns (e.g. .caseOne(...)) are used in pattern-matching positions. SwiftSyntax represents such patterns as FunctionCallExprSyntax, so the rule previously treated them as real calls and produced violations.

### Problem

The rule could incorrectly lint enum-case patterns in pattern-matching constructs, e.g.:
```swift
if case .caseOne(1, 2, 3, 4) = value {
    // ...
}
```
This is a pattern, not a function call, but it was previously linted as a call expression.

### Fix

We now ignore FunctionCallExprSyntax nodes only when they are located inside a pattern subtree (pattern-part only), by walking up the parent chain and checking containment within pattern containers:

- MatchingPatternConditionSyntax (e.g. if/guard/while case ...)
- SwitchCaseItemSyntax (e.g., case .foo(...))
- ForStmtSyntax (e.g., for case let .foo(...) in ...)
- CatchClauseSyntax (e.g. catch EnumCase.foo(...) / catch let EnumCase.foo(...))