### PR TITLE
Fix false positives in vertical_parameter_alignment_on_call with Unicode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,12 @@
   [SimplyDanny](https://github.com/SimplyDanny)
   [#6466](https://github.com/realm/SwiftLint/issues/6466)
 
+* Measure alignment columns in `vertical_parameter_alignment_on_call` using
+  character positions instead of raw UTF-8 columns, avoiding false positives
+  when a preceding line contains multi-byte characters.  
+  [theamodhshetty](https://github.com/theamodhshetty)
+  [#6467](https://github.com/realm/SwiftLint/issues/6467)
+
 ## 0.63.2: High-Speed Extraction
 
 ### Breaking

--- a/Source/SwiftLintBuiltInRules/Rules/Style/VerticalParameterAlignmentOnCallRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/VerticalParameterAlignmentOnCallRule.swift
@@ -83,6 +83,15 @@ struct VerticalParameterAlignmentOnCallRule: Rule {
                 // completion
             }
             """),
+            Example("""
+            func test() {
+                СreateAdUpdateShopHelper.updateShopModels(categoryModels: &categoryModels,
+                                                          contactModels: &contactModels,
+                                                          country: response.country!,
+                                                          contact: response.contact,
+                                                          shop: response.shop)
+            }
+            """),
         ],
         triggeringExamples: [
             Example("""
@@ -132,7 +141,7 @@ private extension VerticalParameterAlignmentOnCallRule {
                 return
             }
 
-            var firstArgumentLocation = locationConverter.location(for: firstArg.positionAfterSkippingLeadingTrivia)
+            var firstArgumentLocation = characterLocation(for: firstArg.positionAfterSkippingLeadingTrivia)
 
             var visitedLines = Set<Int>()
             var previousArgumentWasMultiline = false
@@ -144,7 +153,7 @@ private extension VerticalParameterAlignmentOnCallRule {
                     }
 
                     let position = argument.positionAfterSkippingLeadingTrivia
-                    let location = locationConverter.location(for: position)
+                    let location = characterLocation(for: position)
                     guard location.line > firstArgumentLocation.line else {
                         return nil
                     }
@@ -173,6 +182,27 @@ private extension VerticalParameterAlignmentOnCallRule {
             let endPosition = locationConverter.location(for: expression.endPositionBeforeTrailingTrivia)
 
             return endPosition.line > startPosition.line
+        }
+
+        private func characterLocation(for position: AbsolutePosition) -> SourceLocation {
+            let location = locationConverter.location(for: position)
+
+            let characterColumn: Int
+            let graphemeClusters = String(
+                locationConverter.sourceLines[location.line - 1].utf8.prefix(location.column - 1)
+            )
+            if let graphemeClusters {
+                characterColumn = graphemeClusters.count + 1
+            } else {
+                characterColumn = location.column
+            }
+
+            return SourceLocation(
+                line: location.line,
+                column: characterColumn,
+                offset: location.offset,
+                file: location.file
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- compare argument alignment using character columns instead of raw UTF-8 columns
- add a regression example for a call whose first line contains a multi-byte character before the argument list
- update the changelog

Fixes #6467.

## Testing
- swift test --filter VerticalParameterAlignmentOnCallRuleGeneratedTests
- ./.build/debug/swiftlint lint Source/SwiftLintBuiltInRules/Rules/Style/VerticalParameterAlignmentOnCallRule.swift CHANGELOG.md --strict