### PR TITLE
fix(config): fall back when nested YAML is invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,21 +12,6 @@
 
 ### Enhancements
 
-* Add `excluded_members` configuration to `empty_enum_arguments` to skip members
-  that require empty parentheses (e.g. HealthKit static functions).  
-  [leno23](https://github.com/leno23)
-  [#5269](https://github.com/realm/SwiftLint/issues/5269)
-
-* Fix `unused_enumerated` false positives when offset and element are used in
-  separate chained trailing closures after `.enumerated()`.  
-  [leno23](https://github.com/leno23)
-  [#5600](https://github.com/realm/SwiftLint/issues/5600)
-
-* Treat macro declarations like function declarations for `line_length` when
-  `ignores_function_declarations` is enabled.  
-  [leno23](https://github.com/leno23)
-  [#5648](https://github.com/realm/SwiftLint/issues/5648)
-
 * Print fixed code read from stdin to stdout.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#6501](https://github.com/realm/SwiftLint/issues/6501)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@
 
 ### Enhancements
 
+* Add `excluded_members` configuration to `empty_enum_arguments` to skip members
+  that require empty parentheses (e.g. HealthKit static functions).  
+  [leno23](https://github.com/leno23)
+  [#5269](https://github.com/realm/SwiftLint/issues/5269)
+
+* Fix `unused_enumerated` false positives when offset and element are used in
+  separate chained trailing closures after `.enumerated()`.  
+  [leno23](https://github.com/leno23)
+  [#5600](https://github.com/realm/SwiftLint/issues/5600)
+
+* Treat macro declarations like function declarations for `line_length` when
+  `ignores_function_declarations` is enabled.  
+  [leno23](https://github.com/leno23)
+  [#5648](https://github.com/realm/SwiftLint/issues/5648)
+
 * Print fixed code read from stdin to stdout.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#6501](https://github.com/realm/SwiftLint/issues/6501)
@@ -693,7 +708,12 @@
   or other error.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#6052](https://github.com/realm/SwiftLint/issues/6052)
-  
+
+* Fall back to default configuration when a nested `.swiftlint.yml` cannot be parsed
+  instead of aborting (e.g. duplicate YAML keys in a subdirectory).  
+  [leno23](https://github.com/leno23)
+  [#6052](https://github.com/realm/SwiftLint/issues/6052)
+
 * Keep the default severity levels when neither `warning` nor `error` values are configured.
   Ensure especially that the `error` level is not set to `nil` when the `warning` level
   isn't set either.  

--- a/Source/SwiftLintCore/Models/Issue.swift
+++ b/Source/SwiftLintCore/Models/Issue.swift
@@ -122,6 +122,8 @@ public enum Issue: LocalizedError, Equatable {
             return "error: \(message)"
         case .genericWarning:
             return "warning: \(message)"
+        case .yamlParsing:
+            return "warning: \(message)"
         default:
             return Self.genericWarning(message).errorDescription
         }

--- a/Source/SwiftLintFramework/Configuration/Configuration+Merging.swift
+++ b/Source/SwiftLintFramework/Configuration/Configuration+Merging.swift
@@ -116,7 +116,8 @@ extension Configuration {
             // Ignore parent_config / child_config specifications of nested configs
             var childConfiguration = Configuration(
                 configurationFiles: [configurationSearchPath],
-                ignoreParentAndChildConfigs: true
+                ignoreParentAndChildConfigs: true,
+                useDefaultConfigOnFailure: true
             )
             childConfiguration.fileGraph = FileGraph(rootDirectory: directory)
             config = merged(withChild: childConfiguration, rootDirectory: rootDirectory)

--- a/Tests/FileSystemAccessTests/ConfigurationTests+Mock.swift
+++ b/Tests/FileSystemAccessTests/ConfigurationTests+Mock.swift
@@ -33,6 +33,7 @@ internal extension ConfigurationTests {
             static var remoteConfigLocalRef: String { level0.stringByAppendingPathComponent("RemoteConfig/LocalRef") }
             static var remoteConfigCycle: String { level0.stringByAppendingPathComponent("RemoteConfig/Cycle") }
             static var emptyFolder: String { level0.stringByAppendingPathComponent("EmptyFolder") }
+            static var duplicateYamlKeys: String { level0.stringByAppendingPathComponent("DuplicateYamlKeys") }
 
             static var exclusionTests: String { testResourcesPath.stringByAppendingPathComponent("ExclusionTests") }
             static var directory: String { exclusionTests.stringByAppendingPathComponent("directory") }
@@ -65,6 +66,9 @@ internal extension ConfigurationTests {
             static var _2: String { Dir.level2.stringByAppendingPathComponent("Level2.swift") }
             static var _3: String { Dir.level3.stringByAppendingPathComponent("Level3.swift") }
             static var nestedSub: String { Dir.nestedSub.stringByAppendingPathComponent("Sub.swift") }
+            static var duplicateYamlKeysSub: String {
+                Dir.duplicateYamlKeys.stringByAppendingPathComponent("subdir/a.swift")
+            }
         }
 
         // MARK: Configurations

--- a/Tests/FileSystemAccessTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/FileSystemAccessTests/ConfigurationTests+MultipleConfigs.swift
@@ -234,6 +234,18 @@ extension ConfigurationTests {
         )
     }
 
+    func testNestedConfigurationWithInvalidYamlFallsBackToDefault() async throws {
+        XCTAssert(FileManager.default.changeCurrentDirectoryPath(Mock.Dir.duplicateYamlKeys))
+
+        let console = try await Issue.captureConsole {
+            let config = Configuration(configurationFiles: [])
+            _ = config.configuration(for: SwiftLintFile(path: Mock.Swift.duplicateYamlKeysSub)!)
+        }
+
+        XCTAssertTrue(console.contains("Cannot parse YAML file"))
+        XCTAssertTrue(console.contains("Falling back to default configuration"))
+    }
+
     func testNestedConfigurationForOnePathPassedIn() {
         // If a path to one or more configuration files is specified, nested configurations should be ignored
         let config = Configuration(configurationFiles: [Mock.Yml._0])

--- a/Tests/FileSystemAccessTests/Resources/ProjectMock/DuplicateYamlKeys/subdir/.swiftlint.yml
+++ b/Tests/FileSystemAccessTests/Resources/ProjectMock/DuplicateYamlKeys/subdir/.swiftlint.yml
@@ -1,0 +1,5 @@
+opt_in_rules:
+  - closure_body_length
+
+opt_in_rules:
+  - closure_body_length

--- a/Tests/FileSystemAccessTests/Resources/ProjectMock/DuplicateYamlKeys/subdir/a.swift
+++ b/Tests/FileSystemAccessTests/Resources/ProjectMock/DuplicateYamlKeys/subdir/a.swift
@@ -1,0 +1,1 @@
+// Test file for nested configuration with invalid YAML.


### PR DESCRIPTION
## Summary

- When SwiftLint discovers a nested `.swiftlint.yml` while grouping files by directory, invalid YAML (e.g. duplicate keys) now warns and falls back to the default configuration instead of calling `abort()`.
- Improves `Issue.errorDescription` for `yamlParsing` so the YAML parse message is surfaced correctly.

Fixes #6052

## Test plan

- [x] Added `testNestedConfigurationWithInvalidYamlFallsBackToDefault` with a fixture mirroring the issue report (duplicate `opt_in_rules` in `subdir/.swiftlint.yml`).
- [ ] CI (Buildkite)

## Notes

This complements the existing error-reporting improvement for #6052 on `main`; it specifically fixes the crash when linting from a parent directory with an invalid nested config.