### PR TITLE
Add `redundant_final_actor` opt-in rule

### DIFF
--- a/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
+++ b/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
@@ -176,6 +176,7 @@ public let builtInRules: [any Rule.Type] = [
     ReduceBooleanRule.self,
     ReduceIntoRule.self,
     RedundantDiscardableLetRule.self,
+    RedundantFinalActorRule.self,
     RedundantNilCoalescingRule.self,
     RedundantObjcAttributeRule.self,
     RedundantSelfRule.self,

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantFinalActorRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantFinalActorRule.swift
@@ -1,6 +1,6 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule(optIn: true)
+@SwiftSyntaxRule(correctable: true, optIn: true)
 struct RedundantFinalActorRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantFinalActorRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantFinalActorRule.swift
@@ -7,7 +7,12 @@ struct RedundantFinalActorRule: Rule {
     static let description = RuleDescription(
         identifier: "redundant_final_actor",
         name: "Redundant Final on Actor",
-        description: "`final` is redundant on an actor declaration because actors cannot be subclassed",
+        description: "`final` is redundant on an actor declaration and its members because actors cannot be subclassed",
+        rationale: """
+            Actors in Swift currently do not support inheritance, making `final` redundant \
+            on both actor declarations and their members. Note that this may change in future \
+            Swift versions if actor inheritance is introduced.
+            """,
         kind: .idiomatic,
         nonTriggeringExamples: [
             Example("actor MyActor {}"),
@@ -15,6 +20,17 @@ struct RedundantFinalActorRule: Rule {
             Example("""
             @globalActor
             actor MyGlobalActor {}
+            """),
+            Example("""
+            actor MyActor {
+                func doWork() {}
+                var value: Int { 0 }
+            }
+            """),
+            Example("""
+            class MyClass {
+                final func doWork() {}
+            }
             """),
         ],
         triggeringExamples: [
@@ -24,24 +40,75 @@ struct RedundantFinalActorRule: Rule {
             @globalActor
             ↓final actor MyGlobalActor {}
             """),
+            Example("""
+            actor MyActor {
+                ↓final func doWork() {}
+            }
+            """),
+            Example("""
+            actor MyActor {
+                ↓final var value: Int { 0 }
+            }
+            """),
         ],
         corrections: [
             Example("final actor MyActor {}"):
                 Example("actor MyActor {}"),
             Example("public final actor DataStore {}"):
                 Example("public actor DataStore {}"),
+            Example("actor MyActor {\n    final func doWork() {}\n}"):
+                Example("actor MyActor {\n    func doWork() {}\n}"),
         ]
     )
 }
 
 private extension RedundantFinalActorRule {
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
+        private var insideActor = false
+
+        override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind {
+            insideActor = true
+            return .visitChildren
+        }
+
         override func visitPost(_ node: ActorDeclSyntax) {
-            guard let finalModifier = node.modifiers.first(where: { $0.name.text == "final" }) else {
+            if let finalModifier = node.modifiers.first(where: { $0.name.text == "final" }) {
+                addViolation(for: finalModifier)
+            }
+            insideActor = false
+        }
+
+        override func visitPost(_ node: FunctionDeclSyntax) {
+            guard insideActor,
+                  let finalModifier = node.modifiers.first(where: { $0.name.text == "final" }) else {
                 return
             }
+            addViolation(for: finalModifier)
+        }
+
+        override func visitPost(_ node: VariableDeclSyntax) {
+            guard insideActor,
+                  let finalModifier = node.modifiers.first(where: { $0.name.text == "final" }) else {
+                return
+            }
+            addViolation(for: finalModifier)
+        }
+
+        override func visitPost(_ node: SubscriptDeclSyntax) {
+            guard insideActor,
+                  let finalModifier = node.modifiers.first(where: { $0.name.text == "final" }) else {
+                return
+            }
+            addViolation(for: finalModifier)
+        }
+
+        // Don't descend into nested classes where `final` is meaningful
+        override func visit(_: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+            .skipChildren
+        }
+
+        private func addViolation(for finalModifier: DeclModifierSyntax) {
             let start = finalModifier.positionAfterSkippingLeadingTrivia
-            // endPosition includes trailing trivia (the space after "final")
             let end = finalModifier.endPosition
             violations.append(
                 ReasonedRuleViolation(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantFinalActorRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantFinalActorRule.swift
@@ -1,7 +1,7 @@
 import SwiftSyntax
 
-@SwiftSyntaxRule(explicitRewriter: true)
-struct RedundantFinalActorRule: OptInRule {
+@SwiftSyntaxRule(explicitRewriter: true, optIn: true)
+struct RedundantFinalActorRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static let description = RuleDescription(

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantFinalActorRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantFinalActorRule.swift
@@ -1,0 +1,63 @@
+import SwiftSyntax
+
+@SwiftSyntaxRule(explicitRewriter: true)
+struct RedundantFinalActorRule: OptInRule {
+    var configuration = SeverityConfiguration<Self>(.warning)
+
+    static let description = RuleDescription(
+        identifier: "redundant_final_actor",
+        name: "Redundant Final on Actor",
+        description: "`final` is redundant on an actor declaration because actors cannot be subclassed",
+        kind: .idiomatic,
+        nonTriggeringExamples: [
+            Example("actor MyActor {}"),
+            Example("final class MyClass {}"),
+            Example("""
+            @globalActor
+            actor MyGlobalActor {}
+            """),
+        ],
+        triggeringExamples: [
+            Example("↓final actor MyActor {}"),
+            Example("public ↓final actor DataStore {}"),
+            Example("""
+            @globalActor
+            ↓final actor MyGlobalActor {}
+            """),
+        ],
+        corrections: [
+            Example("final actor MyActor {}"):
+                Example("actor MyActor {}"),
+            Example("public final actor DataStore {}"):
+                Example("public actor DataStore {}"),
+        ]
+    )
+}
+
+private extension RedundantFinalActorRule {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
+        override func visitPost(_ node: ActorDeclSyntax) {
+            if let finalModifier = node.modifiers.first(where: { $0.name.text == "final" }) {
+                violations.append(finalModifier.positionAfterSkippingLeadingTrivia)
+            }
+        }
+    }
+
+    final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
+        override func visit(_ node: ActorDeclSyntax) -> DeclSyntax {
+            guard let finalIndex = node.modifiers.firstIndex(where: { $0.name.text == "final" }) else {
+                return super.visit(node)
+            }
+            numberOfCorrections += 1
+            var modifiers = node.modifiers
+            modifiers.remove(at: finalIndex)
+            // If no modifiers remain, preserve the leading trivia on the actor keyword
+            var result = node.with(\.modifiers, modifiers)
+            if modifiers.isEmpty {
+                let leadingTrivia = node.modifiers[finalIndex].leadingTrivia
+                result = result.with(\.actorKeyword.leadingTrivia, leadingTrivia)
+            }
+            return super.visit(result)
+        }
+    }
+}

--- a/Tests/GeneratedTests/GeneratedTests_07.swift
+++ b/Tests/GeneratedTests/GeneratedTests_07.swift
@@ -151,8 +151,8 @@ final class RedundantDiscardableLetRuleGeneratedTests: SwiftLintTestCase {
     }
 }
 
-final class RedundantNilCoalescingRuleGeneratedTests: SwiftLintTestCase {
+final class RedundantFinalActorRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
-        verifyRule(RedundantNilCoalescingRule.description)
+        verifyRule(RedundantFinalActorRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_08.swift
+++ b/Tests/GeneratedTests/GeneratedTests_08.swift
@@ -7,6 +7,12 @@
 @testable import SwiftLintCore
 import TestHelpers
 
+final class RedundantNilCoalescingRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(RedundantNilCoalescingRule.description)
+    }
+}
+
 final class RedundantObjcAttributeRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(RedundantObjcAttributeRule.description)
@@ -148,11 +154,5 @@ final class StaticOverFinalClassRuleGeneratedTests: SwiftLintTestCase {
 final class StrictFilePrivateRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(StrictFilePrivateRule.description)
-    }
-}
-
-final class StrongIBOutletRuleGeneratedTests: SwiftLintTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(StrongIBOutletRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_09.swift
+++ b/Tests/GeneratedTests/GeneratedTests_09.swift
@@ -7,6 +7,12 @@
 @testable import SwiftLintCore
 import TestHelpers
 
+final class StrongIBOutletRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(StrongIBOutletRule.description)
+    }
+}
+
 final class SuperfluousElseRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(SuperfluousElseRule.description)
@@ -148,11 +154,5 @@ final class UnneededParenthesesInClosureArgumentRuleGeneratedTests: SwiftLintTes
 final class UnneededSynthesizedInitializerRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(UnneededSynthesizedInitializerRule.description)
-    }
-}
-
-final class UnneededThrowsRuleGeneratedTests: SwiftLintTestCase {
-    func testWithDefaultConfiguration() {
-        verifyRule(UnneededThrowsRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_10.swift
+++ b/Tests/GeneratedTests/GeneratedTests_10.swift
@@ -7,6 +7,12 @@
 @testable import SwiftLintCore
 import TestHelpers
 
+final class UnneededThrowsRuleGeneratedTests: SwiftLintTestCase {
+    func testWithDefaultConfiguration() {
+        verifyRule(UnneededThrowsRule.description)
+    }
+}
+
 final class UnownedVariableCaptureRuleGeneratedTests: SwiftLintTestCase {
     func testWithDefaultConfiguration() {
         verifyRule(UnownedVariableCaptureRule.description)

--- a/Tests/IntegrationTests/Resources/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/Resources/default_rule_configurations.yml
@@ -1006,6 +1006,11 @@ redundant_discardable_let:
   meta:
     opt-in: false
     correctable: true
+redundant_final_actor:
+  severity: warning
+  meta:
+    opt-in: true
+    correctable: true
 redundant_nil_coalescing:
   severity: warning
   meta:


### PR DESCRIPTION
## Summary

Implements #6407.

Actors in Swift cannot be subclassed ([SE-0306](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0306-actors.md#actors-2)), so the `final` modifier is always redundant on actor declarations. The compiler doesn't warn about this, but it's unnecessary noise similar to redundant `internal` access control.

## New Rule: `redundant_final_actor`

- **Kind:** Idiomatic
- **Default severity:** Warning
- **Opt-in:** Yes (since it doesn't affect logic, but may surprise developers unfamiliar with actor semantics)
- **Auto-correctable:** Yes — removes the redundant `final` modifier

### Examples

```swift
// Triggering
final actor MyActor {}           // → actor MyActor {}
public final actor DataStore {}  // → public actor DataStore {}

// Non-triggering
actor MyActor {}
final class MyClass {}
```

## Changes

- Added `RedundantFinalActorRule.swift` with visitor + rewriter
- Registered in `BuiltInRules.swift`