### PR TITLE
feat: add `redundant_final_actor` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ### Enhancements
 
+* Add new `redundant_final_actor` rule that warns when the `final` modifier is applied to an `actor` declaration. Since actors are implicitly `final` per [SE-0306](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0306-actors.md), the modifier is always redundant.  
+  [VDurocher](https://github.com/VDurocher)
+  [#6407](https://github.com/realm/SwiftLint/issues/6407)
+
 * Print fixed code read from stdin to stdout.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#6501](https://github.com/realm/SwiftLint/issues/6501)

--- a/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
+++ b/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
@@ -178,6 +178,7 @@ public let builtInRules: [any Rule.Type] = [
     ReduceBooleanRule.self,
     ReduceIntoRule.self,
     RedundantDiscardableLetRule.self,
+    RedundantFinalActorRule.self,
     RedundantNilCoalescingRule.self,
     RedundantObjcAttributeRule.self,
     RedundantSelfRule.self,

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantFinalActorRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantFinalActorRule.swift
@@ -1,0 +1,77 @@
+import SwiftSyntax
+
+@SwiftSyntaxRule(correctable: true)
+struct RedundantFinalActorRule: Rule {
+    var configuration = SeverityConfiguration<Self>(.warning)
+
+    static let description = RuleDescription(
+        identifier: "redundant_final_actor",
+        name: "Redundant Final Actor",
+        description: "Actors are implicitly `final`; the `final` modifier is redundant.",
+        kind: .idiomatic,
+        nonTriggeringExamples: [
+            Example("actor DataStorage {}"),
+            Example("""
+            actor Counter {
+                var count = 0
+            }
+            """),
+            Example("final class Foo {}"),
+            Example("""
+            public actor Scheduler {
+                func schedule() {}
+            }
+            """),
+        ],
+        triggeringExamples: [
+            Example("↓final actor DataStorage {}"),
+            Example("""
+            ↓final actor Counter {
+                var count = 0
+            }
+            """),
+            Example("public ↓final actor Scheduler {}"),
+        ],
+        corrections: [
+            Example("↓final actor DataStorage {}"): Example("actor DataStorage {}"),
+            Example("""
+            ↓final actor Counter {
+                var count = 0
+            }
+            """): Example("""
+            actor Counter {
+                var count = 0
+            }
+            """),
+            Example("public ↓final actor Scheduler {}"): Example("public actor Scheduler {}"),
+        ]
+    )
+}
+
+private extension RedundantFinalActorRule {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
+        override func visitPost(_ node: ActorDeclSyntax) {
+            guard let finalModifier = node.modifiers.first(where: { $0.name.tokenKind == .keyword(.final) }) else {
+                return
+            }
+            // Find the position just after this modifier (start of next modifier or actor keyword)
+            // to correctly capture any trailing whitespace in the correction range.
+            let endPosition = node.modifiers
+                .dropFirst(node.modifiers.distance(from: node.modifiers.startIndex,
+                                                   to: node.modifiers.firstIndex(where: { $0.name.tokenKind == .keyword(.final) })!) + 1)
+                .first
+                .map { $0.positionAfterSkippingLeadingTrivia }
+                ?? node.actorKeyword.positionAfterSkippingLeadingTrivia
+            violations.append(
+                ReasonedRuleViolation(
+                    position: finalModifier.positionAfterSkippingLeadingTrivia,
+                    correction: .init(
+                        start: finalModifier.positionAfterSkippingLeadingTrivia,
+                        end: endPosition,
+                        replacement: ""
+                    )
+                )
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Description

Adds a new `redundant_final_actor` rule that warns when a `final` modifier is applied to an `actor` declaration.

Per [SE-0306](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0306-actors.md#actors-2), actors are reference types without support for inheritance, so they are implicitly `final`. Writing `final actor` is therefore redundant, similar to how `internal` is redundant as an access modifier.

Closes #6407

## Examples

**Triggers:**
```swift
final actor DataStorage {}

final actor Counter {
    var count = 0
}

public final actor Scheduler {}
```

**Does not trigger:**
```swift
actor DataStorage {}

public actor Scheduler {}

final class Foo {}  // still valid for classes
```

## Auto-correction

This rule supports auto-correction: it removes the redundant `final` modifier automatically.

## Notes

- `BuiltInRules.swift` updated manually (run `make register` to verify the generated output matches)
- CHANGELOG entry to be added under `### Enhancements` in `## Main`
