### PR TITLE
fix(reporter): add JUnit metadata to GitLab reporter output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@
 
 ### Enhancements
 
+* Add `tests`, `failures`, `errors`, and `name` attributes to the GitLab JUnit reporter output.  
+  [leno23](https://github.com/leno23)
+
 * Print fixed code read from stdin to stdout.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#6501](https://github.com/realm/SwiftLint/issues/6501)

--- a/Source/SwiftLintFramework/Reporters/GitLabJUnitReporter.swift
+++ b/Source/SwiftLintFramework/Reporters/GitLabJUnitReporter.swift
@@ -7,7 +7,13 @@ struct GitLabJUnitReporter: Reporter {
     static let description = "Reports violations as JUnit XML supported by GitLab."
 
     static func generateReport(_ violations: [StyleViolation]) -> String {
-        "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<testsuites><testsuite>" +
+        let warningCount = violations.filter({ $0.severity == .warning }).count
+        let errorCount = violations.filter({ $0.severity == .error }).count
+        let testCount = warningCount + errorCount
+
+        return "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+            "<testsuites failures=\"\(warningCount)\" errors=\"\(errorCount)\" tests=\"\(testCount)\">" +
+            "<testsuite name=\"SwiftLint\" failures=\"\(warningCount)\" errors=\"\(errorCount)\" tests=\"\(testCount)\">" +
             violations.map({ violation -> String in
                 let fileName = (violation.location.relativeFile ?? "<nopath>").escapedForXML()
                 let line = violation.location.line.map(String.init)

--- a/Tests/FileSystemAccessTests/Resources/CannedGitLabJUnitReporterOutput.xml
+++ b/Tests/FileSystemAccessTests/Resources/CannedGitLabJUnitReporterOutput.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<testsuites><testsuite>
+<testsuites failures="1" errors="3" tests="4">
+<testsuite name="SwiftLint" failures="1" errors="3" tests="4">
 	<testcase name='warning: line_length in filename:1'>
 		<failure>Severity: warning
 Rule: line_length


### PR DESCRIPTION
## Summary

- Adds `tests`, `failures`, and `errors` attributes to `<testsuites>` and `<testsuite>` in the GitLab JUnit reporter
- Sets `name="SwiftLint"` on `<testsuite>` for clearer CI ingestion (e.g. Bitbucket)

Related to #6161 (JUnit reporter metadata; GitLab reporter was missing the same attributes).

## Test plan

- [x] Updated `CannedGitLabJUnitReporterOutput.xml` fixture
- [ ] CI `ReporterTests.testGitLabJUnitReporter` passes