### PR TITLE
Keep file content when the file is virtual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ### Enhancements
 
+* Print fixed code read from stdin to stdout.  
+  [SimplyDanny](https://github.com/SimplyDanny)
+  [#6501](https://github.com/realm/SwiftLint/issues/6501)
+
 * Add `ignored_literal_argument_functions` option to the `force_unwrapping` rule
   to skip violations for configurable function calls when all arguments are
   literal values (e.g. `URL(string: "https://example.com")!`). Defaults

--- a/Source/SwiftLintCore/Extensions/SwiftLintFile+Cache.swift
+++ b/Source/SwiftLintCore/Extensions/SwiftLintFile+Cache.swift
@@ -182,7 +182,9 @@ extension SwiftLintFile {
 
     /// Invalidates all cached data for this file.
     public func invalidateCache() {
-        file.clearCaches()
+        if !isVirtual {
+            file.clearCaches()
+        }
         responseCache.invalidate(self)
         assertHandlerCache.invalidate(self)
         structureDictionaryCache.invalidate(self)

--- a/Source/SwiftLintCore/Extensions/SwiftLintFile+Regex.swift
+++ b/Source/SwiftLintCore/Extensions/SwiftLintFile+Regex.swift
@@ -134,6 +134,7 @@ extension SwiftLintFile {
         guard string.isNotEmpty else {
             return
         }
+        defer { invalidateCache() }
         file.contents += string
         if isVirtual {
             return
@@ -147,13 +148,13 @@ extension SwiftLintFile {
         _ = fileHandle.seekToEndOfFile()
         fileHandle.write(stringData)
         fileHandle.closeFile()
-        invalidateCache()
     }
 
     public func write<S: StringProtocol>(_ string: S) {
         guard string != contents else {
             return
         }
+        defer { invalidateCache() }
         file.contents = String(string)
         if isVirtual {
             return
@@ -169,7 +170,6 @@ extension SwiftLintFile {
         } catch {
             queuedFatalError("can't write file to \(path)")
         }
-        invalidateCache()
     }
 
     public func ruleEnabled(violatingRanges: [NSRange], for rule: some Rule) -> [NSRange] {


### PR DESCRIPTION
Virtual files are not stored on disk and can thus also not be read from there again. Their content needs to stay in memory and be modified right there.

Fixes #6501.