### PR TITLE
Add autocorrection support to indentation_width rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,10 @@
   The modern replacement is safer, cleaner, Retina-aware and more performant.  
   [Dimitri Dupuis-Latour](https://github.com/DimDL)
   [#6268](https://github.com/realm/SwiftLint/issues/6268)
+* Add autocorrection support to `indentation_width` rule to automatically fix
+  indentation violations using the `--fix` option.  
+  [nadeemnali](https://github.com/nadeemnali)
+  [#6497](https://github.com/realm/SwiftLint/issues/6497)
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,10 @@
   The modern replacement is safer, cleaner, Retina-aware and more performant.  
   [Dimitri Dupuis-Latour](https://github.com/DimDL)
   [#6268](https://github.com/realm/SwiftLint/issues/6268)
+* Add autocorrection support to `indentation_width` rule to automatically fix
+  indentation violations using the `--fix` option.  
+  [nadeemnali](https://github.com/nadeemnali)
+  [#6497](https://github.com/realm/SwiftLint/issues/6497)
 
 * Support access level modifiers on imports in `unused_imports` rule.  
   [SimplyDanny](https://github.com/SimplyDanny)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/IndentationWidthRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/IndentationWidthRule.swift
@@ -3,7 +3,7 @@ import SourceKittenFramework
 import SwiftSyntax
 
 @DisabledWithoutSourceKit
-struct IndentationWidthRule: OptInRule {
+struct IndentationWidthRule: OptInRule, CorrectableRule {
     // MARK: - Subtypes
     private enum Indentation: Equatable {
         case tabs(Int)
@@ -278,6 +278,103 @@ struct IndentationWidthRule: OptInRule {
                 (lastSpaceEquivalent - currentSpaceEquivalent).isMultiple(of: configuration.indentationWidth)
             ) // Allow unindent if it stays in the grid
         )
+    }
+
+    // MARK: - Methods: Correction
+    func correct(file: SwiftLintFile) -> Int {
+        var corrections = 0
+        var previousLineIndentations: [Indentation] = []
+        var correctedLines = file.lines.map(\.content)
+
+        for (lineIndex, line) in file.lines.enumerated() {
+            corrections += correctLine(
+                at: lineIndex,
+                line: line,
+                file: file,
+                in: &correctedLines,
+                trackingIndentations: &previousLineIndentations
+            )
+        }
+
+        if corrections > 0 {
+            let correctedContent = correctedLines.joined(separator: "\n")
+            file.write(correctedContent)
+        }
+
+        return corrections
+    }
+
+    private func correctLine(
+        at lineIndex: Int,
+        line: Line,
+        file: SwiftLintFile,
+        in correctedLines: inout [String],
+        trackingIndentations previousLineIndentations: inout [Indentation]
+    ) -> Int {
+        if ignoreCompilerDirective(line: line, in: file) { return 0 }
+        let indentationCharacterCount = line.content.countOfLeadingCharacters(in: CharacterSet(charactersIn: " \t"))
+        if line.content.count == indentationCharacterCount { return 0 }
+        if ignoreComment(line: line, in: file) || ignoreMultilineStrings(line: line, in: file) { return 0 }
+
+        let prefix = String(line.content.prefix(indentationCharacterCount))
+        let tabCount = prefix.filter { $0 == "\t" }.count
+        let spaceCount = prefix.filter { $0 == " " }.count
+
+        if tabCount != 0, spaceCount != 0 { return 0 }
+
+        let indentation: Indentation = tabCount != 0 ? .tabs(tabCount) : .spaces(spaceCount)
+
+        guard previousLineIndentations.isNotEmpty else {
+            previousLineIndentations = [indentation]
+            if indentation != .spaces(0) {
+                correctedLines[lineIndex] = String(line.content.dropFirst(indentationCharacterCount))
+                return 1
+            }
+            return 0
+        }
+
+        let linesValidationResult = previousLineIndentations.map {
+            validate(indentation: indentation, comparingTo: $0)
+        }
+
+        if linesValidationResult.contains(true) {
+            if linesValidationResult.first == true {
+                previousLineIndentations = [indentation]
+            } else {
+                previousLineIndentations.append(indentation)
+            }
+            return 0
+        }
+
+        guard let lastValidIndentation = previousLineIndentations.first else { return 0 }
+
+        let correctIndentLevel = lastValidIndentation.spacesEquivalent(indentationWidth: configuration.indentationWidth)
+        let shouldUseTabs = tabCount > 0
+        let correctIndent = generateIndentation(spaceCount: correctIndentLevel, usesTabs: shouldUseTabs)
+        let lineContent = String(line.content.dropFirst(indentationCharacterCount))
+        correctedLines[lineIndex] = correctIndent + lineContent
+
+        let correctedIndentation: Indentation = shouldUseTabs
+            ? .tabs(correctIndent.filter { $0 == "\t" }.count)
+            : .spaces(correctIndent.filter { $0 == " " }.count)
+        previousLineIndentations = [correctedIndentation]
+
+        return 1
+    }
+
+    /// Generates an indentation string based on the number of spaces and whether tabs should be used.
+    ///
+    /// - parameter spaceCount: The number of space-equivalents needed.
+    /// - parameter usesTabs:   Whether the indentation should use tabs.
+    ///
+    /// - returns: The generated indentation string.
+    private func generateIndentation(spaceCount: Int, usesTabs: Bool) -> String {
+        if usesTabs {
+            let tabCount = spaceCount / configuration.indentationWidth
+            let remainingSpaces = spaceCount % configuration.indentationWidth
+            return String(repeating: "\t", count: tabCount) + String(repeating: " ", count: remainingSpaces)
+        }
+        return String(repeating: " ", count: spaceCount)
     }
 }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/IndentationWidthRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/IndentationWidthRule.swift
@@ -319,7 +319,8 @@ struct IndentationWidthRule: OptInRule, CorrectableRule {
 
             // Indentation is wrong, fix it
             let lastValidIndentation = previousLineIndentations[0]
-            let correctIndentLevel = lastValidIndentation.spacesEquivalent(indentationWidth: configuration.indentationWidth)
+            let correctIndentLevel = lastValidIndentation.spacesEquivalent(
+                indentationWidth: configuration.indentationWidth)
             let shouldUseTabs = prefix.tabCount > 0
             let correctIndent = generateIndentation(spaceCount: correctIndentLevel, usesTabs: shouldUseTabs)
             let lineContent = String(line.content.dropFirst(indentationCharacterCount))


### PR DESCRIPTION
Summary

This PR implements autocorrection for the indentation_width rule, allowing violations to be automatically fixed using the --fix option. The rule now conforms to CorrectableRule and will adjust indentation to match the configured width,
preserving the original style (tabs or spaces).

Details

 - Implements correct(file:) for IndentationWidthRule
 - Handles first-line indentation, whitespace-only lines, and mixed tabs/spaces
 - Respects configuration flags for comments, compiler directives, and multiline strings
 - Extracts helpers for clarity and maintainability

Testing

 - All tests pass with zero regressions
 - Manual verification confirms correct autocorrection

Closes #6497