### PR TITLE
Add combine_flatmap lint rule

### DIFF
--- a/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
+++ b/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
@@ -21,6 +21,7 @@ public let builtInRules: [any Rule.Type] = [
     ClosureSpacingRule.self,
     CollectionAlignmentRule.self,
     ColonRule.self,
+    CombineFlatMapRule.self,
     CommaInheritanceRule.self,
     CommaRule.self,
     CommentSpacingRule.self,

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/CombineFlatMapRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/CombineFlatMapRule.swift
@@ -1,0 +1,58 @@
+import SwiftSyntax
+
+@SwiftSyntaxRule
+struct CombineFlatMapRule: Rule {
+    var configuration = SeverityConfiguration<Self>(.warning)
+
+    static let description = RuleDescription(
+        identifier: "combine_flatmap",
+        name: "Combine FlatMap",
+        description: "Avoid using Combine's flatMap operator.",
+        kind: .lint,
+        nonTriggeringExamples: [
+            Example("[1, 2, 3].flatMap { $0 }"),
+            Example("array.flatMap { $0 }"),
+            Example("Combine.map { $0 }")
+        ],
+        triggeringExamples: [
+            Example("Combine.flatMap { $0 }"),
+            Example("let transform = Combine.flatMap")
+        ]
+    )
+}
+
+private extension CombineFlatMapRule {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
+        override func visitPost(_ node: FunctionCallExprSyntax) {
+            guard let memberAccess = node.calledExpression.as(MemberAccessExprSyntax.self),
+                  memberAccess.isCombineFlatMap else {
+                return
+            }
+
+            violations.append(node.positionAfterSkippingLeadingTrivia)
+        }
+
+        override func visitPost(_ node: MemberAccessExprSyntax) {
+            guard node.isCombineFlatMap else {
+                return
+            }
+
+            if let parent = node.parent?.as(FunctionCallExprSyntax.self),
+               parent.calledExpression.id == node.id {
+                return
+            }
+
+            violations.append(node.positionAfterSkippingLeadingTrivia)
+        }
+    }
+}
+
+private extension MemberAccessExprSyntax {
+    var isCombineFlatMap: Bool {
+        guard declName.baseName.text == "flatMap" else {
+            return false
+        }
+
+        return base?.as(DeclReferenceExprSyntax.self)?.baseName.text == "Combine"
+    }
+}

--- a/Tests/GeneratedTests/GeneratedTests_01.swift
+++ b/Tests/GeneratedTests/GeneratedTests_01.swift
@@ -121,6 +121,12 @@ final class ColonRuleGeneratedTests: SwiftLintTestCase {
     }
 }
 
+final class CombineFlatMapRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(CombineFlatMapRule.description)
+    }
+}
+
 final class CommaInheritanceRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(CommaInheritanceRule.description)
@@ -148,11 +154,5 @@ final class CompilerProtocolInitRuleGeneratedTests: SwiftLintTestCase {
 final class ComputedAccessorsOrderRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ComputedAccessorsOrderRule.description)
-    }
-}
-
-final class ConditionalReturnsOnNewlineRuleGeneratedTests: SwiftLintTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(ConditionalReturnsOnNewlineRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_02.swift
+++ b/Tests/GeneratedTests/GeneratedTests_02.swift
@@ -7,6 +7,12 @@
 @testable import SwiftLintCore
 import TestHelpers
 
+final class ConditionalReturnsOnNewlineRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(ConditionalReturnsOnNewlineRule.description)
+    }
+}
+
 final class ContainsOverFilterCountRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ContainsOverFilterCountRule.description)
@@ -148,11 +154,5 @@ final class EmptyCollectionLiteralRuleGeneratedTests: SwiftLintTestCase {
 final class EmptyCountRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(EmptyCountRule.description)
-    }
-}
-
-final class EmptyEnumArgumentsRuleGeneratedTests: SwiftLintTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(EmptyEnumArgumentsRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_03.swift
+++ b/Tests/GeneratedTests/GeneratedTests_03.swift
@@ -7,6 +7,12 @@
 @testable import SwiftLintCore
 import TestHelpers
 
+final class EmptyEnumArgumentsRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(EmptyEnumArgumentsRule.description)
+    }
+}
+
 final class EmptyParametersRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(EmptyParametersRule.description)
@@ -148,11 +154,5 @@ final class FlatMapOverMapReduceRuleGeneratedTests: SwiftLintTestCase {
 final class ForWhereRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ForWhereRule.description)
-    }
-}
-
-final class ForceCastRuleGeneratedTests: SwiftLintTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(ForceCastRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_04.swift
+++ b/Tests/GeneratedTests/GeneratedTests_04.swift
@@ -7,6 +7,12 @@
 @testable import SwiftLintCore
 import TestHelpers
 
+final class ForceCastRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(ForceCastRule.description)
+    }
+}
+
 final class ForceTryRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(ForceTryRule.description)
