### PR TITLE
Improve pattern_matching_keywords SwiftSyntax rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,10 @@
   [theamodhshetty](https://github.com/theamodhshetty)
   [#6161](https://github.com/realm/SwiftLint/issues/6161)
 
+* Improve the opt-in `pattern_matching_keywords` rule by extending support
+  beyond `switch case` and refining nested pattern handling.  
+  [GandaLF2006](https://github.com/GandaLF2006)
+
 ### Bug Fixes
 
 * Detect and autocorrect missing whitespace before `else` in `guard`

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PatternMatchingKeywordsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PatternMatchingKeywordsRule.swift
@@ -7,9 +7,12 @@ struct PatternMatchingKeywordsRule: Rule {
     static let description = RuleDescription(
         identifier: "pattern_matching_keywords",
         name: "Pattern Matching Keywords",
-        description: "Combine multiple pattern matching bindings by moving keywords out of tuples",
+        description: """
+            Combine multiple pattern matching bindings by moving keywords out of tuples
+            and enum associated values
+            """,
         kind: .idiomatic,
-        nonTriggeringExamples: [
+        nonTriggeringExamples: switchWrapped(examples: [
             Example("default"),
             Example("case 1"),
             Example("case bar"),
@@ -22,88 +25,238 @@ struct PatternMatchingKeywordsRule: Rule {
             Example("case .foo(var x)"),
             Example("case var .foo(x, y)"),
             Example("case (y, let x, z)"),
-        ].map(wrapInSwitch),
-        triggeringExamples: [
-            Example("case (↓let x,  ↓let y)"),
-            Example("case (↓let x,  ↓let y, .foo)"),
-            Example("case (↓let x,  ↓let y, _)"),
-            Example("case (↓let x,  ↓let y, f())"),
-            Example("case (↓let x,  ↓let y, s.f())"),
-            Example("case (↓let x,  ↓let y, s.t)"),
+            Example("case (foo, let x)"),
+            Example("case (foo, let x, let y)"),
+            Example("case .foo(bar, let x)"),
+            Example("case (let x, y)"),
+            Example("case .foo(let x, y)"),
+            Example("case (.foo(let x), y)"),
+            Example("case let .foo(x, y), let .bar(x, y)"),
+            Example("case var .foo(x, y), var .bar(x, y)"),
+            Example("case let .foo(x, y), let .bar(x, y), let .baz(x, y)"),
+            Example("case .foo(bar: let x, baz: var y)"),
+            Example("case (.yamlParsing(var x), (.yamlParsing(var y), z))"),
+            Example("case (.foo(let x), (y, let z))"),
+        ]) + [
+            Example("if case let (x, y) = foo {}"),
+            Example("guard case let (x, y) = foo else { return }"),
+            Example("while case let (x, y) = foo {}"),
+            Example("for case let (x, y) in foos {}"),
+            Example("if case (foo, let x) = value {}"),
+            Example("guard case .foo(bar, let x) = value else { return }"),
+            Example("do {} catch let Pattern.error(x, y) {}"),
+            Example("do {} catch (foo, let x) {}"),
+        ],
+        triggeringExamples: switchWrapped(examples: [
+            Example("case (↓let x, ↓let y)"),
+            Example("case (↓let x, ↓let y, .foo)"),
+            Example("case (↓let x, ↓let y, _)"),
+            Example("case (↓let x, ↓let y, 1)"),
+            Example("case (↓let x, ↓let y, f())"),
+            Example("case (↓let x, ↓let y, s.f())"),
+            Example("case (↓let x, ↓let y, s.t)"),
             Example("case .foo(↓let x, ↓let y)"),
-            Example("case (.yamlParsing(↓let x), .yamlParsing(↓let y))"),
-            Example("case (↓var x,  ↓var y)"),
+            Example("case .foo(bar: ↓let x, baz: ↓let y)"),
             Example("case .foo(↓var x, ↓var y)"),
-            Example("case (.yamlParsing(↓var x), .yamlParsing(↓var y))"),
-        ].map(wrapInSwitch)
+            Example("case .foo(bar: ↓var x, baz: ↓var y)"),
+            Example("case (.yamlParsing(↓let x), .yamlParsing(↓let y))"),
+            Example("case (.yamlParsing(↓var x), (.yamlParsing(↓var y), _))"),
+            Example("case ((↓let x, ↓let y), z)"),
+            Example("case .foo((↓let x, ↓let y), z)"),
+            Example("case (.foo(↓let x, ↓let y), z)"),
+            Example("case .foo(.bar(↓let x), .bar(↓let y))"),
+            Example("case .foo(.bar(↓let x), .bar(↓let y), .baz)"),
+            Example("case .foo(↓let x, ↓let y), .bar(↓let x, ↓let y)"),
+            Example("case .foo(↓var x, ↓var y), .bar(↓var x, ↓var y)"),
+        ]) + [
+            Example("if case (↓let x, ↓let y) = foo {}"),
+            Example("guard case (↓let x, ↓let y) = foo else { return }"),
+            Example("while case (↓let x, ↓let y) = foo {}"),
+            Example("for case (↓let x, ↓let y) in foos {}"),
+            Example("if case .foo(bar: ↓let x, baz: ↓let y) = value {}"),
+            Example("do {} catch Pattern.error(↓let x, ↓let y) {}"),
+            Example("do {} catch (↓let x, ↓let y) {}"),
+            Example("do {} catch Foo.outer(.inner(↓let x), .inner(↓let y)) {}"),
+        ]
     )
 
-    private static func wrapInSwitch(_ example: Example) -> Example {
-        example.with(code: """
-            switch foo {
-                \(example.code): break
-            }
-            """)
+    private static func switchWrapped(examples: [Example]) -> [Example] {
+        examples.map { example in
+            example.with(
+                code: """
+                switch foo {
+                    \(example.code): break
+                }
+                """
+            )
+        }
     }
 }
 
 private extension PatternMatchingKeywordsRule {
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: SwitchCaseItemSyntax) {
-            let localViolations = TupleVisitor(configuration: configuration, file: file)
-                .walk(tree: node.pattern, handler: \.violations)
-            violations.append(contentsOf: localViolations)
+            appendViolations(from: node.pattern)
+        }
+
+        override func visitPost(_ node: MatchingPatternConditionSyntax) {
+            appendViolations(from: node.pattern)
+        }
+
+        override func visitPost(_ node: ForStmtSyntax) {
+            guard node.caseKeyword != nil else {
+                return
+            }
+
+            appendViolations(from: node.pattern)
+        }
+
+        override func visitPost(_ node: CatchItemSyntax) {
+            guard let pattern = node.pattern else {
+                return
+            }
+
+            appendViolations(from: pattern)
+        }
+
+        private func appendViolations(from pattern: PatternSyntax) {
+            violations.append(contentsOf: PatternViolationCollector.collect(in: pattern))
         }
     }
 }
 
-private final class TupleVisitor<Configuration: RuleConfiguration>: ViolationsSyntaxVisitor<Configuration> {
-    override func visitPost(_ node: LabeledExprListSyntax) {
-        let list = node.flatteningEnumPatterns().map(\.expression.categorized)
-        if list.contains(where: \.isReference) {
+private enum PatternViolationCollector {
+    static func collect(in pattern: PatternSyntax) -> [AbsolutePosition] {
+        var violations: [AbsolutePosition] = []
+        collect(from: pattern, into: &violations)
+        return violations
+    }
+
+    private static func collect(from pattern: PatternSyntax, into violations: inout [AbsolutePosition]) {
+        if let binding = pattern.as(ValueBindingPatternSyntax.self) {
+            collect(from: binding.pattern, into: &violations)
             return
         }
-        let specifiers = list.compactMap { if case let .binding(specifier) = $0 { specifier } else { nil } }
-        if specifiers.count > 1, specifiers.allSatisfy({ $0.tokenKind == specifiers.first?.tokenKind }) {
+
+        guard let expression = pattern.as(ExpressionPatternSyntax.self)?.expression else {
+            return
+        }
+
+        collect(from: expression, into: &violations)
+    }
+
+    private static func collect(from expression: ExprSyntax, into violations: inout [AbsolutePosition]) {
+        if let childExpressions = expression.immediatePatternGroupChildren {
+            appendViolationsIfBindingsCanBeLifted(from: childExpressions, into: &violations)
+
+            for childExpression in childExpressions {
+                collect(from: childExpression, into: &violations)
+            }
+
+            return
+        }
+
+        if let pattern = expression.as(PatternExprSyntax.self)?.pattern {
+            collect(from: pattern, into: &violations)
+        }
+    }
+
+    private static func appendViolationsIfBindingsCanBeLifted(
+        from expressions: [ExprSyntax],
+        into violations: inout [AbsolutePosition]
+    ) {
+        let categories = expressions.map(GroupCategoryResolver.category(for:))
+
+        if categories.contains(where: \.isReference) {
+            return
+        }
+
+        let specifiers = categories.compactMap(\.bindingSpecifier)
+        guard specifiers.count > 1, let first = specifiers.first else {
+            return
+        }
+
+        if specifiers.allSatisfy({ $0.tokenKind == first.tokenKind }) {
             violations.append(contentsOf: specifiers.map(\.positionAfterSkippingLeadingTrivia))
         }
     }
 }
 
-private extension LabeledExprListSyntax {
-    func flatteningEnumPatterns() -> [LabeledExprSyntax] {
-        flatMap { elem in
-            guard let pattern = elem.expression.as(FunctionCallExprSyntax.self),
-                  pattern.calledExpression.is(MemberAccessExprSyntax.self) else {
-                return [elem]
-            }
+private enum GroupCategory {
+    case binding(specifier: TokenSyntax)
+    case reference
+    case neutral
 
-            return Array(pattern.arguments)
+    var isReference: Bool {
+        switch self {
+        case .reference:
+            return true
+        default:
+            return false
+        }
+    }
+
+    var bindingSpecifier: TokenSyntax? {
+        switch self {
+        case let .binding(specifier):
+            return specifier
+        default:
+            return nil
         }
     }
 }
 
-private enum ArgumentType {
-    case binding(specifier: TokenSyntax)
-    case reference
-    case constant
-
-    var isReference: Bool {
-        switch self {
-        case .reference: true
-        default: false
+private enum GroupCategoryResolver {
+    static func category(for expression: ExprSyntax) -> GroupCategory {
+        if let binding = expression.as(PatternExprSyntax.self)?.pattern.as(ValueBindingPatternSyntax.self) {
+            return .binding(specifier: binding.bindingSpecifier)
         }
+
+        // `case (foo, let x)` must not become `case let (foo, x)`,
+        // because `foo` would stop matching an existing value and
+        // would instead become a newly introduced binding.
+        if expression.is(DeclReferenceExprSyntax.self) {
+            return .reference
+        }
+
+        if let childExpressions = expression.immediatePatternGroupChildren {
+            return liftedCategory(for: childExpressions)
+        }
+
+        return .neutral
+    }
+
+    private static func liftedCategory(for expressions: [ExprSyntax]) -> GroupCategory {
+        let categories = expressions.map(category(for:))
+
+        if categories.contains(where: \.isReference) {
+            return .neutral
+        }
+
+        let specifiers = categories.compactMap(\.bindingSpecifier)
+        guard let first = specifiers.first else {
+            return .neutral
+        }
+
+        if specifiers.allSatisfy({ $0.tokenKind == first.tokenKind }) {
+            return .binding(specifier: first)
+        }
+
+        return .neutral
     }
 }
 
 private extension ExprSyntax {
-    var categorized: ArgumentType {
-        if let binding = `as`(PatternExprSyntax.self)?.pattern.as(ValueBindingPatternSyntax.self) {
-            return .binding(specifier: binding.bindingSpecifier)
+    var immediatePatternGroupChildren: [ExprSyntax]? {
+        if let tuple = `as`(TupleExprSyntax.self) {
+            return tuple.elements.map(\.expression)
         }
-        if `is`(DeclReferenceExprSyntax.self) {
-            return .reference
+
+        if let call = `as`(FunctionCallExprSyntax.self),
+           call.calledExpression.is(MemberAccessExprSyntax.self) {
+            return call.arguments.map(\.expression)
         }
-        return .constant
+
+        return nil
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PatternMatchingKeywordsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PatternMatchingKeywordsRule.swift
@@ -9,7 +9,7 @@ struct PatternMatchingKeywordsRule: Rule {
         name: "Pattern Matching Keywords",
         description: "Combine multiple pattern matching bindings by moving keywords out of tuples",
         kind: .idiomatic,
-        nonTriggeringExamples: switchWrapped(examples: [
+        nonTriggeringExamples: [
             Example("default"),
             Example("case 1"),
             Example("case bar"),
@@ -34,7 +34,7 @@ struct PatternMatchingKeywordsRule: Rule {
             Example("case .foo(bar: let x, baz: var y)"),
             Example("case (.yamlParsing(var x), (.yamlParsing(var y), z))"),
             Example("case (.foo(let x), (y, let z))"),
-        ]) + [
+        ].map(wrapInSwitch) + [
             Example("if case let (x, y) = foo {}"),
             Example("guard case let (x, y) = foo else { return }"),
             Example("while case let (x, y) = foo {}"),
@@ -44,7 +44,7 @@ struct PatternMatchingKeywordsRule: Rule {
             Example("do {} catch let Pattern.error(x, y) {}"),
             Example("do {} catch (foo, let x) {}"),
         ],
-        triggeringExamples: switchWrapped(examples: [
+        triggeringExamples: [
             Example("case (↓let x, ↓let y)"),
             Example("case (↓let x, ↓let y, .foo)"),
             Example("case (↓let x, ↓let y, _)"),
@@ -65,7 +65,7 @@ struct PatternMatchingKeywordsRule: Rule {
             Example("case .foo(.bar(↓let x), .bar(↓let y), .baz)"),
             Example("case .foo(↓let x, ↓let y), .bar(↓let x, ↓let y)"),
             Example("case .foo(↓var x, ↓var y), .bar(↓var x, ↓var y)"),
-        ]) + [
+        ].map(wrapInSwitch) + [
             Example("if case (↓let x, ↓let y) = foo {}"),
             Example("guard case (↓let x, ↓let y) = foo else { return }"),
             Example("while case (↓let x, ↓let y) = foo {}"),
@@ -77,16 +77,13 @@ struct PatternMatchingKeywordsRule: Rule {
         ]
     )
 
-    private static func switchWrapped(examples: [Example]) -> [Example] {
-        examples.map { example in
-            example.with(
-                code: """
-                switch foo {
-                    \(example.code): break
-                }
-                """
-            )
-        }
+    private static func wrapInSwitch(_ example: Example) -> Example {
+        example.with(code: """
+            switch foo {
+                \(example.code): break
+            }
+            """
+        )
     }
 }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PatternMatchingKeywordsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PatternMatchingKeywordsRule.swift
@@ -4,6 +4,12 @@ import SwiftSyntax
 struct PatternMatchingKeywordsRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
+    enum Reason {
+        static let tuples = "Combine multiple pattern matching bindings by moving keywords out of tuples"
+        static let enumAssociatedValues =
+            "Combine multiple pattern matching bindings by moving keywords out of enum associated values"
+    }
+
     static let description = RuleDescription(
         identifier: "pattern_matching_keywords",
         name: "Pattern Matching Keywords",
@@ -90,11 +96,11 @@ struct PatternMatchingKeywordsRule: Rule {
 private extension PatternMatchingKeywordsRule {
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: SwitchCaseItemSyntax) {
-            appendViolations(from: node.pattern)
+            collectViolations(from: node.pattern)
         }
 
         override func visitPost(_ node: MatchingPatternConditionSyntax) {
-            appendViolations(from: node.pattern)
+            collectViolations(from: node.pattern)
         }
 
         override func visitPost(_ node: ForStmtSyntax) {
@@ -102,7 +108,7 @@ private extension PatternMatchingKeywordsRule {
                 return
             }
 
-            appendViolations(from: node.pattern)
+            collectViolations(from: node.pattern)
         }
 
         override func visitPost(_ node: CatchItemSyntax) {
@@ -110,78 +116,55 @@ private extension PatternMatchingKeywordsRule {
                 return
             }
 
-            appendViolations(from: pattern)
+            collectViolations(from: pattern)
         }
 
-        private func appendViolations(from pattern: PatternSyntax) {
-            violations.append(contentsOf: PatternViolationCollector.collect(in: pattern))
-        }
-    }
-}
-
-private enum PatternViolationCollector {
-    static func collect(in pattern: PatternSyntax) -> [ReasonedRuleViolation] {
-        var violations: [ReasonedRuleViolation] = []
-        collect(from: pattern, into: &violations)
-        return violations
-    }
-
-    private static func collect(from pattern: PatternSyntax, into violations: inout [ReasonedRuleViolation]) {
-        if let binding = pattern.as(ValueBindingPatternSyntax.self) {
-            collect(from: binding.pattern, into: &violations)
-            return
-        }
-
-        guard let expression = pattern.as(ExpressionPatternSyntax.self)?.expression else {
-            return
-        }
-
-        collect(from: expression, into: &violations)
-    }
-
-    private static func collect(from expression: ExprSyntax, into violations: inout [ReasonedRuleViolation]) {
-        if let childExpressions = expression.immediatePatternGroupChildren {
-            appendViolationsIfBindingsCanBeLifted(from: childExpressions, into: &violations, isTuple: expression.is(TupleExprSyntax.self))
-
-            for childExpression in childExpressions {
-                collect(from: childExpression, into: &violations)
+        private func collectViolations(from pattern: PatternSyntax) {
+            if let binding = pattern.as(ValueBindingPatternSyntax.self) {
+                collectViolations(from: binding.pattern)
+                return
             }
 
-            return
+            guard let expression = pattern.as(ExpressionPatternSyntax.self)?.expression else {
+                return
+            }
+
+            collectViolations(from: expression)
         }
 
-        if let pattern = expression.as(PatternExprSyntax.self)?.pattern {
-            collect(from: pattern, into: &violations)
-        }
-    }
+        private func collectViolations(from expression: ExprSyntax) {
+            guard let childExpressions = expression.immediatePatternGroupChildren else {
+                if let pattern = expression.as(PatternExprSyntax.self)?.pattern {
+                    collectViolations(from: pattern)
+                }
 
-    private static func appendViolationsIfBindingsCanBeLifted(
-        from expressions: [ExprSyntax],
-        into violations: inout [ReasonedRuleViolation],
-        isTuple: Bool
-    ) {
-        let categories = expressions.map(GroupCategory.from(expression:))
+                return
+            }
 
-        if categories.contains(.reference) {
-            return
-        }
+            let categories = childExpressions.map(GroupCategory.from(expression:))
 
-        let specifiers = categories.compactMap {
-            if case let .binding(specifier) = $0 { return specifier }
-            return nil
-        }
-        guard specifiers.count > 1, let first = specifiers.first else {
-            return
-        }
+            if !categories.contains(.reference) {
+                let specifiers = categories.compactMap {
+                    if case let .binding(specifier) = $0 { return specifier }
+                    return nil
+                }
 
-        if specifiers.allSatisfy({ $0.tokenKind == first.tokenKind }) {
-            let reason = isTuple
-                ? "Combine multiple pattern matching bindings by moving keywords out of tuples"
-                : "Combine multiple pattern matching bindings by moving keywords out of enum associated values"
+                if specifiers.count > 1,
+                   let first = specifiers.first,
+                   specifiers.allSatisfy({ $0.tokenKind == first.tokenKind }) {
+                    let reason = expression.is(TupleExprSyntax.self)
+                        ? Reason.tuples
+                        : Reason.enumAssociatedValues
 
-            violations.append(contentsOf: specifiers.map {
-                ReasonedRuleViolation(position: $0.positionAfterSkippingLeadingTrivia, reason: reason)
-            })
+                    violations.append(contentsOf: specifiers.map {
+                        ReasonedRuleViolation(position: $0.positionAfterSkippingLeadingTrivia, reason: reason)
+                    })
+                }
+            }
+
+            for childExpression in childExpressions {
+                collectViolations(from: childExpression)
+            }
         }
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PatternMatchingKeywordsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PatternMatchingKeywordsRule.swift
@@ -7,10 +7,7 @@ struct PatternMatchingKeywordsRule: Rule {
     static let description = RuleDescription(
         identifier: "pattern_matching_keywords",
         name: "Pattern Matching Keywords",
-        description: """
-            Combine multiple pattern matching bindings by moving keywords out of tuples
-            and enum associated values
-            """,
+        description: "Combine multiple pattern matching bindings by moving keywords out of tuples",
         kind: .idiomatic,
         nonTriggeringExamples: switchWrapped(examples: [
             Example("default"),
@@ -126,13 +123,13 @@ private extension PatternMatchingKeywordsRule {
 }
 
 private enum PatternViolationCollector {
-    static func collect(in pattern: PatternSyntax) -> [AbsolutePosition] {
-        var violations: [AbsolutePosition] = []
+    static func collect(in pattern: PatternSyntax) -> [ReasonedRuleViolation] {
+        var violations: [ReasonedRuleViolation] = []
         collect(from: pattern, into: &violations)
         return violations
     }
 
-    private static func collect(from pattern: PatternSyntax, into violations: inout [AbsolutePosition]) {
+    private static func collect(from pattern: PatternSyntax, into violations: inout [ReasonedRuleViolation]) {
         if let binding = pattern.as(ValueBindingPatternSyntax.self) {
             collect(from: binding.pattern, into: &violations)
             return
@@ -145,9 +142,9 @@ private enum PatternViolationCollector {
         collect(from: expression, into: &violations)
     }
 
-    private static func collect(from expression: ExprSyntax, into violations: inout [AbsolutePosition]) {
+    private static func collect(from expression: ExprSyntax, into violations: inout [ReasonedRuleViolation]) {
         if let childExpressions = expression.immediatePatternGroupChildren {
-            appendViolationsIfBindingsCanBeLifted(from: childExpressions, into: &violations)
+            appendViolationsIfBindingsCanBeLifted(from: childExpressions, into: &violations, isTuple: expression.is(TupleExprSyntax.self))
 
             for childExpression in childExpressions {
                 collect(from: childExpression, into: &violations)
@@ -163,7 +160,8 @@ private enum PatternViolationCollector {
 
     private static func appendViolationsIfBindingsCanBeLifted(
         from expressions: [ExprSyntax],
-        into violations: inout [AbsolutePosition]
+        into violations: inout [ReasonedRuleViolation],
+        isTuple: Bool
     ) {
         let categories = expressions.map(GroupCategoryResolver.category(for:))
 
@@ -177,7 +175,13 @@ private enum PatternViolationCollector {
         }
 
         if specifiers.allSatisfy({ $0.tokenKind == first.tokenKind }) {
-            violations.append(contentsOf: specifiers.map(\.positionAfterSkippingLeadingTrivia))
+            let reason = isTuple
+                ? "Combine multiple pattern matching bindings by moving keywords out of tuples"
+                : "Combine multiple pattern matching bindings by moving keywords out of enum associated values"
+
+            violations.append(contentsOf: specifiers.map {
+                ReasonedRuleViolation(position: $0.positionAfterSkippingLeadingTrivia, reason: reason)
+            })
         }
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PatternMatchingKeywordsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PatternMatchingKeywordsRule.swift
@@ -166,7 +166,10 @@ private enum PatternViolationCollector {
             return
         }
 
-        let specifiers = categories.compactMap(\.bindingSpecifier)
+        let specifiers = categories.compactMap {
+            if case let .binding(specifier) = $0 { return specifier }
+            return nil
+        }
         guard specifiers.count > 1, let first = specifiers.first else {
             return
         }
@@ -187,15 +190,6 @@ private enum GroupCategory: Equatable {
     case binding(specifier: TokenSyntax)
     case reference
     case neutral
-
-    var bindingSpecifier: TokenSyntax? {
-        switch self {
-        case let .binding(specifier):
-            return specifier
-        default:
-            return nil
-        }
-    }
 }
 
 private enum GroupCategoryResolver {
@@ -225,7 +219,10 @@ private enum GroupCategoryResolver {
             return .neutral
         }
 
-        let specifiers = categories.compactMap(\.bindingSpecifier)
+        let specifiers = categories.compactMap {
+            if case let .binding(specifier) = $0 { return specifier }
+            return nil
+        }
         guard let first = specifiers.first else {
             return .neutral
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PatternMatchingKeywordsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PatternMatchingKeywordsRule.swift
@@ -162,7 +162,7 @@ private enum PatternViolationCollector {
     ) {
         let categories = expressions.map(GroupCategoryResolver.category(for:))
 
-        if categories.contains(where: \.isReference) {
+        if categories.contains(.reference) {
             return
         }
 
@@ -183,19 +183,10 @@ private enum PatternViolationCollector {
     }
 }
 
-private enum GroupCategory {
+private enum GroupCategory: Equatable {
     case binding(specifier: TokenSyntax)
     case reference
     case neutral
-
-    var isReference: Bool {
-        switch self {
-        case .reference:
-            return true
-        default:
-            return false
-        }
-    }
 
     var bindingSpecifier: TokenSyntax? {
         switch self {
@@ -230,7 +221,7 @@ private enum GroupCategoryResolver {
     private static func liftedCategory(for expressions: [ExprSyntax]) -> GroupCategory {
         let categories = expressions.map(category(for:))
 
-        if categories.contains(where: \.isReference) {
+        if categories.contains(.reference) {
             return .neutral
         }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PatternMatchingKeywordsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PatternMatchingKeywordsRule.swift
@@ -5,15 +5,21 @@ struct PatternMatchingKeywordsRule: Rule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     enum Reason {
-        static let tuples = "Combine multiple pattern matching bindings by moving keywords out of tuples"
-        static let enumAssociatedValues =
-            "Combine multiple pattern matching bindings by moving keywords out of enum associated values"
+        static let tuples = """
+            Combine multiple pattern bindings by moving binding keywords out of tuple
+            """
+        static let enumAssociatedValues = """
+            Combine multiple pattern bindings by moving binding keywords out of associated values
+            """
     }
 
     static let description = RuleDescription(
         identifier: "pattern_matching_keywords",
         name: "Pattern Matching Keywords",
-        description: "Combine multiple pattern matching bindings by moving keywords out of tuples",
+        description: """
+            Combine multiple pattern matching bindings by moving binding keywords out of tuples and associated values
+            in enum cases to reduce visual noise.
+            """,
         kind: .idiomatic,
         nonTriggeringExamples: [
             Example("default"),

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PatternMatchingKeywordsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PatternMatchingKeywordsRule.swift
@@ -160,7 +160,7 @@ private enum PatternViolationCollector {
         into violations: inout [ReasonedRuleViolation],
         isTuple: Bool
     ) {
-        let categories = expressions.map(GroupCategoryResolver.category(for:))
+        let categories = expressions.map(GroupCategory.from(expression:))
 
         if categories.contains(.reference) {
             return
@@ -190,10 +190,8 @@ private enum GroupCategory: Equatable {
     case binding(specifier: TokenSyntax)
     case reference
     case neutral
-}
 
-private enum GroupCategoryResolver {
-    static func category(for expression: ExprSyntax) -> GroupCategory {
+    static func from(expression: ExprSyntax) -> Self {
         if let binding = expression.as(PatternExprSyntax.self)?.pattern.as(ValueBindingPatternSyntax.self) {
             return .binding(specifier: binding.bindingSpecifier)
         }
@@ -206,14 +204,14 @@ private enum GroupCategoryResolver {
         }
 
         if let childExpressions = expression.immediatePatternGroupChildren {
-            return liftedCategory(for: childExpressions)
+            return liftedCategory(from: childExpressions)
         }
 
         return .neutral
     }
 
-    private static func liftedCategory(for expressions: [ExprSyntax]) -> GroupCategory {
-        let categories = expressions.map(category(for:))
+    private static func liftedCategory(from expressions: [ExprSyntax]) -> Self {
+        let categories = expressions.map { from(expression: $0) }
 
         if categories.contains(.reference) {
             return .neutral

--- a/Source/SwiftLintFramework/Configuration/Configuration+Parsing.swift
+++ b/Source/SwiftLintFramework/Configuration/Configuration+Parsing.swift
@@ -211,8 +211,8 @@ extension Configuration {
 
         if case .onlyConfiguration(let onlyRules) = parentConfiguration?.rulesMode {
             enabledInParentRules = onlyRules
-        } else if case .defaultConfiguration(
-            let parentDisabledRules, let parentOptInRules
+        } else if case let .defaultConfiguration(
+            parentDisabledRules, parentOptInRules
         ) = parentConfiguration?.rulesMode {
             enabledInParentRules = parentOptInRules
             disabledInParentRules = parentDisabledRules

--- a/Tests/BuiltInRulesTests/PatternMatchingKeywordsRuleTests.swift
+++ b/Tests/BuiltInRulesTests/PatternMatchingKeywordsRuleTests.swift
@@ -1,0 +1,131 @@
+@testable import SwiftLintBuiltInRules
+import TestHelpers
+
+final class PatternMatchingKeywordsRuleTests: SwiftLintTestCase {
+    func testRegressionExamples() {
+        let triggering = [
+            "switch foo { case (.yamlParsing(↓let x), .yamlParsing(↓let y)): break }",
+            "switch foo { case (.yamlParsing(↓var x), (.yamlParsing(↓var y), _)): break }",
+            """
+            do {} catch Foo.outer(.inner(↓let x), .inner(↓let y)) {}
+            """,
+        ]
+
+        let nonTriggering = [
+            "switch foo { case (.yamlParsing(var x), (.yamlParsing(var y), z)): break }",
+            "switch foo { case (foo, let x): break }",
+            "if case (foo, let x) = value {}",
+        ]
+
+        verifyRule(
+            PatternMatchingKeywordsRule.description.with(
+                nonTriggeringExamples: nonTriggering.map { Example($0) },
+                triggeringExamples: triggering.map { Example($0) }
+            )
+        )
+    }
+
+    func testLabeledAssociatedValues() {
+        let triggering = [
+            "switch foo { case .foo(bar: ↓let lhs, baz: ↓let rhs): break }",
+            "switch foo { case .foo(bar: ↓var lhs, baz: ↓var rhs): break }",
+            "do {} catch .foo(bar: ↓let x, baz: ↓let y) {}",
+        ]
+
+        let nonTriggering = [
+            "switch foo { case let .foo(bar: lhs, baz: rhs): break }",
+            "switch foo { case var .foo(bar: lhs, baz: rhs): break }",
+            "switch foo { case .foo(bar: existingValue, baz: let x): break }",
+            "switch foo { case .foo(bar: let x, baz: existingValue): break }",
+            "do {} catch let .foo(bar: x, baz: y) {}",
+        ]
+
+        verifyRule(
+            PatternMatchingKeywordsRule.description.with(
+                nonTriggeringExamples: nonTriggering.map { Example($0) },
+                triggeringExamples: triggering.map { Example($0) }
+            )
+        )
+    }
+
+    func testSingleBindingDoesNotTrigger() {
+        let examples = [
+            "switch foo { case (let x, y): break }",
+            "switch foo { case .foo(let x, y): break }",
+            "switch foo { case (.foo(let x), y): break }",
+        ]
+
+        verifyRule(
+            PatternMatchingKeywordsRule.description.with(
+                nonTriggeringExamples: examples.map { Example($0) }
+            )
+        )
+    }
+
+    func testNeutralElementsDoNotBlockLift() {
+        let examples = [
+            "switch foo { case (↓let x, ↓let y, _): break }",
+            "switch foo { case (↓let x, ↓let y, 1): break }",
+            "switch foo { case (↓let x, ↓let y, .foo): break }",
+            "switch foo { case (↓let x, ↓let y, s.t): break }",
+            "switch foo { case .foo(↓let x, ↓let y, _): break }",
+            "switch foo { case .foo(.bar(↓let x), .bar(↓let y), .baz): break }",
+        ]
+
+        verifyRule(
+            PatternMatchingKeywordsRule.description.with(
+                triggeringExamples: examples.map { Example($0) }
+            )
+        )
+    }
+
+    func testThreeAlternativeMultiPatternCase() {
+        let triggering = [
+            "switch foo { case .foo(↓let x, ↓let y), .bar(↓let x, ↓let y), .baz(↓let x, ↓let y): break }",
+        ]
+
+        let nonTriggering = [
+            "switch foo { case let .foo(x, y), let .bar(x, y), let .baz(x, y): break }",
+        ]
+
+        verifyRule(
+            PatternMatchingKeywordsRule.description.with(
+                nonTriggeringExamples: nonTriggering.map { Example($0) },
+                triggeringExamples: triggering.map { Example($0) }
+            )
+        )
+    }
+
+    func testForCaseWithEnumAssociatedValues() {
+        let triggering = [
+            "for case .foo(↓let x, ↓let y) in values {}",
+        ]
+
+        let nonTriggering = [
+            "for case let .foo(x, y) in values {}",
+            "for case .foo(existingValue, let x) in values {}",
+        ]
+
+        verifyRule(
+            PatternMatchingKeywordsRule.description.with(
+                nonTriggeringExamples: nonTriggering.map { Example($0) },
+                triggeringExamples: triggering.map { Example($0) }
+            )
+        )
+    }
+
+    func testSanityChecksForNonInterestingPatterns() {
+        let examples = [
+            "switch foo { case _: break }",
+            "switch foo { case .foo: break }",
+            "switch foo { case 42: break }",
+            "switch foo { case existingValue: break }",
+        ]
+
+        verifyRule(
+            PatternMatchingKeywordsRule.description.with(
+                nonTriggeringExamples: examples.map { Example($0) }
+            )
+        )
+    }
+}

--- a/Tests/BuiltInRulesTests/PatternMatchingKeywordsRuleTests.swift
+++ b/Tests/BuiltInRulesTests/PatternMatchingKeywordsRuleTests.swift
@@ -11,7 +11,7 @@ final class PatternMatchingKeywordsRuleTests: SwiftLintTestCase {
         XCTAssertEqual(violations.count, 2)
         XCTAssertEqual(
             violations.first?.reason,
-            "Combine multiple pattern matching bindings by moving keywords out of tuples"
+            PatternMatchingKeywordsRule.Reason.tuples
         )
     }
 
@@ -23,9 +23,10 @@ final class PatternMatchingKeywordsRuleTests: SwiftLintTestCase {
         XCTAssertEqual(violations.count, 2)
         XCTAssertEqual(
             violations.first?.reason,
-            "Combine multiple pattern matching bindings by moving keywords out of enum associated values"
+            PatternMatchingKeywordsRule.Reason.enumAssociatedValues
         )
     }
+
     func testRegressionExamples() {
         let triggering = [
             "switch foo { case (.yamlParsing(↓let x), .yamlParsing(↓let y)): break }",

--- a/Tests/BuiltInRulesTests/PatternMatchingKeywordsRuleTests.swift
+++ b/Tests/BuiltInRulesTests/PatternMatchingKeywordsRuleTests.swift
@@ -1,7 +1,31 @@
 @testable import SwiftLintBuiltInRules
 import TestHelpers
+import XCTest
 
 final class PatternMatchingKeywordsRuleTests: SwiftLintTestCase {
+    func testViolationReasonForTuples() throws {
+        let config = try XCTUnwrap(makeConfig(nil, PatternMatchingKeywordsRule.identifier))
+        let example = Example("switch foo { case (let x, let y): break }")
+        let violations = violations(example, config: config)
+
+        XCTAssertEqual(violations.count, 2)
+        XCTAssertEqual(
+            violations.first?.reason,
+            "Combine multiple pattern matching bindings by moving keywords out of tuples"
+        )
+    }
+
+    func testViolationReasonForEnumAssociatedValues() throws {
+        let config = try XCTUnwrap(makeConfig(nil, PatternMatchingKeywordsRule.identifier))
+        let example = Example("switch foo { case .bar(let x, let y): break }")
+        let violations = violations(example, config: config)
+
+        XCTAssertEqual(violations.count, 2)
+        XCTAssertEqual(
+            violations.first?.reason,
+            "Combine multiple pattern matching bindings by moving keywords out of enum associated values"
+        )
+    }
     func testRegressionExamples() {
         let triggering = [
             "switch foo { case (.yamlParsing(↓let x), .yamlParsing(↓let y)): break }",

--- a/Tests/FileSystemAccessTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/FileSystemAccessTests/ConfigurationTests+MultipleConfigs.swift
@@ -488,7 +488,7 @@ extension ConfigurationTests {
         configuration: Configuration,
         ruleType: any Rule.Type
     ) {
-        guard case .defaultConfiguration(let disabledRules, let optInRules) = configuration.rulesMode else {
+        guard case let .defaultConfiguration(disabledRules, optInRules) = configuration.rulesMode else {
             XCTFail("Configuration rulesMode was not the default")
             return
         }


### PR DESCRIPTION
## Summary

This PR improves the existing opt-in SwiftLint rule `pattern_matching_keywords`.

Compared to the original implementation, the rule now covers more pattern-matching contexts and handles nested tuple/enum associated value patterns more reliably.

## What changed

The original implementation only analyzed `switch` case items and relied on a narrower syntax-based approach.

This update expands the rule to also check:

- `if case`
- `guard case`
- `while case`
- `for case`
- `catch`

It also improves handling of:

- nested tuple patterns
- nested enum associated value patterns
- labeled associated values
- multi-pattern `case` clauses