### PR TITLE
Add claude files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,7 @@ oss-check-summary.md
 
 # VS Code
 .vscode
+
+# AI Tools
+Claude.md
+.claude/


### PR DESCRIPTION
## Summary
Claude.md is a file used to give claude background information on the repo and optionally the current users goals and experience 
.claude/ is a caching directory

## Problem
This will prevent people using Claude code from accidentally commiting these files. The .claude directory we definitely do not want within the repo. A generic Claude.md file could be useful but probably best to ignore it for now as otherwise we'd  end up with one of these for every AI tool anyone ever uses.