### PR TITLE
junit: add testsuite name and failure line metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,8 +75,7 @@
 * Support access level modifiers on imports in `unused_imports` rule.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#6620](https://github.com/realm/SwiftLint/issues/6620)
-* Add `name` on JUnit `testsuite` output and include a `line` attribute on
-  each `failure` element for better CI parser compatibility.  
+
 * Add `name="SwiftLint"` to JUnit `testsuites` and `testsuite` output for
   better CI parser compatibility.  
   [theamodhshetty](https://github.com/theamodhshetty)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,10 @@
 * Support access level modifiers on imports in `unused_imports` rule.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#6620](https://github.com/realm/SwiftLint/issues/6620)
+* Add `name` on JUnit `testsuite` output and include a `line` attribute on
+  each `failure` element for better CI parser compatibility.  
+  [theamodhshetty](https://github.com/theamodhshetty)
+  [#6161](https://github.com/realm/SwiftLint/issues/6161)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@
   [#6620](https://github.com/realm/SwiftLint/issues/6620)
 * Add `name` on JUnit `testsuite` output and include a `line` attribute on
   each `failure` element for better CI parser compatibility.  
+* Add `name="SwiftLint"` to JUnit `testsuites` and `testsuite` output for
+  better CI parser compatibility.  
   [theamodhshetty](https://github.com/theamodhshetty)
   [#6161](https://github.com/realm/SwiftLint/issues/6161)
 

--- a/Source/SwiftLintFramework/Reporters/JUnitReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/JUnitReporter.swift
@@ -15,7 +15,7 @@ struct JUnitReporter: Reporter {
 
         return """
             <?xml version="1.0" encoding="utf-8"?>
-            <testsuites failures="\(warningCount)" errors="\(errorCount)" tests="\(testCount)">
+            <testsuites name="SwiftLint" failures="\(warningCount)" errors="\(errorCount)" tests="\(testCount)">
             \t<testsuite name="SwiftLint" failures="\(warningCount)" errors="\(errorCount)" tests="\(testCount)">
             \(violations.map(testCase(for:)).joined(separator: "\n"))
             \t</testsuite>
@@ -32,7 +32,7 @@ struct JUnitReporter: Reporter {
 
         return """
             \t\t<testcase classname='Formatting Test' name='\(fileName)'>
-            \t\t\t<failure message='\(reason)' line='\(lineNumber)'>\(message)</failure>
+            \t\t\t<failure message='\(reason)'>\(message)</failure>
             \t\t</testcase>
             """
     }

--- a/Source/SwiftLintFramework/Reporters/JUnitReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/JUnitReporter.swift
@@ -16,7 +16,7 @@ struct JUnitReporter: Reporter {
         return """
             <?xml version="1.0" encoding="utf-8"?>
             <testsuites failures="\(warningCount)" errors="\(errorCount)" tests="\(testCount)">
-            \t<testsuite failures="\(warningCount)" errors="\(errorCount)" tests="\(testCount)">
+            \t<testsuite name="SwiftLint" failures="\(warningCount)" errors="\(errorCount)" tests="\(testCount)">
             \(violations.map(testCase(for:)).joined(separator: "\n"))
             \t</testsuite>
             </testsuites>
@@ -32,7 +32,7 @@ struct JUnitReporter: Reporter {
 
         return """
             \t\t<testcase classname='Formatting Test' name='\(fileName)'>
-            \t\t\t<failure message='\(reason)'>\(message)</failure>
+            \t\t\t<failure message='\(reason)' line='\(lineNumber)'>\(message)</failure>
             \t\t</testcase>
             """
     }

--- a/Tests/FileSystemAccessTests/Resources/CannedJunitReporterOutput.xml
+++ b/Tests/FileSystemAccessTests/Resources/CannedJunitReporterOutput.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<testsuites failures="1" errors="3" tests="4">
+<testsuites name="SwiftLint" failures="1" errors="3" tests="4">
 	<testsuite name="SwiftLint" failures="1" errors="3" tests="4">
 		<testcase classname='Formatting Test' name='filename'>
-			<failure message='Violation Reason 1' line='1'>Warning:Line:1</failure>
+			<failure message='Violation Reason 1'>Warning:Line:1</failure>
 		</testcase>
 		<testcase classname='Formatting Test' name='filename'>
-			<failure message='Violation Reason 2' line='1'>Error:Line:1</failure>
+			<failure message='Violation Reason 2'>Error:Line:1</failure>
 		</testcase>
 		<testcase classname='Formatting Test' name='${CURRENT_WORKING_DIRECTORY}/path/file.swift'>
-			<failure message='Shorthand syntactic sugar should be used, i.e. [Int] instead of Array&lt;Int&gt;' line='1'>Error:Line:1</failure>
+			<failure message='Shorthand syntactic sugar should be used, i.e. [Int] instead of Array&lt;Int&gt;'>Error:Line:1</failure>
 		</testcase>
 		<testcase classname='Formatting Test' name='&lt;nopath&gt;'>
-			<failure message='Colons should be next to the identifier when specifying a type and next to the key in dictionary literals' line='0'>Error:Line:0</failure>
+			<failure message='Colons should be next to the identifier when specifying a type and next to the key in dictionary literals'>Error:Line:0</failure>
 		</testcase>
 	</testsuite>
 </testsuites>

--- a/Tests/FileSystemAccessTests/Resources/CannedJunitReporterOutput.xml
+++ b/Tests/FileSystemAccessTests/Resources/CannedJunitReporterOutput.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <testsuites failures="1" errors="3" tests="4">
-	<testsuite failures="1" errors="3" tests="4">
+	<testsuite name="SwiftLint" failures="1" errors="3" tests="4">
 		<testcase classname='Formatting Test' name='filename'>
-			<failure message='Violation Reason 1'>Warning:Line:1</failure>
+			<failure message='Violation Reason 1' line='1'>Warning:Line:1</failure>
 		</testcase>
 		<testcase classname='Formatting Test' name='filename'>
-			<failure message='Violation Reason 2'>Error:Line:1</failure>
+			<failure message='Violation Reason 2' line='1'>Error:Line:1</failure>
 		</testcase>
 		<testcase classname='Formatting Test' name='${CURRENT_WORKING_DIRECTORY}/path/file.swift'>
-			<failure message='Shorthand syntactic sugar should be used, i.e. [Int] instead of Array&lt;Int&gt;'>Error:Line:1</failure>
+			<failure message='Shorthand syntactic sugar should be used, i.e. [Int] instead of Array&lt;Int&gt;' line='1'>Error:Line:1</failure>
 		</testcase>
 		<testcase classname='Formatting Test' name='&lt;nopath&gt;'>
-			<failure message='Colons should be next to the identifier when specifying a type and next to the key in dictionary literals'>Error:Line:0</failure>
+			<failure message='Colons should be next to the identifier when specifying a type and next to the key in dictionary literals' line='0'>Error:Line:0</failure>
 		</testcase>
 	</testsuite>
 </testsuites>


### PR DESCRIPTION
## Summary

Follow-up to #6161 to improve JUnit XML compatibility for CI parsers.

## What changed

- Added `name="SwiftLint"` to the `<testsuite>` element in `JUnitReporter`.
- Added `line="..."` attribute to each `<failure>` element.
- Updated canned JUnit reporter fixture to match the new output.
- Added a changelog entry in `Main > Enhancements`.

## Why

Some JUnit consumers rely on suite naming and explicit line metadata for better ingestion/rendering.  
SwiftLint already reports counts; this adds metadata without changing violation semantics.

## Validation

- `swift test --filter ReporterTests/testJunitReporter`
- `swift test --filter ReporterTests`

## Checklist

- [x] Reporter output updated
- [x] Fixture/test updated
- [x] Changelog entry added
