### PR TITLE
feat(empty_enum_arguments): add excluded_members configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 
 ### Enhancements
 
+* Add `excluded_members` configuration to `empty_enum_arguments` to skip members
+  that require empty parentheses (e.g. HealthKit static functions).  
+  [leno23](https://github.com/leno23)
+  [#5269](https://github.com/realm/SwiftLint/issues/5269)
+
 * Print fixed code read from stdin to stdout.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#6501](https://github.com/realm/SwiftLint/issues/6501)

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/EmptyEnumArgumentsConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/EmptyEnumArgumentsConfiguration.swift
@@ -1,0 +1,9 @@
+import SwiftLintCore
+
+@AutoConfigParser
+struct EmptyEnumArgumentsConfiguration: SeverityBasedRuleConfiguration {
+    @ConfigurationElement(key: "severity")
+    private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement(key: "excluded_members")
+    private(set) var excludedMembers = Set<String>()
+}

--- a/Source/SwiftLintBuiltInRules/Rules/Style/EmptyEnumArgumentsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/EmptyEnumArgumentsRule.swift
@@ -26,7 +26,7 @@ private func wrapInFunc(_ str: String, file: StaticString = #filePath, line: UIn
 
 @SwiftSyntaxRule(explicitRewriter: true)
 struct EmptyEnumArgumentsRule: Rule {
-    var configuration = SeverityConfiguration<Self>(.warning)
+    var configuration = EmptyEnumArgumentsConfiguration()
 
     static let description = RuleDescription(
         identifier: "empty_enum_arguments",
@@ -61,6 +61,7 @@ struct EmptyEnumArgumentsRule: Rule {
                 return true
             }
             """),
+            Example("if case .gram() = foo {}", configuration: ["excluded_members": ["gram"]]),
         ],
         triggeringExamples: [
             wrapInSwitch("case .bar↓(_)"),
@@ -117,13 +118,19 @@ struct EmptyEnumArgumentsRule: Rule {
 private extension EmptyEnumArgumentsRule {
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: SwitchCaseItemSyntax) {
-            if let violationPosition = node.pattern.emptyEnumArgumentsViolation(rewrite: false)?.position {
+            if let violationPosition = node.pattern.emptyEnumArgumentsViolation(
+                rewrite: false,
+                excludedMembers: configuration.excludedMembers
+            )?.position {
                 violations.append(violationPosition)
             }
         }
 
         override func visitPost(_ node: MatchingPatternConditionSyntax) {
-            if let violationPosition = node.pattern.emptyEnumArgumentsViolation(rewrite: false)?.position {
+            if let violationPosition = node.pattern.emptyEnumArgumentsViolation(
+                rewrite: false,
+                excludedMembers: configuration.excludedMembers
+            )?.position {
                 violations.append(violationPosition)
             }
         }
@@ -131,7 +138,10 @@ private extension EmptyEnumArgumentsRule {
 
     final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
         override func visit(_ node: SwitchCaseItemSyntax) -> SwitchCaseItemSyntax {
-            guard let (_, newPattern) = node.pattern.emptyEnumArgumentsViolation(rewrite: true) else {
+            guard let (_, newPattern) = node.pattern.emptyEnumArgumentsViolation(
+                rewrite: true,
+                excludedMembers: configuration.excludedMembers
+            ) else {
                 return super.visit(node)
             }
             numberOfCorrections += 1
@@ -139,7 +149,10 @@ private extension EmptyEnumArgumentsRule {
         }
 
         override func visit(_ node: MatchingPatternConditionSyntax) -> MatchingPatternConditionSyntax {
-            guard let (_, newPattern) = node.pattern.emptyEnumArgumentsViolation(rewrite: true) else {
+            guard let (_, newPattern) = node.pattern.emptyEnumArgumentsViolation(
+                rewrite: true,
+                excludedMembers: configuration.excludedMembers
+            ) else {
                 return super.visit(node)
             }
             numberOfCorrections += 1
@@ -149,7 +162,10 @@ private extension EmptyEnumArgumentsRule {
 }
 
 private extension PatternSyntax {
-    func emptyEnumArgumentsViolation(rewrite: Bool) -> (position: AbsolutePosition, pattern: PatternSyntax)? {
+    func emptyEnumArgumentsViolation(
+        rewrite: Bool,
+        excludedMembers: Set<String>
+    ) -> (position: AbsolutePosition, pattern: PatternSyntax)? {
         guard
             var pattern = `as`(ExpressionPatternSyntax.self),
             let expression = pattern.expression.as(FunctionCallExprSyntax.self),
@@ -158,6 +174,15 @@ private extension PatternSyntax {
             calledExpression.base == nil,
             let violationPosition = expression.innermostFunctionCall.leftParen?.positionAfterSkippingLeadingTrivia
         else {
+            return nil
+        }
+
+        let memberName = expression.innermostFunctionCall.calledExpression
+            .as(MemberAccessExprSyntax.self)?
+            .declName
+            .baseName
+            .text
+        if let memberName, excludedMembers.contains(memberName) {
             return nil
         }
 


### PR DESCRIPTION
## Summary

- Adds `excluded_members` rule configuration (set of member names)
- Skips violations and autocorrect for excluded members (e.g. HealthKit `gramUnit`)
- Adds a non-triggering example with configuration

Closes #5269

## Test plan

- [x] Added configured non-triggering example
- [ ] CI rule tests pass (`EmptyEnumArgumentsRuleGeneratedTests`)