### PR TITLE
Fix prefer_self_in_static_references for shadowed nested types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@
 * `multiline_call_arguments` no longer reports violations for enum-case patterns in
   pattern matching (e.g. if case, switch case, for case, catch).  
   [GandaLF2006](https://github.com/GandaLF2006)
+
 * Avoid false positives in `prefer_self_in_static_references` when a nested type
   shadows its enclosing type name.  
   [theamodhshetty](https://github.com/theamodhshetty)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,10 @@
 * `multiline_call_arguments` no longer reports violations for enum-case patterns in
   pattern matching (e.g. if case, switch case, for case, catch).  
   [GandaLF2006](https://github.com/GandaLF2006)
+* Avoid false positives in `prefer_self_in_static_references` when a nested type
+  shadows its enclosing type name.  
+  [theamodhshetty](https://github.com/theamodhshetty)
+  [#5917](https://github.com/realm/SwiftLint/issues/5917)
 
 ## 0.63.2: High-Speed Extraction
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRule.swift
@@ -37,15 +37,16 @@ private extension PreferSelfInStaticReferencesRule {
 
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         private var parentDeclScopes = Stack<ParentDeclBehavior>()
+        private var shadowingNestedTypeScopes = Stack<Bool>()
         private var variableDeclScopes = Stack<VariableDeclBehavior>()
 
         override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind {
-            parentDeclScopes.push(.likeClass(name: node.name.text))
+            pushParentDeclScope(.likeClass(name: node.name.text), for: node.name.text, memberBlock: node.memberBlock)
             return .skipChildren
         }
 
         override func visitPost(_: ActorDeclSyntax) {
-            parentDeclScopes.pop()
+            popParentDeclScope()
         }
 
         override func visit(_: AttributeSyntax) -> SyntaxVisitorContinueKind {
@@ -56,12 +57,12 @@ private extension PreferSelfInStaticReferencesRule {
         }
 
         override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
-            parentDeclScopes.push(.likeClass(name: node.name.text))
+            pushParentDeclScope(.likeClass(name: node.name.text), for: node.name.text, memberBlock: node.memberBlock)
             return .visitChildren
         }
 
         override func visitPost(_: ClassDeclSyntax) {
-            parentDeclScopes.pop()
+            popParentDeclScope()
         }
 
         override func visit(_: CodeBlockItemListSyntax) -> SyntaxVisitorContinueKind {
@@ -74,21 +75,21 @@ private extension PreferSelfInStaticReferencesRule {
         }
 
         override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
-            parentDeclScopes.push(.likeStruct(node.name.text))
+            pushParentDeclScope(.likeStruct(node.name.text), for: node.name.text, memberBlock: node.memberBlock)
             return .visitChildren
         }
 
         override func visitPost(_: EnumDeclSyntax) {
-            parentDeclScopes.pop()
+            popParentDeclScope()
         }
 
         override func visit(_: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
-            parentDeclScopes.push(.skipReferences)
+            pushParentDeclScope(.skipReferences)
             return .visitChildren
         }
 
         override func visitPost(_: ExtensionDeclSyntax) {
-            parentDeclScopes.pop()
+            popParentDeclScope()
         }
 
         override func visit(_ node: MemberAccessExprSyntax) -> SyntaxVisitorContinueKind {
@@ -146,12 +147,12 @@ private extension PreferSelfInStaticReferencesRule {
         }
 
         override func visit(_: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
-            parentDeclScopes.push(.skipReferences)
+            pushParentDeclScope(.skipReferences)
             return .skipChildren
         }
 
         override func visitPost(_: ProtocolDeclSyntax) {
-            parentDeclScopes.pop()
+            popParentDeclScope()
         }
 
         override func visit(_: ReturnClauseSyntax) -> SyntaxVisitorContinueKind {
@@ -162,12 +163,12 @@ private extension PreferSelfInStaticReferencesRule {
         }
 
         override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
-            parentDeclScopes.push(.likeStruct(node.name.text))
+            pushParentDeclScope(.likeStruct(node.name.text), for: node.name.text, memberBlock: node.memberBlock)
             return .visitChildren
         }
 
         override func visitPost(_: StructDeclSyntax) {
-            parentDeclScopes.pop()
+            popParentDeclScope()
         }
 
         override func visit(_: GenericArgumentListSyntax) -> SyntaxVisitorContinueKind {
@@ -213,7 +214,9 @@ private extension PreferSelfInStaticReferencesRule {
         }
 
         private func addViolation(on node: TokenSyntax) {
-            if let parentName = parentDeclScopes.peek()?.parentName, node.tokenKind == .identifier(parentName) {
+            if shadowingNestedTypeScopes.peek() != true,
+               let parentName = parentDeclScopes.peek()?.parentName,
+               node.tokenKind == .identifier(parentName) {
                 violations.append(
                     at: node.positionAfterSkippingLeadingTrivia,
                     correction: .init(
@@ -222,6 +225,45 @@ private extension PreferSelfInStaticReferencesRule {
                         replacement: "Self"
                     )
                 )
+            }
+        }
+
+        private func pushParentDeclScope(
+            _ behavior: ParentDeclBehavior,
+            for name: String? = nil,
+            memberBlock: MemberBlockSyntax? = nil
+        ) {
+            parentDeclScopes.push(behavior)
+            let hasShadowingNestedType: Bool
+            if let name, let memberBlock {
+                hasShadowingNestedType = containsSameNamedNestedType(named: name, in: memberBlock)
+            } else {
+                hasShadowingNestedType = false
+            }
+            shadowingNestedTypeScopes.push(hasShadowingNestedType)
+        }
+
+        private func popParentDeclScope() {
+            parentDeclScopes.pop()
+            shadowingNestedTypeScopes.pop()
+        }
+
+        private func containsSameNamedNestedType(named name: String, in memberBlock: MemberBlockSyntax) -> Bool {
+            memberBlock.members.contains { member in
+                if let actor = member.decl.as(ActorDeclSyntax.self) {
+                    return actor.name.text == name
+                }
+                if let classDecl = member.decl.as(ClassDeclSyntax.self) {
+                    return classDecl.name.text == name
+                }
+                if let enumDecl = member.decl.as(EnumDeclSyntax.self) {
+                    return enumDecl.name.text == name
+                }
+                if let structDecl = member.decl.as(StructDeclSyntax.self) {
+                    return structDecl.name.text == name
+                }
+
+                return false
             }
         }
     }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRule.swift
@@ -37,16 +37,15 @@ private extension PreferSelfInStaticReferencesRule {
 
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         private var parentDeclScopes = Stack<ParentDeclBehavior>()
-        private var shadowingNestedTypeScopes = Stack<Bool>()
         private var variableDeclScopes = Stack<VariableDeclBehavior>()
 
         override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind {
-            pushParentDeclScope(.likeClass(name: node.name.text), for: node.name.text, memberBlock: node.memberBlock)
+            pushParentDeclScope(.likeClass(name: node.name.text), memberBlock: node.memberBlock)
             return .skipChildren
         }
 
         override func visitPost(_: ActorDeclSyntax) {
-            popParentDeclScope()
+            parentDeclScopes.pop()
         }
 
         override func visit(_: AttributeSyntax) -> SyntaxVisitorContinueKind {
@@ -57,12 +56,12 @@ private extension PreferSelfInStaticReferencesRule {
         }
 
         override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
-            pushParentDeclScope(.likeClass(name: node.name.text), for: node.name.text, memberBlock: node.memberBlock)
+            pushParentDeclScope(.likeClass(name: node.name.text), memberBlock: node.memberBlock)
             return .visitChildren
         }
 
         override func visitPost(_: ClassDeclSyntax) {
-            popParentDeclScope()
+            parentDeclScopes.pop()
         }
 
         override func visit(_: CodeBlockItemListSyntax) -> SyntaxVisitorContinueKind {
@@ -75,21 +74,21 @@ private extension PreferSelfInStaticReferencesRule {
         }
 
         override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
-            pushParentDeclScope(.likeStruct(node.name.text), for: node.name.text, memberBlock: node.memberBlock)
+            pushParentDeclScope(.likeStruct(node.name.text), memberBlock: node.memberBlock)
             return .visitChildren
         }
 
         override func visitPost(_: EnumDeclSyntax) {
-            popParentDeclScope()
+            parentDeclScopes.pop()
         }
 
         override func visit(_: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
-            pushParentDeclScope(.skipReferences)
+            parentDeclScopes.push(.skipReferences)
             return .visitChildren
         }
 
         override func visitPost(_: ExtensionDeclSyntax) {
-            popParentDeclScope()
+            parentDeclScopes.pop()
         }
 
         override func visit(_ node: MemberAccessExprSyntax) -> SyntaxVisitorContinueKind {
@@ -147,12 +146,12 @@ private extension PreferSelfInStaticReferencesRule {
         }
 
         override func visit(_: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
-            pushParentDeclScope(.skipReferences)
+            parentDeclScopes.push(.skipReferences)
             return .skipChildren
         }
 
         override func visitPost(_: ProtocolDeclSyntax) {
-            popParentDeclScope()
+            parentDeclScopes.pop()
         }
 
         override func visit(_: ReturnClauseSyntax) -> SyntaxVisitorContinueKind {
@@ -163,12 +162,12 @@ private extension PreferSelfInStaticReferencesRule {
         }
 
         override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
-            pushParentDeclScope(.likeStruct(node.name.text), for: node.name.text, memberBlock: node.memberBlock)
+            pushParentDeclScope(.likeStruct(node.name.text), memberBlock: node.memberBlock)
             return .visitChildren
         }
 
         override func visitPost(_: StructDeclSyntax) {
-            popParentDeclScope()
+            parentDeclScopes.pop()
         }
 
         override func visit(_: GenericArgumentListSyntax) -> SyntaxVisitorContinueKind {
@@ -214,8 +213,7 @@ private extension PreferSelfInStaticReferencesRule {
         }
 
         private func addViolation(on node: TokenSyntax) {
-            if shadowingNestedTypeScopes.peek() != true,
-               let parentName = parentDeclScopes.peek()?.parentName,
+            if let parentName = parentDeclScopes.peek()?.parentName,
                node.tokenKind == .identifier(parentName) {
                 violations.append(
                     at: node.positionAfterSkippingLeadingTrivia,
@@ -228,39 +226,20 @@ private extension PreferSelfInStaticReferencesRule {
             }
         }
 
-        private func pushParentDeclScope(
-            _ behavior: ParentDeclBehavior,
-            for name: String? = nil,
-            memberBlock: MemberBlockSyntax? = nil
-        ) {
-            parentDeclScopes.push(behavior)
-            let hasShadowingNestedType: Bool
-            if let name, let memberBlock {
-                hasShadowingNestedType = containsSameNamedNestedType(named: name, in: memberBlock)
-            } else {
-                hasShadowingNestedType = false
-            }
-            shadowingNestedTypeScopes.push(hasShadowingNestedType)
-        }
-
-        private func popParentDeclScope() {
-            parentDeclScopes.pop()
-            shadowingNestedTypeScopes.pop()
+        private func pushParentDeclScope(_ behavior: ParentDeclBehavior, memberBlock: MemberBlockSyntax) {
+            let hasShadowingNestedType =
+                if let name = behavior.parentName {
+                    containsSameNamedNestedType(named: name, in: memberBlock)
+                } else {
+                    false
+                }
+            parentDeclScopes.push(hasShadowingNestedType ? .skipReferences : behavior)
         }
 
         private func containsSameNamedNestedType(named name: String, in memberBlock: MemberBlockSyntax) -> Bool {
             memberBlock.members.contains { member in
-                if let actor = member.decl.as(ActorDeclSyntax.self) {
-                    return actor.name.text == name
-                }
-                if let classDecl = member.decl.as(ClassDeclSyntax.self) {
-                    return classDecl.name.text == name
-                }
-                if let enumDecl = member.decl.as(EnumDeclSyntax.self) {
-                    return enumDecl.name.text == name
-                }
-                if let structDecl = member.decl.as(StructDeclSyntax.self) {
-                    return structDecl.name.text == name
+                if member.decl.isProtocol((any DeclGroupSyntax).self) || member.decl.is(TypeAliasDeclSyntax.self) {
+                    return member.decl.asProtocol((any NamedDeclSyntax).self)?.name.text == name
                 }
 
                 return false

--- a/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRuleExamples.swift
@@ -101,6 +101,12 @@ enum PreferSelfInStaticReferencesRuleExamples {
                 }
             }
             """, excludeFromDocumentation: true),
+        Example("""
+            struct S1 {
+                struct S1 {}
+                var s = S1()
+            }
+            """, excludeFromDocumentation: true),
     ]
 
     static let triggeringExamples = [

--- a/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRuleExamples.swift
@@ -107,6 +107,12 @@ enum PreferSelfInStaticReferencesRuleExamples {
                 var s = S1()
             }
             """, excludeFromDocumentation: true),
+        Example("""
+            struct S1 {
+                var s = S1()
+                struct S1 {}
+            }
+            """, excludeFromDocumentation: true),
     ]
 
     static let triggeringExamples = [


### PR DESCRIPTION
## Summary
- skip `prefer_self_in_static_references` violations when a nested type shadows its enclosing type name
- add a rule example covering the shadowed nested type case
- add the changelog entry

## Testing
- `swift test --filter PreferSelfInStaticReferencesRuleGeneratedTests`
- `./.build/debug/swiftlint lint Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRule.swift Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRuleExamples.swift CHANGELOG.md --strict`
- manual repro with `only_rules: [prefer_self_in_static_references]` against the `struct S1 { struct S1 {}; var s = S1() }` sample
