### PR TITLE
fix(missing_docs): lint members when excluding inherited types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 
 ### Enhancements
 
+* Fix `missing_docs` not reporting undocumented members when `excludes_inherited_types` is enabled.  
+  [leno23](https://github.com/leno23)
+  [#5633](https://github.com/realm/SwiftLint/issues/5633)
+
 * Print fixed code read from stdin to stdout.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#6501](https://github.com/realm/SwiftLint/issues/6501)

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/MissingDocsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/MissingDocsRule.swift
@@ -26,11 +26,9 @@ private extension MissingDocsRule {
         }
 
         override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind {
-            if node.inherits, configuration.excludesInheritedTypes {
-                _ = super.visit(node)
-                return .skipChildren
+            if !(node.inherits && configuration.excludesInheritedTypes) {
+                collectViolation(from: node, on: node.actorKeyword)
             }
-            collectViolation(from: node, on: node.actorKeyword)
             return super.visit(node)
         }
 
@@ -71,11 +69,9 @@ private extension MissingDocsRule {
         }
 
         override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
-            if node.inherits, configuration.excludesInheritedTypes {
-                _ = super.visit(node)
-                return .skipChildren
+            if !(node.inherits && configuration.excludesInheritedTypes) {
+                collectViolation(from: node, on: node.enumKeyword)
             }
-            collectViolation(from: node, on: node.enumKeyword)
             return super.visit(node)
         }
 
@@ -103,20 +99,16 @@ private extension MissingDocsRule {
         }
 
         override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
-            if node.inherits, configuration.excludesInheritedTypes {
-                _ = super.visit(node)
-                return .skipChildren
+            if !(node.inherits && configuration.excludesInheritedTypes) {
+                collectViolation(from: node, on: node.protocolKeyword)
             }
-            collectViolation(from: node, on: node.protocolKeyword)
             return super.visit(node)
         }
 
         override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
-            if node.inherits, configuration.excludesInheritedTypes {
-                _ = super.visit(node)
-                return .skipChildren
+            if !(node.inherits && configuration.excludesInheritedTypes) {
+                collectViolation(from: node, on: node.structKeyword)
             }
-            collectViolation(from: node, on: node.structKeyword)
             return super.visit(node)
         }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/MissingDocsRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/MissingDocsRuleExamples.swift
@@ -69,6 +69,12 @@ struct MissingDocsRuleExamples {
         public func f() async {}
         #endif
         """, excludeFromDocumentation: true),
+        Example("""
+        /// My type.
+        public struct MyType: Identifiable {
+            public var id: String
+        }
+        """, configuration: ["excludes_inherited_types": true]),
     ]
 
     static let triggeringExamples = [
@@ -90,6 +96,13 @@ struct MissingDocsRuleExamples {
             public let b: Int
         }
         """),
+        Example("""
+        /// My type.
+        public struct MyType: Identifiable {
+            public var id: String
+            public ↓var name: String
+        }
+        """, configuration: ["excludes_inherited_types": true]),
         // Violation marker is on `static` keyword.
         Example("""
         /// a doc


### PR DESCRIPTION
## Summary

When `excludes_inherited_types` was enabled, SwiftLint skipped the entire body of types that conform to a protocol. That prevented legitimate `missing_docs` violations on non-inherited members.

This change only excludes the type declaration itself and continues linting members inside the type.

Fixes #5633

## Test plan

- [x] Added non-triggering and triggering examples for `Identifiable` conformance
- [ ] CI rule tests pass