### PR TITLE
Support String.init and .init syntax in optional_data_string_conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,12 @@
 
 ### Enhancements
 
-* None.
+* Support `String.init(decoding:as:)` and `.init(decoding:as:)` syntax in the
+  `optional_data_string_conversion` rule. The bare `.init` form is gated behind
+  a new `include_bare_init` option (default: `false`) since type inference cannot
+  be verified syntactically.
+  [claudeaceae](https://github.com/claudeaceae)
+  [#6359](https://github.com/realm/SwiftLint/issues/6359)
 
 ### Bug Fixes
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/OptionalDataStringConversionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/OptionalDataStringConversionRule.swift
@@ -2,7 +2,7 @@ import SwiftSyntax
 
 @SwiftSyntaxRule
 struct OptionalDataStringConversionRule: Rule {
-    var configuration = SeverityConfiguration<Self>(.warning)
+    var configuration = OptionalDataStringConversionConfiguration()
 
     static let description = RuleDescription(
         identifier: "optional_data_string_conversion",
@@ -15,24 +15,64 @@ struct OptionalDataStringConversionRule: Rule {
             Example("String(UTF8.self)"),
             Example("String(a, b, c, UTF8.self)"),
             Example("String(decoding: data, encoding: UTF8.self)"),
+            Example("let text: String = .init(decoding: data, as: UTF8.self)"),
         ],
         triggeringExamples: [
-            Example("String(decoding: data, as: UTF8.self)")
+            Example("↓String(decoding: data, as: UTF8.self)"),
+            Example("↓String.init(decoding: data, as: UTF8.self)"),
         ]
     )
 }
 
 private extension OptionalDataStringConversionRule {
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
-        override func visitPost(_ node: DeclReferenceExprSyntax) {
-            if node.baseName.text == "String",
-               let parent = node.parent?.as(FunctionCallExprSyntax.self),
-               parent.arguments.map(\.label?.text) == ["decoding", "as"],
-               let expr = parent.arguments.last?.expression.as(MemberAccessExprSyntax.self),
-               expr.base?.description == "UTF8",
-               expr.declName.baseName.description == "self" {
-                violations.append(node.positionAfterSkippingLeadingTrivia)
+        override func visitPost(_ node: FunctionCallExprSyntax) {
+            guard hasDecodingAsUTF8Arguments(node) else {
+                return
             }
+
+            let calledExpression = node.calledExpression
+
+            // Case 1: String(decoding:as:)
+            if let declRef = calledExpression.as(DeclReferenceExprSyntax.self),
+               declRef.baseName.text == "String" {
+                violations.append(declRef.positionAfterSkippingLeadingTrivia)
+                return
+            }
+
+            guard let memberAccess = calledExpression.as(MemberAccessExprSyntax.self),
+                  memberAccess.declName.baseName.text == "init" else {
+                return
+            }
+
+            // Case 2: String.init(decoding:as:)
+            if let base = memberAccess.base,
+               let declRef = base.as(DeclReferenceExprSyntax.self),
+               declRef.baseName.text == "String" {
+                violations.append(declRef.positionAfterSkippingLeadingTrivia)
+                return
+            }
+
+            // Case 3: .init(decoding:as:) — only with include_bare_init
+            if memberAccess.base == nil, configuration.includeBareInit {
+                let reason = "Prefer failable `String(bytes:encoding:)` — assuming `.init` refers to `String.init`"
+                violations.append(
+                    ReasonedRuleViolation(
+                        position: memberAccess.period.positionAfterSkippingLeadingTrivia,
+                        reason: reason
+                    )
+                )
+            }
+        }
+
+        private func hasDecodingAsUTF8Arguments(_ node: FunctionCallExprSyntax) -> Bool {
+            guard node.arguments.map(\.label?.text) == ["decoding", "as"],
+                  let expr = node.arguments.last?.expression.as(MemberAccessExprSyntax.self),
+                  expr.base?.description == "UTF8",
+                  expr.declName.baseName.description == "self" else {
+                return false
+            }
+            return true
         }
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OptionalDataStringConversionConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OptionalDataStringConversionConfiguration.swift
@@ -1,0 +1,7 @@
+@AutoConfigParser
+struct OptionalDataStringConversionConfiguration: SeverityBasedRuleConfiguration {
+    @ConfigurationElement(key: "severity")
+    private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement(key: "include_bare_init")
+    private(set) var includeBareInit = false
+}

--- a/Tests/BuiltInRulesTests/OptionalDataStringConversionRuleTests.swift
+++ b/Tests/BuiltInRulesTests/OptionalDataStringConversionRuleTests.swift
@@ -1,0 +1,20 @@
+@testable import SwiftLintBuiltInRules
+import TestHelpers
+
+final class OptionalDataStringConversionRuleTests: SwiftLintTestCase {
+    func testIncludeBareInit() {
+        let nonTriggeringExamples = OptionalDataStringConversionRule.description.nonTriggeringExamples
+            .filter { !$0.code.contains(".init") }
+
+        let triggeringExamples =
+            OptionalDataStringConversionRule.description.triggeringExamples + [
+                Example("let text: String = ↓.init(decoding: data, as: UTF8.self)"),
+            ]
+
+        let description = OptionalDataStringConversionRule.description
+            .with(nonTriggeringExamples: nonTriggeringExamples)
+            .with(triggeringExamples: triggeringExamples)
+
+        verifyRule(description, ruleConfiguration: ["include_bare_init": true])
+    }
+}

--- a/Tests/IntegrationTests/Resources/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/Resources/default_rule_configurations.yml
@@ -836,6 +836,7 @@ operator_usage_whitespace:
     correctable: true
 optional_data_string_conversion:
   severity: warning
+  include_bare_init: false
   meta:
     opt-in: false
     correctable: false


### PR DESCRIPTION
## Summary

Fixes #6359. The `optional_data_string_conversion` rule now detects `String.init(decoding:as:)` syntax in addition to `String(decoding:as:)`.

A new `include_bare_init` configuration option (default: `false`) enables detection of bare `.init(decoding:as:)` where the `String` type is inferred from context. This is behind an option because SwiftLint's syntactic analysis cannot verify that `.init` actually refers to `String.init`, as noted by @SimplyDanny in #6359.

### Changes

- **Rule implementation**: Rewrote the visitor to match on `FunctionCallExprSyntax` instead of `DeclReferenceExprSyntax`, handling three cases:
  1. `String(decoding:as:)` — always flags (existing behavior)
  2. `String.init(decoding:as:)` — always flags (new)
  3. `.init(decoding:as:)` — flags only when `include_bare_init: true` (new, opt-in)
- **Configuration**: New `OptionalDataStringConversionConfiguration` with `include_bare_init` option, following the same pattern as `ExplicitInitConfiguration`
- **Tests**: Added `OptionalDataStringConversionRuleTests` with `testIncludeBareInit()` for the opt-in behavior
- **CHANGELOG**: Added entry under Enhancements

### Examples

```yaml
# .swiftlint.yml
optional_data_string_conversion:
  include_bare_init: true  # opt-in to detect .init(decoding:as:)
```

```swift
// Always triggers (default config):
String(decoding: data, as: UTF8.self)       // use String(bytes:encoding:) instead
String.init(decoding: data, as: UTF8.self)  // use String(bytes:encoding:) instead

// Only triggers with include_bare_init: true:
let text: String = .init(decoding: data, as: UTF8.self)

// Never triggers:
String(data: data, encoding: .utf8)
String(bytes: data, encoding: .utf8)
```

## Test plan

- [x] Existing triggering/non-triggering examples pass
- [x] New `String.init(decoding:as:)` triggering example added
- [x] `include_bare_init` test verifies opt-in `.init` detection
- [x] Default rule configurations updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)