### PR TITLE
Fix false positive in `accessibility_label_for_image` for SwiftUI Lab…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,12 @@
   * `file_types_order`
   <!-- Keep empty line to have the contributors on a separate line. -->
   [SimplyDanny](https://github.com/SimplyDanny)
+  
+* Fix false positive in `accessibility_label_for_image` rule for images inside
+  SwiftUI `Label`'s `icon:` closure, which are inherently labeled by the
+  `Label`'s text content.  
+  [sutheesh](https://github.com/sutheesh)
+  [#6420](https://github.com/realm/SwiftLint/issues/6420)
 
 ### Bug Fixes
 
@@ -188,11 +194,6 @@
 * Improve the opt-in `pattern_matching_keywords` rule by extending support
   beyond `switch case` and refining nested pattern handling.  
   [GandaLF2006](https://github.com/GandaLF2006)
-* Fix false positive in `accessibility_label_for_image` rule for images inside
-  SwiftUI `Label`'s `icon:` closure, which are inherently labeled by the
-  `Label`'s text content.  
-  [sutheesh](https://github.com/sutheesh)
-  [#6420](https://github.com/realm/SwiftLint/issues/6420)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,11 @@
 * Improve the opt-in `pattern_matching_keywords` rule by extending support
   beyond `switch case` and refining nested pattern handling.  
   [GandaLF2006](https://github.com/GandaLF2006)
+* Fix false positive in `accessibility_label_for_image` rule for images inside
+  SwiftUI `Label`'s `icon:` closure, which are inherently labeled by the
+  `Label`'s text content.  
+  [sutheesh](https://github.com/sutheesh)
+  [#6420](https://github.com/realm/SwiftLint/issues/6420)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,12 @@
   [kapitoshka438](https://github.com/kapitoshka438)
   [#6045](https://github.com/realm/SwiftLint/issues/6045)
 
+* Fix false positive in `accessibility_label_for_image` rule for images inside
+  SwiftUI `Label`'s `icon:` closure, which are inherently labeled by the
+  `Label`'s text content.  
+  [sutheesh](https://github.com/sutheesh)
+  [#6420](https://github.com/realm/SwiftLint/issues/6420)
+
 ### Bug Fixes
 
 * Detect and autocorrect missing whitespace before `else` in `guard`

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityLabelForImageRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityLabelForImageRule.swift
@@ -288,6 +288,10 @@ private extension FunctionCallExprSyntax {
                 return true
             }
 
+            if node.parent?.is(DeclSyntax.self) == true {
+                break
+            }
+
             currentNode = node.parent
         }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityLabelForImageRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityLabelForImageRule.swift
@@ -76,7 +76,14 @@ private struct AccessibilityDeterminator {
             return true
         }
 
-        // 2. Check the parent hierarchy for exemptions
+        // 2. Check if the Image is inside a Label's icon: closure.
+        //    SwiftUI Label provides accessibility through its text content, so the
+        //    icon image is inherently labeled and needs no separate accessibility label.
+        if imageCall.isInsideLabelIconClosure() {
+            return true
+        }
+
+        // 3. Check the parent hierarchy for exemptions
         return imageCall.isExemptedByAncestors()
     }
 }
@@ -248,6 +255,40 @@ private extension FunctionCallExprSyntax {
         // Button exempts children if it has accessibility treatment
         if containerName == "Button" {
             return hasDirectAccessibilityTreatment()
+        }
+
+        return false
+    }
+
+    /// Check if this Image is inside the `icon:` closure argument of a SwiftUI Label.
+    /// In SwiftUI, Label provides accessibility through its text content, so any Image
+    /// in the icon closure is inherently labeled and does not need a separate label.
+    func isInsideLabelIconClosure() -> Bool {
+        var currentNode: Syntax? = Syntax(self)
+
+        while let node = currentNode {
+            // Trailing closure syntax: Label { text } icon: { image }
+            // The `icon:` part is a MultipleTrailingClosureElementSyntax whose
+            // parent is MultipleTrailingClosureElementListSyntax, grandparent is the Label call.
+            if let trailingClosure = node.as(MultipleTrailingClosureElementSyntax.self),
+               trailingClosure.label.text == "icon",
+               let funcCall = trailingClosure.parent?.parent?.as(FunctionCallExprSyntax.self),
+               let identifier = funcCall.calledExpression.as(DeclReferenceExprSyntax.self),
+               identifier.baseName.text == "Label" {
+                return true
+            }
+
+            // Regular argument syntax: Label(content: { text }, icon: { image })
+            if let labeledExpr = node.as(LabeledExprSyntax.self),
+               labeledExpr.label?.text == "icon",
+               let argList = labeledExpr.parent?.as(LabeledExprListSyntax.self),
+               let funcCall = argList.parent?.as(FunctionCallExprSyntax.self),
+               let identifier = funcCall.calledExpression.as(DeclReferenceExprSyntax.self),
+               identifier.baseName.text == "Label" {
+                return true
+            }
+
+            currentNode = node.parent
         }
 
         return false

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityLabelForImageRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityLabelForImageRuleExamples.swift
@@ -258,6 +258,41 @@ internal struct AccessibilityLabelForImageRuleExamples {
             }
         }
         """),
+        // MARK: - Label icon closure exemptions
+        // Images inside a Label's icon: closure are inherently labeled by the Label's text content.
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                Label {
+                    Text("Connected")
+                } icon: {
+                    Image(systemName: "checkmark.circle.fill")
+                }
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                Label {
+                    Text("Download")
+                } icon: {
+                    Image("custom-download-icon")
+                }
+            }
+        }
+        """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                Label {
+                    Text("Profile")
+                } icon: {
+                    Image(uiImage: profileImage)
+                }
+            }
+        }
+        """),
     ]
 
     static let triggeringExamples = [

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityLabelForImageRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityLabelForImageRuleExamples.swift
@@ -274,22 +274,7 @@ internal struct AccessibilityLabelForImageRuleExamples {
         Example("""
         struct MyView: View {
             var body: some View {
-                Label {
-                    Text("Download")
-                } icon: {
-                    Image("custom-download-icon")
-                }
-            }
-        }
-        """),
-        Example("""
-        struct MyView: View {
-            var body: some View {
-                Label {
-                    Text("Profile")
-                } icon: {
-                    Image(uiImage: profileImage)
-                }
+                Label(content: { Text("Download") }, icon: { Image("custom-download-icon") })
             }
         }
         """),


### PR DESCRIPTION
…el icon closures

Images inside a `Label`'s `icon:` closure are inherently labeled by the Label's text content and do not need a separate accessibility label. Adds `isInsideLabelIconClosure()` to detect this pattern via SwiftSyntax and exempts matching images from the rule, with three new non-triggering examples covering `systemName`, asset name, and `uiImage` variants.

Fixes #6420