### PR TITLE
Surface violations of `prefer_self_in_static_references` inside extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,8 @@
 
 ### Enhancements
 
-* Surface violations of `prefer_self_in_static_references` inside
-  extensions of types whose name is a plain identifier or a member type
-  (e.g. `extension Foo` or `extension Foo.Bar`). Stored-property
-  initializers and function signatures remain exempt — matching the
-  rule's existing behaviour for top-level class declarations.  
+* Treat extensions like classes in the `prefer_self_in_static_references`
+  rule.  
   [itsybitsybootsy](https://github.com/itsybitsybootsy)
   [#3993](https://github.com/realm/SwiftLint/issues/3993)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@
 
 ### Enhancements
 
+* Surface violations of `prefer_self_in_static_references` inside
+  extensions of types whose name is a plain identifier or a member type
+  (e.g. `extension Foo` or `extension Foo.Bar`). Stored-property
+  initializers and function signatures remain exempt — matching the
+  rule's existing behaviour for top-level class declarations.  
+  [itsybitsybootsy](https://github.com/itsybitsybootsy)
+  [#3993](https://github.com/realm/SwiftLint/issues/3993)
+
 * Print fixed code read from stdin to stdout.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#6501](https://github.com/realm/SwiftLint/issues/6501)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferKeyPathRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferKeyPathRule.swift
@@ -265,7 +265,7 @@ private extension ExprSyntax {
                     this = memberAccess.base
                 }
             }
-            return "\\.\(raw: elements.reversed().map(\.baseName.text).joined(separator: "."))" as ExprSyntax
+            return "\\.\(raw: elements.reversed().map(\.baseName.text).joined(separator: "."))" as Self
         }
 
         if !ignoreIdentityClosures, SwiftVersion.current >= .six, `is`(DeclReferenceExprSyntax.self) {

--- a/Source/SwiftLintBuiltInRules/Rules/Performance/EmptyCountRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Performance/EmptyCountRule.swift
@@ -250,6 +250,6 @@ private extension InfixOperatorExprSyntax {
 private extension String {
     private static let operators: Set = ["==", "!=", ">", ">=", "<", "<="]
     var isComparison: Bool {
-        String.operators.contains(self)
+        Self.operators.contains(self)
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ContrastedOpeningBraceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ContrastedOpeningBraceRule.swift
@@ -107,7 +107,7 @@ private extension TokenSyntax {
 
 private extension IfExprSyntax {
     var indentationDecidingParent: any SyntaxProtocol {
-        if keyPathInParent == \IfExprSyntax.elseBody, let parent = parent?.as(IfExprSyntax.self) {
+        if keyPathInParent == \Self.elseBody, let parent = parent?.as(IfExprSyntax.self) {
             return parent.indentationDecidingParent
         }
         return self

--- a/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRule.swift
@@ -137,12 +137,15 @@ private extension PreferSelfInStaticReferencesRule {
                     return .skipChildren
                 }
             }
-            // In a member-type extension (e.g. `extension Foo.Bar`), the only
-            // valid reference to the extended type is the full member path, so
-            // match the access chain structurally rather than a single token.
-            // A path used to call an initializer (`Foo.Bar()`) is left alone.
+            // In a member-type extension (e.g. `extension Foo.Bar`), match the
+            // extended-type access chain structurally; a single token can't
+            // disambiguate `Outer.Inner.x` from `Other.Inner.x`. Skip when the
+            // path is the callee of a call or carries explicit generic
+            // arguments (`Foo.Bar()`, `Foo.Bar<Int>()`), since `Self` doesn't
+            // substitute for those.
             if let components = parentDeclScopes.peek()?.memberTypeComponents,
                node.parent?.is(FunctionCallExprSyntax.self) != true,
+               node.parent?.is(GenericSpecializationExprSyntax.self) != true,
                let tokens = memberAccessChain(node),
                tokens.map(\.text) == components {
                 addMemberTypeViolation(spanning: tokens)
@@ -254,6 +257,12 @@ private extension PreferSelfInStaticReferencesRule {
             }
             // Don't flag the extended type in the extension header itself.
             if node.parent?.is(ExtensionDeclSyntax.self) == true {
+                return
+            }
+            // Mirror the single-identifier rule: a type appearing as a generic
+            // argument is left alone, since `Self` may not be available in that
+            // position (e.g. an extension's own inheritance clause).
+            if node.parent?.is(GenericArgumentSyntax.self) == true {
                 return
             }
             if let tokens = memberTypeChain(node), tokens.map(\.text) == components {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRule.swift
@@ -16,17 +16,37 @@ struct PreferSelfInStaticReferencesRule: Rule {
 }
 
 private extension PreferSelfInStaticReferencesRule {
+    private enum ExtendedType {
+        /// A type named by a plain identifier, e.g. `extension Foo`.
+        case identifier(String)
+        /// A member type, e.g. `extension Foo.Bar`, stored as its component path.
+        case memberType([String])
+    }
+
     private enum ParentDeclBehavior {
-        case likeClass(name: String)
+        case likeClass(ExtendedType)
         case likeStruct(String)
         case skipReferences
 
+        /// The single identifier matched for token-based violations and for the
+        /// nested-type shadowing check. `nil` for member-type extensions, which
+        /// are matched structurally instead.
         var parentName: String? {
             switch self {
-            case let .likeClass(name): return name
+            case let .likeClass(.identifier(name)): return name
+            case .likeClass(.memberType): return nil
             case let .likeStruct(name): return name
             case .skipReferences: return nil
             }
+        }
+
+        /// The component path of a member-type extension, e.g. `["Foo", "Bar"]`,
+        /// or `nil` for any other scope.
+        var memberTypeComponents: [String]? {
+            if case let .likeClass(.memberType(components)) = self {
+                return components
+            }
+            return nil
         }
     }
 
@@ -40,7 +60,7 @@ private extension PreferSelfInStaticReferencesRule {
         private var variableDeclScopes = Stack<VariableDeclBehavior>()
 
         override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind {
-            pushParentDeclScope(.likeClass(name: node.name.text), memberBlock: node.memberBlock)
+            pushParentDeclScope(.likeClass(.identifier(node.name.text)), memberBlock: node.memberBlock)
             return .skipChildren
         }
 
@@ -56,7 +76,7 @@ private extension PreferSelfInStaticReferencesRule {
         }
 
         override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
-            pushParentDeclScope(.likeClass(name: node.name.text), memberBlock: node.memberBlock)
+            pushParentDeclScope(.likeClass(.identifier(node.name.text)), memberBlock: node.memberBlock)
             return .visitChildren
         }
 
@@ -89,8 +109,8 @@ private extension PreferSelfInStaticReferencesRule {
             // computed properties and closure bodies. Cases the class scope
             // already skips (e.g. stored-property initializers, function
             // signatures) remain skipped to avoid false positives.
-            if let name = extendedTypeName(of: node.extendedType) {
-                pushParentDeclScope(.likeClass(name: name), memberBlock: node.memberBlock)
+            if let type = extendedType(of: node.extendedType) {
+                pushParentDeclScope(.likeClass(type), memberBlock: node.memberBlock)
             } else {
                 parentDeclScopes.push(.skipReferences)
             }
@@ -101,12 +121,12 @@ private extension PreferSelfInStaticReferencesRule {
             parentDeclScopes.pop()
         }
 
-        private func extendedTypeName(of type: TypeSyntax) -> String? {
+        private func extendedType(of type: TypeSyntax) -> ExtendedType? {
             if let identifier = type.as(IdentifierTypeSyntax.self) {
-                return identifier.name.text
+                return .identifier(identifier.name.text)
             }
-            if let memberType = type.as(MemberTypeSyntax.self) {
-                return memberType.name.text
+            if let memberType = type.as(MemberTypeSyntax.self), let tokens = memberTypeChain(memberType) {
+                return .memberType(tokens.map(\.text))
             }
             return nil
         }
@@ -116,6 +136,17 @@ private extension PreferSelfInStaticReferencesRule {
                 if node.declName.baseName.tokenKind == .keyword(.self) {
                     return .skipChildren
                 }
+            }
+            // In a member-type extension (e.g. `extension Foo.Bar`), the only
+            // valid reference to the extended type is the full member path, so
+            // match the access chain structurally rather than a single token.
+            // A path used to call an initializer (`Foo.Bar()`) is left alone.
+            if let components = parentDeclScopes.peek()?.memberTypeComponents,
+               node.parent?.is(FunctionCallExprSyntax.self) != true,
+               let tokens = memberAccessChain(node),
+               tokens.map(\.text) == components {
+                addMemberTypeViolation(spanning: tokens)
+                return .skipChildren
             }
             return .visitChildren
         }
@@ -217,6 +248,19 @@ private extension PreferSelfInStaticReferencesRule {
             }
         }
 
+        override func visitPost(_ node: MemberTypeSyntax) {
+            guard let components = parentDeclScopes.peek()?.memberTypeComponents else {
+                return
+            }
+            // Don't flag the extended type in the extension header itself.
+            if node.parent?.is(ExtensionDeclSyntax.self) == true {
+                return
+            }
+            if let tokens = memberTypeChain(node), tokens.map(\.text) == components {
+                addMemberTypeViolation(spanning: tokens)
+            }
+        }
+
         override func visit(_: TypeAliasDeclSyntax) -> SyntaxVisitorContinueKind {
             if case .likeClass = parentDeclScopes.peek() {
                 return .skipChildren
@@ -250,6 +294,61 @@ private extension PreferSelfInStaticReferencesRule {
                     )
                 )
             }
+        }
+
+        private func addMemberTypeViolation(spanning tokens: [TokenSyntax]) {
+            guard let first = tokens.first, let last = tokens.last else {
+                return
+            }
+            let start = first.positionAfterSkippingLeadingTrivia
+            violations.append(
+                at: start,
+                correction: .init(
+                    start: start,
+                    end: last.endPositionBeforeTrailingTrivia,
+                    replacement: "Self"
+                )
+            )
+        }
+
+        /// Flattens an expression member-access chain (e.g. `Foo.Bar`) into its
+        /// component tokens, or `nil` if the chain is not a plain type path.
+        private func memberAccessChain(_ node: MemberAccessExprSyntax) -> [TokenSyntax]? {
+            var tokens = [node.declName.baseName]
+            var base = node.base
+            while let member = base?.as(MemberAccessExprSyntax.self) {
+                tokens.insert(member.declName.baseName, at: 0)
+                base = member.base
+            }
+            guard let reference = base?.as(DeclReferenceExprSyntax.self) else {
+                return nil
+            }
+            tokens.insert(reference.baseName, at: 0)
+            return tokens
+        }
+
+        /// Flattens a member type (e.g. `Foo.Bar`) into its component tokens, or
+        /// `nil` if the type is not a plain member path. Member types carrying
+        /// generic arguments are excluded, since `Self` cannot stand in for them.
+        private func memberTypeChain(_ node: MemberTypeSyntax) -> [TokenSyntax]? {
+            guard node.genericArgumentClause == nil else {
+                return nil
+            }
+            var tokens = [node.name]
+            var base = node.baseType
+            while let member = base.as(MemberTypeSyntax.self) {
+                guard member.genericArgumentClause == nil else {
+                    return nil
+                }
+                tokens.insert(member.name, at: 0)
+                base = member.baseType
+            }
+            guard let identifier = base.as(IdentifierTypeSyntax.self),
+                  identifier.genericArgumentClause == nil else {
+                return nil
+            }
+            tokens.insert(identifier.name, at: 0)
+            return tokens
         }
 
         private func pushParentDeclScope(_ behavior: ParentDeclBehavior, memberBlock: MemberBlockSyntax) {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRule.swift
@@ -82,13 +82,33 @@ private extension PreferSelfInStaticReferencesRule {
             parentDeclScopes.pop()
         }
 
-        override func visit(_: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
-            parentDeclScopes.push(.skipReferences)
+        override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
+            // Treat the extended type as a class. Without knowing the exact
+            // declaration kind, this is the most conservative scope that still
+            // surfaces violations on member-access expressions inside methods,
+            // computed properties and closure bodies. Cases the class scope
+            // already skips (e.g. stored-property initializers, function
+            // signatures) remain skipped to avoid false positives.
+            if let name = extendedTypeName(of: node.extendedType) {
+                pushParentDeclScope(.likeClass(name: name), memberBlock: node.memberBlock)
+            } else {
+                parentDeclScopes.push(.skipReferences)
+            }
             return .visitChildren
         }
 
         override func visitPost(_: ExtensionDeclSyntax) {
             parentDeclScopes.pop()
+        }
+
+        private func extendedTypeName(of type: TypeSyntax) -> String? {
+            if let identifier = type.as(IdentifierTypeSyntax.self) {
+                return identifier.name.text
+            }
+            if let memberType = type.as(MemberTypeSyntax.self) {
+                return memberType.name.text
+            }
+            return nil
         }
 
         override func visit(_ node: MemberAccessExprSyntax) -> SyntaxVisitorContinueKind {
@@ -179,6 +199,12 @@ private extension PreferSelfInStaticReferencesRule {
 
         override func visitPost(_ node: IdentifierTypeSyntax) {
             guard let parent = node.parent else {
+                return
+            }
+            // Don't flag identifiers that belong to the extension declaration
+            // header (the extended type itself); the new class-like scope
+            // pushed for the extension would otherwise rewrite it to `Self`.
+            if parent.is(ExtensionDeclSyntax.self) {
                 return
             }
             if case .likeClass = parentDeclScopes.peek(), parent.is(GenericArgumentSyntax.self) {

--- a/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRuleExamples.swift
@@ -113,6 +113,15 @@ enum PreferSelfInStaticReferencesRuleExamples {
                 struct S1 {}
             }
             """, excludeFromDocumentation: true),
+        Example("""
+            class Foo {
+                static let i = 0
+            }
+            class Bar {}
+            extension Bar {
+                func f() -> Int { Foo.i }
+            }
+            """, excludeFromDocumentation: true),
     ]
 
     static let triggeringExamples = [
@@ -235,6 +244,25 @@ enum PreferSelfInStaticReferencesRuleExamples {
                 }
             }
             """, excludeFromDocumentation: true),
+        Example("""
+            class C {
+                static let i = 0
+            }
+            extension C {
+                func f() -> Int { ↓C.i }
+                var v: Int { ↓C.i }
+            }
+            """, excludeFromDocumentation: true),
+        Example("""
+            class Outer {
+                class Inner {
+                    static let i = 0
+                }
+            }
+            extension Outer.Inner {
+                func f() -> Int { ↓Inner.i }
+            }
+            """, excludeFromDocumentation: true),
     ]
 
     static let corrections = [
@@ -275,6 +303,21 @@ enum PreferSelfInStaticReferencesRuleExamples {
                     let k = Self  . j
                     static func f(_ l: Int = Self.i) -> Int { l*Self.j }
                     func g() { Self.i + Self.f() + k }
+                }
+                """),
+        Example("""
+            class C {
+                static let i = 0
+            }
+            extension C {
+                func f() -> Int { ↓C.i }
+            }
+            """): Example("""
+                class C {
+                    static let i = 0
+                }
+                extension C {
+                    func f() -> Int { Self.i }
                 }
                 """),
     ]

--- a/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRuleExamples.swift
@@ -146,6 +146,17 @@ enum PreferSelfInStaticReferencesRuleExamples {
                 func f() -> Int { Outer.i }
             }
             """, excludeFromDocumentation: true),
+        Example("""
+            class Outer {
+                class Inner<T> {
+                    static let i = 0
+                }
+            }
+            extension Outer.Inner {
+                func f() { _ = Outer.Inner<Int>() }
+                func g() { _ = Outer.Inner<Int>.i }
+            }
+            """, excludeFromDocumentation: true),
     ]
 
     static let triggeringExamples = [

--- a/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/PreferSelfInStaticReferencesRuleExamples.swift
@@ -122,6 +122,30 @@ enum PreferSelfInStaticReferencesRuleExamples {
                 func f() -> Int { Foo.i }
             }
             """, excludeFromDocumentation: true),
+        Example("""
+            class Outer {
+                class Inner {
+                    static let i = 0
+                }
+                class Other {
+                    static let i = 0
+                }
+            }
+            extension Outer.Inner {
+                func f() -> Int { Outer.Other.i }
+            }
+            """, excludeFromDocumentation: true),
+        Example("""
+            enum Outer {
+                static let i = 0
+                struct Inner {
+                    static let j = 0
+                }
+            }
+            extension Outer.Inner {
+                func f() -> Int { Outer.i }
+            }
+            """, excludeFromDocumentation: true),
     ]
 
     static let triggeringExamples = [
@@ -260,7 +284,19 @@ enum PreferSelfInStaticReferencesRuleExamples {
                 }
             }
             extension Outer.Inner {
-                func f() -> Int { ↓Inner.i }
+                func f() -> Int { ↓Outer.Inner.i }
+            }
+            """, excludeFromDocumentation: true),
+        Example("""
+            enum Outer {
+                enum Middle {
+                    struct Inner {
+                        static let i = 0
+                    }
+                }
+            }
+            extension Outer.Middle.Inner {
+                func f() -> Int { ↓Outer.Middle.Inner.i }
             }
             """, excludeFromDocumentation: true),
     ]
@@ -317,6 +353,25 @@ enum PreferSelfInStaticReferencesRuleExamples {
                     static let i = 0
                 }
                 extension C {
+                    func f() -> Int { Self.i }
+                }
+                """),
+        Example("""
+            class Outer {
+                class Inner {
+                    static let i = 0
+                }
+            }
+            extension Outer.Inner {
+                func f() -> Int { ↓Outer.Inner.i }
+            }
+            """): Example("""
+                class Outer {
+                    class Inner {
+                        static let i = 0
+                    }
+                }
+                extension Outer.Inner {
                     func f() -> Int { Self.i }
                 }
                 """),

--- a/Source/SwiftLintFramework/Configuration/Configuration+Remote.swift
+++ b/Source/SwiftLintFramework/Configuration/Configuration+Remote.swift
@@ -60,7 +60,7 @@ internal extension Configuration.FileGraph.FilePath {
         let cachedFilePath = getCachedFilePath(urlString: urlString, rootDirectory: rootDirectory)
 
         let configString: String
-        if let mockedValue = Configuration.FileGraph.FilePath.mockedNetworkResults[urlString] {
+        if let mockedValue = Self.mockedNetworkResults[urlString] {
             configString = mockedValue
         } else {
             // Handle wrong url format
@@ -206,7 +206,7 @@ internal extension Configuration.FileGraph.FilePath {
             adjustedUrlString = adjustedUrlString.replacingOccurrences(of: char, with: "_")
         }
         adjustedUrlString = adjustedUrlString.trimmingCharacters(in: CharacterSet(charactersIn: "."))
-        let path = Configuration.FileGraph.FilePath.versionedRemoteCachePath + "/\(adjustedUrlString).yml"
+        let path = Self.versionedRemoteCachePath + "/\(adjustedUrlString).yml"
         return path.bridge().absolutePathRepresentation(rootDirectory: rootDirectory)
     }
 
@@ -225,7 +225,7 @@ internal extension Configuration.FileGraph.FilePath {
 
     private func maintainRemoteConfigCache(rootDirectory: String) throws {
         // Create directory if needed
-        let directory = Configuration.FileGraph.FilePath.versionedRemoteCachePath
+        let directory = Self.versionedRemoteCachePath
             .bridge().absolutePathRepresentation(rootDirectory: rootDirectory)
         if !FileManager.default.fileExists(atPath: directory) {
             try FileManager.default.createDirectory(atPath: directory, withIntermediateDirectories: true)
@@ -234,7 +234,7 @@ internal extension Configuration.FileGraph.FilePath {
         // Delete all cache folders except for the current version's folder
         let directoryWithoutVersionNum = directory.components(separatedBy: "/").dropLast().joined(separator: "/")
         try (try FileManager.default.subpathsOfDirectory(atPath: directoryWithoutVersionNum)).forEach {
-            if !$0.contains("/"), $0 != Configuration.FileGraph.FilePath.remoteCacheVersionNumber {
+            if !$0.contains("/"), $0 != Self.remoteCacheVersionNumber {
                 try FileManager.default.removeItem(atPath:
                     $0.bridge().absolutePathRepresentation(rootDirectory: directoryWithoutVersionNum)
                 )
@@ -242,23 +242,23 @@ internal extension Configuration.FileGraph.FilePath {
         }
 
         // Add gitignore entry if needed
-        let requiredGitignoreAppendix = "\(Configuration.FileGraph.FilePath.remoteCachePath)"
+        let requiredGitignoreAppendix = "\(Self.remoteCachePath)"
         let newGitignoreAppendix = "# SwiftLint Remote Config Cache\n\(requiredGitignoreAppendix)"
 
-        if !FileManager.default.fileExists(atPath: Configuration.FileGraph.FilePath.gitignorePath) {
+        if !FileManager.default.fileExists(atPath: Self.gitignorePath) {
             guard FileManager.default.createFile(
-                atPath: Configuration.FileGraph.FilePath.gitignorePath,
+                atPath: Self.gitignorePath,
                 contents: Data(newGitignoreAppendix.utf8),
                 attributes: [:]
             ) else {
                 throw Issue.genericWarning("Issue maintaining remote config cache.")
             }
         } else {
-            var contents = try String(contentsOfFile: Configuration.FileGraph.FilePath.gitignorePath, encoding: .utf8)
+            var contents = try String(contentsOfFile: Self.gitignorePath, encoding: .utf8)
             if !contents.contains(requiredGitignoreAppendix) {
                 contents += "\n\n\(newGitignoreAppendix)"
                 try contents.write(
-                    toFile: Configuration.FileGraph.FilePath.gitignorePath,
+                    toFile: Self.gitignorePath,
                     atomically: true,
                     encoding: .utf8
                 )

--- a/Source/SwiftLintFramework/Reporters/SummaryReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/SummaryReporter.swift
@@ -122,6 +122,6 @@ private extension Int {
     }()
     var formattedString: String {
         // swiftlint:disable:next legacy_objc_type
-        Int.numberFormatter.string(from: NSNumber(value: self)) ?? ""
+        Self.numberFormatter.string(from: NSNumber(value: self)) ?? ""
     }
 }


### PR DESCRIPTION
## Problem

`prefer_self_in_static_references` currently pushes `.skipReferences` for every `ExtensionDeclSyntax`, which silences the rule inside the entire extension body. The rule misses violations like:

```swift
class Foo {
    static let value = 1
}

extension Foo {
    func helper() -> Int { Foo.value }      // not flagged, should be Self.value
    var alias: Int { Foo.value }            // not flagged, should be Self.value
}
```

Per @SimplyDanny's [comment on #3993](https://github.com/realm/SwiftLint/issues/3993#issuecomment-1937562648):

> Allowing the rule for extensions by treating the type as it was a class, would be achievable as a first step without much effort. This might be a "good first issue".

## Fix

When the extended type is a plain identifier (`extension Foo`) or a member type (`extension Foo.Bar`), push `.likeClass(name: extendedTypeName)` instead of `.skipReferences`. Complex extended-type shapes (generic specialisations, opaque types, function types) continue to fall through to the previous `.skipReferences` behaviour.

The class scope is the most conservative reuse of existing logic — it already correctly handles method bodies, computed properties, and closure invocations on the right-hand side, while still skipping the things class mode skips (stored-property initializers, function signatures) to avoid false positives. This matches the maintainer's "first step" framing: the reporter's exact case (`extension Foo { static let otherValue = Foo.value }` — a stored-property initializer) remains exempt under this change, matching how the rule already treats top-level class declarations.

The `IdentifierTypeSyntax` visitor also gains a guard so that the extension declaration header itself (the extended-type identifier) is excluded from violations — without it, the new scope would rewrite `extension Foo` to `extension Self`.

## Tests

- New non-triggering example: extension of an unrelated type with a reference to a different type (confirms parent-name matching is correct).
- New triggering examples: extension of a class with violations in method body + computed property, and extension of a nested type (`Outer.Inner`) confirming `MemberTypeSyntax` handling.
- New correction: extension method body that auto-fixes `↓C.i` → `Self.i`.
- Existing non-triggering example at the top of the file (`extension T { static let j = S.i + T.i; static let k = { T.j }() }`) continues to pass: class-mode `MemberBlockSyntax` already skips stored-property initializer expressions, so neither `T.i` nor the closure body's `T.j` is reachable.

## Self-corrections

The integration test (`testSwiftLintAutoCorrects`) lints SwiftLint's own source against all rules. With this change, four pre-existing violations in SwiftLint's own code are surfaced and auto-corrected — they're equivalent rewrites of the same shape (`String.operators` → `Self.operators` inside a `private extension String`, etc.) and are bundled here so the integration test passes:

- `Source/SwiftLintBuiltInRules/Rules/Idiomatic/PreferKeyPathRule.swift`: `as ExprSyntax` → `as Self`
- `Source/SwiftLintBuiltInRules/Rules/Performance/EmptyCountRule.swift`: `String.operators` → `Self.operators`
- `Source/SwiftLintBuiltInRules/Rules/Style/ContrastedOpeningBraceRule.swift`: `\IfExprSyntax.elseBody` → `\Self.elseBody`
- `Source/SwiftLintFramework/Reporters/SummaryReporter.swift`: `Int.numberFormatter` → `Self.numberFormatter`

Verified locally with `swift run swiftlint-dev rules register && swift test`. All tests pass.

Resolves #3993.

---

This contribution was developed with the help of Claude Code. The fix, regression tests, edge-case analysis, and the local test suite were reviewed manually before submitting.
