### PR TITLE
Add allow_underscore_prefixed_names option to unused_parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@
   [ahmadalfy](https://github.com/ahmadalfy)
   [#6499](https://github.com/realm/SwiftLint/issues/6499)
 
+* Add `allow_underscore_prefixed_names` option to `unused_parameter` so
+  underscore-prefixed parameter names can be treated as intentionally
+  unused when configured.  
+  [theamodhshetty](https://github.com/theamodhshetty)
+  [#5741](https://github.com/realm/SwiftLint/issues/5741)
+
 ### Bug Fixes
 
 * Add an `ignore_attributes` option to `implicit_optional_initialization` so

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedParameterConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedParameterConfiguration.swift
@@ -1,0 +1,9 @@
+import SwiftLintCore
+
+@AutoConfigParser
+struct UnusedParameterConfiguration: SeverityBasedRuleConfiguration {
+    @ConfigurationElement(key: "severity")
+    private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement(key: "allow_underscore_prefixed_names")
+    private(set) var allowUnderscorePrefixedNames = false
+}

--- a/Tests/FrameworkTests/RuleConfigurationTests.swift
+++ b/Tests/FrameworkTests/RuleConfigurationTests.swift
@@ -347,6 +347,17 @@ final class RuleConfigurationTests: SwiftLintTestCase {
         }
     }
 
+    func testUnusedParameterConfigurationFromDictionary() throws {
+        var configuration = UnusedParameterConfiguration()
+        try configuration.apply(configuration: [
+            "severity": "error",
+            "allow_underscore_prefixed_names": true,
+        ])
+
+        XCTAssertEqual(configuration.severity, .error)
+        XCTAssertTrue(configuration.allowUnderscorePrefixedNames)
+    }
+
     func testComputedAccessorsOrderRuleConfiguration() throws {
         var configuration = ComputedAccessorsOrderConfiguration()
         let config = ["severity": "error", "order": "set_get"]

--- a/Tests/IntegrationTests/Resources/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/Resources/default_rule_configurations.yml
@@ -1356,6 +1356,7 @@ unused_optional_binding:
     correctable: false
 unused_parameter:
   severity: warning
+  allow_underscore_prefixed_names: false
   meta:
     opt-in: true
     correctable: true


### PR DESCRIPTION
## Summary
This adds a new `unused_parameter` configuration option:

- `allow_underscore_prefixed_names` (default: `false`)

When enabled, unused parameters whose names start with `_` are treated as intentionally unused and won't trigger violations.

## Changes
- Added `UnusedParameterConfiguration` with:
  - `severity`
  - `allow_underscore_prefixed_names`
- Updated `UnusedParameterRule` to use the new config and skip violations for `_`-prefixed names when enabled.
- Added rule examples for default and configured behavior.
- Added configuration parsing test.
- Added default config entry in integration fixtures.
- Added changelog entry under `Main > Enhancements`.

## Testing
- `SWIFTPM_ENABLE_KEYCHAIN=0 swift run swiftlint lint Source/SwiftLintBuiltInRules/Rules/Lint/UnusedParameterRule.swift Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnusedParameterConfiguration.swift Tests/FrameworkTests/RuleConfigurationTests.swift`
- `SWIFTPM_ENABLE_KEYCHAIN=0 swift test --filter UnusedParameterRuleGeneratedTests`
- `SWIFTPM_ENABLE_KEYCHAIN=0 swift test --filter RuleConfigurationTests`

Closes #5741
