### PR TITLE
Fix false positive in `accessibility_label_for_image` for SwiftUI Lab…

### DIFF
--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityLabelForImageRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityLabelForImageRule.swift
@@ -76,7 +76,14 @@ private struct AccessibilityDeterminator {
             return true
         }
 
-        // 2. Check the parent hierarchy for exemptions
+        // 2. Check if the Image is inside a Label's icon: closure.
+        //    SwiftUI Label provides accessibility through its text content, so the
+        //    icon image is inherently labeled and needs no separate accessibility label.
+        if imageCall.isInsideLabelIconClosure() {
+            return true
+        }
+
+        // 3. Check the parent hierarchy for exemptions
         return imageCall.isExemptedByAncestors()
     }
 }
@@ -248,6 +255,27 @@ private extension FunctionCallExprSyntax {
         // Button exempts children if it has accessibility treatment
         if containerName == "Button" {
             return hasDirectAccessibilityTreatment()
+        }
+
+        return false
+    }
+
+    /// Check if this Image is inside the `icon:` closure argument of a SwiftUI Label.
+    /// In SwiftUI, Label provides accessibility through its text content, so any Image
+    /// in the icon closure is inherently labeled and does not need a separate label.
+    func isInsideLabelIconClosure() -> Bool {
+        var currentNode: Syntax? = Syntax(self)
+
+        while let node = currentNode {
+            if let labeledExpr = node.as(LabeledExprSyntax.self),
+               labeledExpr.label?.text == "icon",
+               let argList = labeledExpr.parent?.as(LabeledExprListSyntax.self),
+               let funcCall = argList.parent?.as(FunctionCallExprSyntax.self),
+               let identifier = funcCall.calledExpression.as(DeclReferenceExprSyntax.self),
+               identifier.baseName.text == "Label" {
+                return true
+            }
+            currentNode = node.parent
         }
 
         return false

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityLabelForImageRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityLabelForImageRuleExamples.swift
@@ -258,6 +258,41 @@ internal struct AccessibilityLabelForImageRuleExamples {
             }
         }
         """),
+        // MARK: - Label icon closure exemptions
+        // Images inside a Label's icon: closure are inherently labeled by the Label's text content.
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                Label {
+                    Text("Connected")
+                } icon: {
+                    Image(systemName: "checkmark.circle.fill")
+                }
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                Label {
+                    Text("Download")
+                } icon: {
+                    Image("custom-download-icon")
+                }
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                Label {
+                    Text("Profile")
+                } icon: {
+                    Image(uiImage: profileImage)
+                }
+            }
+        }
+        """),
     ]
 
     static let triggeringExamples = [


### PR DESCRIPTION
…el icon closures

Images inside a `Label`'s `icon:` closure are inherently labeled by the Label's text content and do not need a separate accessibility label. Adds `isInsideLabelIconClosure()` to detect this pattern via SwiftSyntax and exempts matching images from the rule, with three new non-triggering examples covering `systemName`, asset name, and `uiImage` variants.

Fixes #6420