@@ -148,11 +154,5 @@ final class LeadingWhitespaceRuleGeneratedTests: SwiftLintTestCase {
 final class LegacyCGGeometryFunctionsRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(LegacyCGGeometryFunctionsRule.description)
-    }
-}
-
-final class LegacyConstantRuleGeneratedTests: SwiftLintTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(LegacyConstantRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_05.swift
+++ b/Tests/GeneratedTests/GeneratedTests_05.swift
@@ -7,6 +7,12 @@
 @testable import SwiftLintCore
 import TestHelpers
 
+final class LegacyConstantRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(LegacyConstantRule.description)
+    }
+}
+
 final class LegacyConstructorRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(LegacyConstructorRule.description)
@@ -148,11 +154,5 @@ final class NSLocalizedStringKeyRuleGeneratedTests: SwiftLintTestCase {
 final class NSLocalizedStringRequireBundleRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(NSLocalizedStringRequireBundleRule.description)
-    }
-}
-
-final class NSNumberInitAsFunctionReferenceRuleGeneratedTests: SwiftLintTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(NSNumberInitAsFunctionReferenceRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_06.swift
+++ b/Tests/GeneratedTests/GeneratedTests_06.swift
@@ -7,6 +7,12 @@
 @testable import SwiftLintCore
 import TestHelpers
 
+final class NSNumberInitAsFunctionReferenceRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(NSNumberInitAsFunctionReferenceRule.description)
+    }
+}
+
 final class NSObjectPreferIsEqualRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(NSObjectPreferIsEqualRule.description)
@@ -148,11 +154,5 @@ final class PatternMatchingKeywordsRuleGeneratedTests: SwiftLintTestCase {
 final class PeriodSpacingRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(PeriodSpacingRule.description)
-    }
-}
-
-final class PreferAssetSymbolsRuleGeneratedTests: SwiftLintTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(PreferAssetSymbolsRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_07.swift
+++ b/Tests/GeneratedTests/GeneratedTests_07.swift
@@ -7,6 +7,12 @@
 @testable import SwiftLintCore
 import TestHelpers
 
+final class PreferAssetSymbolsRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(PreferAssetSymbolsRule.description)
+    }
+}
+
 final class PreferConditionListRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(PreferConditionListRule.description)
@@ -148,11 +154,5 @@ final class ReduceIntoRuleGeneratedTests: SwiftLintTestCase {
 final class RedundantDiscardableLetRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(RedundantDiscardableLetRule.description)
-    }
-}
-
-final class RedundantNilCoalescingRuleGeneratedTests: SwiftLintTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(RedundantNilCoalescingRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_08.swift
+++ b/Tests/GeneratedTests/GeneratedTests_08.swift
@@ -7,6 +7,12 @@
 @testable import SwiftLintCore
 import TestHelpers
 
+final class RedundantNilCoalescingRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(RedundantNilCoalescingRule.description)
+    }
+}
+
 final class RedundantObjcAttributeRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(RedundantObjcAttributeRule.description)
@@ -148,11 +154,5 @@ final class StaticOverFinalClassRuleGeneratedTests: SwiftLintTestCase {
 final class StrictFilePrivateRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(StrictFilePrivateRule.description)
-    }
-}
-
-final class StrongIBOutletRuleGeneratedTests: SwiftLintTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(StrongIBOutletRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_09.swift
+++ b/Tests/GeneratedTests/GeneratedTests_09.swift
@@ -7,6 +7,12 @@
 @testable import SwiftLintCore
 import TestHelpers
 
+final class StrongIBOutletRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(StrongIBOutletRule.description)
+    }
+}
+
 final class SuperfluousElseRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(SuperfluousElseRule.description)
@@ -148,11 +154,5 @@ final class UnneededParenthesesInClosureArgumentRuleGeneratedTests: SwiftLintTes
 final class UnneededSynthesizedInitializerRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(UnneededSynthesizedInitializerRule.description)
-    }
-}
-
-final class UnneededThrowsRuleGeneratedTests: SwiftLintTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(UnneededThrowsRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_10.swift
+++ b/Tests/GeneratedTests/GeneratedTests_10.swift
@@ -7,6 +7,12 @@
 @testable import SwiftLintCore
 import TestHelpers
 
+final class UnneededThrowsRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(UnneededThrowsRule.description)
+    }
+}
+
 final class UnownedVariableCaptureRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(UnownedVariableCaptureRule.description)


### PR DESCRIPTION
## Summary
- Adds a new `combine_flatmap` lint rule that warns against using Combine's `flatMap` operator
- Detects both `Combine.flatMap { ... }` call expressions and `Combine.flatMap` member access references
- Includes non-triggering examples for array `flatMap` and `Combine.map` to avoid false positives

## Test plan
- [ ] Verify non-triggering examples pass (array flatMap, Combine.map)
- [ ] Verify triggering examples flag violations (Combine.flatMap call and member access)
- [ ] Run `swift run swiftlint-dev rules validate` to confirm rule registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)