### PR TITLE
Fix closure_end_indentation corrupting CRLF files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Main
 
+* Fix closure_end_indentation corrupting CRLF files.  
+  [HttpGetBinary](https://github.com/HttpGetBinary)  
+  [#6598](https://github.com/realm/SwiftLint/issues/6598)
+
+
 ### Breaking
 
 * None.

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ClosureEndIndentationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ClosureEndIndentationRule.swift
@@ -66,11 +66,11 @@ private extension ClosureEndIndentationRule {
                             ""
                         )
                     } else {
-                        // If no newline, we need to add one. The replacement will be inserted
-                        // after the previous token and before the closing brace.
+                        // If no newline, we need to add one. Preserve the file's
+                        // line-ending style so CRLF files don't get corrupted.
                         (
                             node.rightBrace.positionAfterSkippingLeadingTrivia,
-                            "\n"
+                            file.contents.contains("\r\n") ? "\r\n" : "\n"
                         )
                     }
 
@@ -198,7 +198,7 @@ private extension ClosureEndIndentationRule {
             guard lineNumber > 0, lineNumber <= file.lines.count else {
                 return 1 // Should not happen
             }
-            let lineContent = file.lines[lineNumber - 1].content
+            let lineContent = file.lines[lineNumber - 1].content.replacingOccurrences(of: "\r", with: "")
 
             if let firstCharIndex = lineContent.firstIndex(where: { !$0.isWhitespace }) {
                 return lineContent.distance(from: lineContent.startIndex, to: firstCharIndex) + 1

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ClosureEndIndentationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ClosureEndIndentationRule.swift
@@ -19,6 +19,7 @@ struct ClosureEndIndentationRule: Rule {
 
 private extension ClosureEndIndentationRule {
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
+        private lazy var lineEnding: String = file.contents.contains("\r\n") ? "\r\n" : "\n"
         override func visitPost(_ node: ClosureExprSyntax) {
             // Get locations of opening and closing braces
             let leftBraceLocation = locationConverter.location(
@@ -70,7 +71,7 @@ private extension ClosureEndIndentationRule {
                         // line-ending style so CRLF files don't get corrupted.
                         (
                             node.rightBrace.positionAfterSkippingLeadingTrivia,
-                            file.contents.contains("\r\n") ? "\r\n" : "\n"
+                            lineEnding
                         )
                     }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ClosureEndIndentationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ClosureEndIndentationRule.swift
@@ -198,7 +198,7 @@ private extension ClosureEndIndentationRule {
             guard lineNumber > 0, lineNumber <= file.lines.count else {
                 return 1 // Should not happen
             }
-            let lineContent = file.lines[lineNumber - 1].content.replacingOccurrences(of: "\r", with: "")
+            let lineContent = file.lines[lineNumber - 1].content.filter { $0 != "\r" }
 
             if let firstCharIndex = lineContent.firstIndex(where: { !$0.isWhitespace }) {
                 return lineContent.distance(from: lineContent.startIndex, to: firstCharIndex) + 1


### PR DESCRIPTION
Fixes #6598

## What's wrong

`swiftlint --fix` on a CRLF file moves closing braces to wrong positions, corrupting it.

## Why

Two bugs in `ClosureEndIndentationRule`:

1. `getFirstNonWhitespaceColumn` reads line content including a trailing `\r` on CRLF files, skewing column distance calculations.
2. The correction hardcodes `"\n"` when inserting a newline, breaking files that use `"\r\n"`.

## Fix

1. Strip `\r` from line content before measuring indentation.
2. Detect the file's line ending and use it when inserting newlines in corrections.
