### PR TITLE
fix(redundant_self): allow self in os.Logger privacy interpolations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@
   rule.  
   [itsybitsybootsy](https://github.com/itsybitsybootsy)
   [#3993](https://github.com/realm/SwiftLint/issues/3993)
+* Fix `redundant_self` false positive when `self` is used in labeled string interpolation
+  expressions such as os.Logger privacy arguments.  
+  [leno23](https://github.com/leno23)
+  [#6542](https://github.com/realm/SwiftLint/issues/6542)
 
 * Print fixed code read from stdin to stdout.  
   [SimplyDanny](https://github.com/SimplyDanny)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@
 
 ### Bug Fixes
 
+* Fix `redundant_self` false positive when `self` is used in labeled string interpolation
+  expressions such as os.Logger privacy arguments.  
+  [leno23](https://github.com/leno23)
+  [#6542](https://github.com/realm/SwiftLint/issues/6542)
+
 * Avoid false positives in `prefer_self_in_static_references` for generic
   constraints and generic parameter bounds such as `where A: P` and `<A: P>`
   in classes and extensions.  
@@ -58,11 +63,6 @@
   rule.  
   [itsybitsybootsy](https://github.com/itsybitsybootsy)
   [#3993](https://github.com/realm/SwiftLint/issues/3993)
-* Fix `redundant_self` false positive when `self` is used in labeled string interpolation
-  expressions such as os.Logger privacy arguments.  
-  [leno23](https://github.com/leno23)
-  [#6542](https://github.com/realm/SwiftLint/issues/6542)
-
 * Print fixed code read from stdin to stdout.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#6501](https://github.com/realm/SwiftLint/issues/6501)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/RedundantSelfRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/RedundantSelfRule.swift
@@ -113,6 +113,9 @@ private extension RedundantSelfRule {
             if configuration.keepInInitializers, initializerScopes.peek() == true {
                 return
             }
+            if requiresExplicitSelf(node) {
+                return
+            }
             if closureExprScopes.isNotEmpty, !isSelfRedundant {
                 return
             }
@@ -156,6 +159,21 @@ private extension RedundantSelfRule {
             return closureType == .anonymousCall
                 || selfCapture == .strong && SwiftVersion.current >= .fiveDotThree
                 || selfCapture == .weak && SwiftVersion.current >= .fiveDotEight
+        }
+
+        private func requiresExplicitSelf(_ node: MemberAccessExprSyntax) -> Bool {
+            guard node.isBaseSelf else {
+                return false
+            }
+            var current: Syntax? = Syntax(node)
+            while let parent = current?.parent {
+                if let labeledExpr = parent.as(LabeledExprSyntax.self),
+                   labeledExpr.label?.text == "privacy" {
+                    return true
+                }
+                current = parent
+            }
+            return false
         }
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/RedundantSelfRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/RedundantSelfRuleExamples.swift
@@ -118,6 +118,18 @@ struct RedundantSelfRuleExamples {
             }
             """),
         Example("""
+            import os
+
+            class Name {
+                private let test = ""
+
+                func testLog() {
+                    Logger(subsystem: "sub", category: "cat")
+                        .warning("test: \\(self.test, privacy: .private(mask: .hash))")
+                }
+            }
+            """),
+        Example("""
             struct S {
                 var x = 0, y = 0
                 init() {


### PR DESCRIPTION
## Summary

- Skips `redundant_self` when `self` is used in labeled string interpolation arguments (e.g. `privacy:` for `os.Logger`)
- Adds a non-triggering example from #6542

Fixes #6542

## Test plan

- [x] Added non-triggering example for Logger + privacy interpolation
- [ ] CI rule tests pass