### PR TITLE
Add optional shorthand .init support to optional_data_string_conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@
   [ahmadalfy](https://github.com/ahmadalfy)
   [#6499](https://github.com/realm/SwiftLint/issues/6499)
 
+* Add `include_shorthand_init` option to
+  `optional_data_string_conversion` rule to optionally lint shorthand
+  `.init(decoding:as:)` calls as `String` conversions.  
+  [theamodhshetty](https://github.com/theamodhshetty)
+  [#6359](https://github.com/realm/SwiftLint/issues/6359)
+
 ### Bug Fixes
 
 * Ensure that disable commands work for `redundant_nil_coalescing` rule.  

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OptionalDataStringConversionConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OptionalDataStringConversionConfiguration.swift
@@ -1,0 +1,11 @@
+import SwiftLintCore
+
+@AutoConfigParser
+struct OptionalDataStringConversionConfiguration: SeverityBasedRuleConfiguration {
+    // swiftlint:disable:previous type_name
+
+    @ConfigurationElement(key: "severity")
+    private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement(key: "include_shorthand_init")
+    private(set) var includeShorthandInit = false
+}

--- a/Tests/IntegrationTests/Resources/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/Resources/default_rule_configurations.yml
@@ -837,6 +837,7 @@ operator_usage_whitespace:
     correctable: true
 optional_data_string_conversion:
   severity: warning
+  include_shorthand_init: false
   meta:
     opt-in: false
     correctable: false


### PR DESCRIPTION
## Summary
This updates `optional_data_string_conversion` to:
- detect `String.init(decoding:as:)` in addition to `String(decoding:as:)`
- optionally detect shorthand `.init(decoding:as:)` via a new config option:
  - `include_shorthand_init` (default: `false`)

The shorthand case is behind an option because `.init(...)` can be ambiguous without type context.

## Changes
- Added `OptionalDataStringConversionConfiguration` with:
  - `severity`
  - `include_shorthand_init` (default `false`)
- Updated rule visitor logic and examples
- Added `include_shorthand_init: false` to default rule configurations
- Added changelog entry under `Main > Enhancements`

## Testing
- `SWIFTPM_ENABLE_KEYCHAIN=0 swift test --filter OptionalDataStringConversionRuleGeneratedTests`
- `SWIFTPM_ENABLE_KEYCHAIN=0 swift test --filter RuleConfigurationTests`
- `SWIFTPM_ENABLE_KEYCHAIN=0 swift run swiftlint lint Source/SwiftLintBuiltInRules/Rules/Lint/OptionalDataStringConversionRule.swift`

Closes #6359
