### PR TITLE
Fix false positives for unused_enumerated with result member access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
   statements for the `statement_position` rule.  
   [theamodhshetty](https://github.com/theamodhshetty)
   [#6153](https://github.com/realm/SwiftLint/issues/6153)
+
 * Avoid false positives from `unused_enumerated` when higher-order calls on
   `.enumerated()` use result members like `?.offset` after the closure.  
   [theamodhshetty](https://github.com/theamodhshetty)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,10 @@
   statements for the `statement_position` rule.  
   [theamodhshetty](https://github.com/theamodhshetty)
   [#6153](https://github.com/realm/SwiftLint/issues/6153)
+* Avoid false positives from `unused_enumerated` when higher-order calls on
+  `.enumerated()` use result members like `?.offset` after the closure.  
+  [theamodhshetty](https://github.com/theamodhshetty)
+  [#5881](https://github.com/realm/SwiftLint/issues/5881)
 
 * Add an `ignore_attributes` option to `implicit_optional_initialization` so
   wrappers/attributes that require explicit `= nil` can be excluded from

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnusedEnumeratedRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnusedEnumeratedRule.swift
@@ -25,6 +25,18 @@ struct UnusedEnumeratedRule: Rule {
             Example("list.enumerated().map { ($0.offset, $0.element) }"),
             Example("list.enumerated().map { ($0.0, $0.1) }"),
             Example("""
+            list.enumerated().first {
+                $0.element.0.isNumber &&
+                $0.element.1.isNumber &&
+                $0.element.0 != $0.element.1
+            }?.offset
+            """),
+            Example("""
+            list.enumerated().max {
+                $0.element < $1.element
+            }?.offset
+            """),
+            Example("""
             list.enumerated().map {
                 $1.enumerated().forEach { print($0, $1) }
                 return $0
@@ -95,14 +107,21 @@ private extension UnusedEnumeratedRule {
         var zeroPosition: AbsolutePosition?
         var onePosition: AbsolutePosition?
 
-        init(enumeratedPosition: AbsolutePosition? = nil) {
+        init(
+            enumeratedPosition: AbsolutePosition? = nil,
+            usesZeroResultMember: Bool = false,
+            usesOneResultMember: Bool = false
+        ) {
             self.enumeratedPosition = enumeratedPosition
+            self.zeroPosition = usesZeroResultMember ? enumeratedPosition : nil
+            self.onePosition = usesOneResultMember ? enumeratedPosition : nil
         }
     }
 
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         private var nextClosureId: SyntaxIdentifier?
         private var lastEnumeratedPosition: AbsolutePosition?
+        private var lastEnumeratedResultMemberUsage = (zero: false, one: false)
         private var closures = Stack<Closure>()
 
         override func visitPost(_ node: ForStmtSyntax) {
@@ -159,6 +178,9 @@ private extension UnusedEnumeratedRule {
             } else {
                 nextClosureId = trailingClosure.id
                 lastEnumeratedPosition = node.enumeratedPosition
+                lastEnumeratedResultMemberUsage =
+                    parent.parent?.as(FunctionCallExprSyntax.self)?
+                    .usedEnumeratedResultMembers ?? (false, false)
             }
 
             return .visitChildren
@@ -166,9 +188,14 @@ private extension UnusedEnumeratedRule {
 
         override func visit(_ node: ClosureExprSyntax) -> SyntaxVisitorContinueKind {
             if let nextClosureId, nextClosureId == node.id, let lastEnumeratedPosition {
-                closures.push(Closure(enumeratedPosition: lastEnumeratedPosition))
-                self.nextClosureId = nil
-                self.lastEnumeratedPosition = nil
+                closures.push(Closure(
+                    enumeratedPosition: lastEnumeratedPosition,
+                    usesZeroResultMember: lastEnumeratedResultMemberUsage.zero,
+                    usesOneResultMember: lastEnumeratedResultMemberUsage.one
+                ))
+                nextClosureId = nil
+                lastEnumeratedPosition = nil
+                lastEnumeratedResultMemberUsage = (false, false)
             } else {
                 closures.push(Closure())
             }
@@ -256,6 +283,27 @@ private extension FunctionCallExprSyntax {
            trailingClosure == nil
         && additionalTrailingClosures.isEmpty
         && arguments.isEmpty
+    }
+
+    var usedEnumeratedResultMembers: (zero: Bool, one: Bool) {
+        var current = parent
+
+        while let currentNode = current {
+            if let memberAccess = currentNode.as(MemberAccessExprSyntax.self) {
+                switch memberAccess.declName.baseName.text {
+                case "offset", "0":
+                    return (true, false)
+                case "element", "1":
+                    return (false, true)
+                default:
+                    return (false, false)
+                }
+            }
+
+            current = currentNode.parent
+        }
+
+        return (false, false)
     }
 }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnusedEnumeratedRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnusedEnumeratedRule.swift
@@ -187,9 +187,11 @@ private extension UnusedEnumeratedRule {
         }
 
         override func visit(_ node: ClosureExprSyntax) -> SyntaxVisitorContinueKind {
-            if let nextClosureId, nextClosureId == node.id, let lastEnumeratedPosition {
+            if let trackedClosureId = nextClosureId,
+               trackedClosureId == node.id,
+               let trackedEnumeratedPosition = lastEnumeratedPosition {
                 closures.push(Closure(
-                    enumeratedPosition: lastEnumeratedPosition,
+                    enumeratedPosition: trackedEnumeratedPosition,
                     usesZeroResultMember: lastEnumeratedResultMemberUsage.zero,
                     usesOneResultMember: lastEnumeratedResultMemberUsage.one
                 ))

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnusedEnumeratedRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnusedEnumeratedRule.swift
@@ -32,6 +32,11 @@ struct UnusedEnumeratedRule: Rule {
             }?.offset
             """),
             Example("""
+            (list.enumerated().first {
+                $0.element.isNumber
+            })?.offset
+            """),
+            Example("""
             list.enumerated().max {
                 $0.element < $1.element
             }?.offset
@@ -175,7 +180,7 @@ private extension UnusedEnumeratedRule {
                 pendingClosure = PendingClosure(
                     id: trailingClosure.id,
                     enumeratedPosition: enumeratedPosition,
-                    usedEnumeratedResultMembers: parentCall.usedEnumeratedResultMembers
+                    usedEnumeratedResultMembers: ExprSyntax(parentCall).usedEnumeratedResultMembers
                 )
             }
 
@@ -196,7 +201,7 @@ private extension UnusedEnumeratedRule {
         }
 
         override func visitPost(_: ClosureExprSyntax) {
-            guard let closure = popTrackedClosure() else { return }
+            guard let closure = closures.pop().flatMap(\.self) else { return }
 
             let zeroPosition = closure.zeroPosition
                 ?? (closure.usedEnumeratedResultMembers.zero ? closure.enumeratedPosition : nil)
@@ -213,42 +218,30 @@ private extension UnusedEnumeratedRule {
 
         override func visitPost(_ node: DeclReferenceExprSyntax) {
             guard
-                currentTrackedClosure != nil,
+                closures.peek().flatMap(\.self) != nil,
                 node.baseName.text == "$0" || node.baseName.text == "$1"
             else {
                 return
             }
 
-            modifyTrackedClosure {
+            closures.modifyLast { trackedClosure in
+                guard var closure = trackedClosure else { return }
+
                 if node.baseName.text == "$0" {
                     let member = node.parent?.as(MemberAccessExprSyntax.self)?.declName.baseName.text
                     if member == "element" || member == "1" {
-                        $0.onePosition = node.positionAfterSkippingLeadingTrivia
+                        closure.onePosition = node.positionAfterSkippingLeadingTrivia
                     } else {
-                        $0.zeroPosition = node.positionAfterSkippingLeadingTrivia
+                        closure.zeroPosition = node.positionAfterSkippingLeadingTrivia
                         if node.isUnpacked {
-                            $0.onePosition = node.positionAfterSkippingLeadingTrivia
+                            closure.onePosition = node.positionAfterSkippingLeadingTrivia
                         }
                     }
                 } else {
-                    $0.onePosition = node.positionAfterSkippingLeadingTrivia
+                    closure.onePosition = node.positionAfterSkippingLeadingTrivia
                 }
-            }
-        }
 
-        private var currentTrackedClosure: Closure? {
-            closures.peek().flatMap(\.self)
-        }
-
-        private func popTrackedClosure() -> Closure? {
-            closures.pop().flatMap(\.self)
-        }
-
-        private func modifyTrackedClosure(_ modifier: (inout Closure) -> Void) {
-            closures.modifyLast {
-                guard var closure = $0 else { return }
-                modifier(&closure)
-                $0 = closure
+                trackedClosure = closure
             }
         }
 
@@ -299,31 +292,37 @@ private extension FunctionCallExprSyntax {
         && additionalTrailingClosures.isEmpty
         && arguments.isEmpty
     }
+}
 
+private extension ExprSyntax {
     var usedEnumeratedResultMembers: (zero: Bool, one: Bool) {
-        var currentNode: Syntax? = Syntax(self)
+        if let tupleElement = parent?.as(LabeledExprSyntax.self),
+           tupleElement.expression.id == id,
+           let tuple = tupleElement.parent?.parent?.as(TupleExprSyntax.self),
+           tuple.elements.onlyElement?.id == tupleElement.id {
+            return ExprSyntax(tuple).usedEnumeratedResultMembers
+        }
 
-        while let node = currentNode, let parent = node.parent {
-            if let memberAccess = parent.as(MemberAccessExprSyntax.self),
-               memberAccess.base?.id == node.id {
-                switch memberAccess.declName.baseName.text {
-                case "offset", "0":
-                    return (true, false)
-                case "element", "1":
-                    return (false, true)
-                default:
-                    break
-                }
+        guard let parent = parent?.as(ExprSyntax.self) else {
+            return (false, false)
+        }
+
+        if let memberAccess = parent.as(MemberAccessExprSyntax.self),
+           memberAccess.base?.id == id {
+            switch memberAccess.declName.baseName.text {
+            case "offset", "0":
+                return (true, false)
+            case "element", "1":
+                return (false, true)
+            default:
+                return parent.usedEnumeratedResultMembers
             }
+        }
 
-            guard parent.is(OptionalChainingExprSyntax.self)
-                || parent.is(ForceUnwrapExprSyntax.self)
-                || parent.is(MemberAccessExprSyntax.self)
-            else {
-                return (false, false)
-            }
-
-            currentNode = parent
+        if parent.as(OptionalChainingExprSyntax.self)?.expression.id == id
+            || parent.as(ForceUnwrapExprSyntax.self)?.expression.id == id
+            || parent.as(TupleExprSyntax.self)?.elements.onlyElement?.expression.id == id {
+            return parent.usedEnumeratedResultMembers
         }
 
         return (false, false)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnusedEnumeratedRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnusedEnumeratedRule.swift
@@ -103,26 +103,21 @@ struct UnusedEnumeratedRule: Rule {
 
 private extension UnusedEnumeratedRule {
     private struct Closure {
-        let enumeratedPosition: AbsolutePosition?
+        let enumeratedPosition: AbsolutePosition
+        let usedEnumeratedResultMembers: (zero: Bool, one: Bool)
         var zeroPosition: AbsolutePosition?
         var onePosition: AbsolutePosition?
+    }
 
-        init(
-            enumeratedPosition: AbsolutePosition? = nil,
-            usesZeroResultMember: Bool = false,
-            usesOneResultMember: Bool = false
-        ) {
-            self.enumeratedPosition = enumeratedPosition
-            self.zeroPosition = usesZeroResultMember ? enumeratedPosition : nil
-            self.onePosition = usesOneResultMember ? enumeratedPosition : nil
-        }
+    private struct PendingClosure {
+        let id: SyntaxIdentifier
+        let enumeratedPosition: AbsolutePosition
+        let usedEnumeratedResultMembers: (zero: Bool, one: Bool)
     }
 
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
-        private var nextClosureId: SyntaxIdentifier?
-        private var lastEnumeratedPosition: AbsolutePosition?
-        private var lastEnumeratedResultMemberUsage = (zero: false, one: false)
-        private var closures = Stack<Closure>()
+        private var pendingClosure: PendingClosure?
+        private var closures = Stack<Closure?>()
 
         override func visitPost(_ node: ForStmtSyntax) {
             guard let tuplePattern = node.pattern.as(TuplePatternSyntax.self),
@@ -151,7 +146,8 @@ private extension UnusedEnumeratedRule {
             guard node.isEnumerated,
                   let parent = node.parent,
                   parent.as(MemberAccessExprSyntax.self)?.declName.baseName.text != "filter",
-                  let trailingClosure = parent.parent?.as(FunctionCallExprSyntax.self)?.trailingClosure
+                  let parentCall = parent.parent?.as(FunctionCallExprSyntax.self),
+                  let trailingClosure = parentCall.trailingClosure
             else {
                 return .visitChildren
             }
@@ -175,54 +171,55 @@ private extension UnusedEnumeratedRule {
                     zeroPosition: firstTokenIsUnderscore ? firstElement.positionAfterSkippingLeadingTrivia : nil,
                     onePosition: firstTokenIsUnderscore ? nil : secondElement.positionAfterSkippingLeadingTrivia
                 )
-            } else {
-                nextClosureId = trailingClosure.id
-                lastEnumeratedPosition = node.enumeratedPosition
-                lastEnumeratedResultMemberUsage =
-                    parent.parent?.as(FunctionCallExprSyntax.self)?
-                    .usedEnumeratedResultMembers ?? (false, false)
+            } else if let enumeratedPosition = node.enumeratedPosition {
+                pendingClosure = PendingClosure(
+                    id: trailingClosure.id,
+                    enumeratedPosition: enumeratedPosition,
+                    usedEnumeratedResultMembers: parentCall.usedEnumeratedResultMembers
+                )
             }
 
             return .visitChildren
         }
 
         override func visit(_ node: ClosureExprSyntax) -> SyntaxVisitorContinueKind {
-            if let trackedClosureId = nextClosureId,
-               trackedClosureId == node.id,
-               let trackedEnumeratedPosition = lastEnumeratedPosition {
+            if let pendingClosure, pendingClosure.id == node.id {
                 closures.push(Closure(
-                    enumeratedPosition: trackedEnumeratedPosition,
-                    usesZeroResultMember: lastEnumeratedResultMemberUsage.zero,
-                    usesOneResultMember: lastEnumeratedResultMemberUsage.one
+                    enumeratedPosition: pendingClosure.enumeratedPosition,
+                    usedEnumeratedResultMembers: pendingClosure.usedEnumeratedResultMembers
                 ))
-                nextClosureId = nil
-                lastEnumeratedPosition = nil
-                lastEnumeratedResultMemberUsage = (false, false)
+                self.pendingClosure = nil
             } else {
-                closures.push(Closure())
+                closures.push(nil)
             }
             return .visitChildren
         }
 
         override func visitPost(_: ClosureExprSyntax) {
-            if let closure = closures.pop(), (closure.zeroPosition != nil) != (closure.onePosition != nil) {
-                addViolation(
-                    zeroPosition: closure.onePosition,
-                    onePosition: closure.zeroPosition,
-                    enumeratedPosition: closure.enumeratedPosition
-                )
-            }
+            guard let closure = popTrackedClosure() else { return }
+
+            let zeroPosition = closure.zeroPosition
+                ?? (closure.usedEnumeratedResultMembers.zero ? closure.enumeratedPosition : nil)
+            let onePosition = closure.onePosition
+                ?? (closure.usedEnumeratedResultMembers.one ? closure.enumeratedPosition : nil)
+            guard (zeroPosition != nil) != (onePosition != nil) else { return }
+
+            addViolation(
+                zeroPosition: onePosition,
+                onePosition: zeroPosition,
+                enumeratedPosition: closure.enumeratedPosition
+            )
         }
 
         override func visitPost(_ node: DeclReferenceExprSyntax) {
             guard
-                let closure = closures.peek(),
-                closure.enumeratedPosition != nil,
+                currentTrackedClosure != nil,
                 node.baseName.text == "$0" || node.baseName.text == "$1"
             else {
                 return
             }
-            closures.modifyLast {
+
+            modifyTrackedClosure {
                 if node.baseName.text == "$0" {
                     let member = node.parent?.as(MemberAccessExprSyntax.self)?.declName.baseName.text
                     if member == "element" || member == "1" {
@@ -236,6 +233,22 @@ private extension UnusedEnumeratedRule {
                 } else {
                     $0.onePosition = node.positionAfterSkippingLeadingTrivia
                 }
+            }
+        }
+
+        private var currentTrackedClosure: Closure? {
+            closures.peek().flatMap(\.self)
+        }
+
+        private func popTrackedClosure() -> Closure? {
+            closures.pop().flatMap(\.self)
+        }
+
+        private func modifyTrackedClosure(_ modifier: (inout Closure) -> Void) {
+            closures.modifyLast {
+                guard var closure = $0 else { return }
+                modifier(&closure)
+                $0 = closure
             }
         }
 
@@ -288,21 +301,29 @@ private extension FunctionCallExprSyntax {
     }
 
     var usedEnumeratedResultMembers: (zero: Bool, one: Bool) {
-        var current = parent
+        var currentNode: Syntax? = Syntax(self)
 
-        while let currentNode = current {
-            if let memberAccess = currentNode.as(MemberAccessExprSyntax.self) {
+        while let node = currentNode, let parent = node.parent {
+            if let memberAccess = parent.as(MemberAccessExprSyntax.self),
+               memberAccess.base?.id == node.id {
                 switch memberAccess.declName.baseName.text {
                 case "offset", "0":
                     return (true, false)
                 case "element", "1":
                     return (false, true)
                 default:
-                    return (false, false)
+                    break
                 }
             }
 
-            current = currentNode.parent
+            guard parent.is(OptionalChainingExprSyntax.self)
+                || parent.is(ForceUnwrapExprSyntax.self)
+                || parent.is(MemberAccessExprSyntax.self)
+            else {
+                return (false, false)
+            }
+
+            currentNode = parent
         }
 
         return (false, false)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnusedEnumeratedRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnusedEnumeratedRule.swift
@@ -320,8 +320,8 @@ private extension ExprSyntax {
         }
 
         if parent.as(OptionalChainingExprSyntax.self)?.expression.id == id
-            || parent.as(ForceUnwrapExprSyntax.self)?.expression.id == id
-            || parent.as(TupleExprSyntax.self)?.elements.onlyElement?.expression.id == id {
+           || parent.as(ForceUnwrapExprSyntax.self)?.expression.id == id
+           || parent.as(TupleExprSyntax.self)?.elements.onlyElement?.expression.id == id {
             return parent.usedEnumeratedResultMembers
         }
 


### PR DESCRIPTION
## Summary
- avoid flagging `.enumerated()` when a higher-order call uses tuple members like `?.offset` after the closure
- keep tracking `$0.element` / `$0.0` and seed the closure usage from result-member access on the surrounding call
- add regression examples and the required changelog entry

## Testing
- swift test --filter UnusedEnumeratedRuleGeneratedTests
- ./.build/debug/swiftlint lint Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnusedEnumeratedRule.swift CHANGELOG.md --strict
- ./.build/debug/swiftlint lint --only-rule unused_enumerated /tmp/unused_enumerated_ok.swift --quiet
- ./.build/debug/swiftlint lint --only-rule unused_enumerated /tmp/unused_enumerated_bad.swift --quiet

Closes #5881