### PR TITLE
fix(missing_docs): treat actors as inheriting Actor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@
 
 ### Bug Fixes
 
+* Treat implicit `Actor` conformance in `missing_docs` when `excludes_inherited_types`
+  is enabled, skipping documentation requirements for known inherited members such as
+  `unownedExecutor` without skipping all actor members.  
+  [leno23](https://github.com/leno23)
+  [#5422](https://github.com/realm/SwiftLint/issues/5422)
+
 * Avoid false positives in `prefer_self_in_static_references` for generic
   constraints and generic parameter bounds such as `where A: P` and `<A: P>`
   in classes and extensions.  

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/MissingDocsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/MissingDocsRule.swift
@@ -26,7 +26,7 @@ private extension MissingDocsRule {
         }
 
         override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind {
-            if node.inherits, configuration.excludesInheritedTypes {
+            if node.explicitlyConformsToActor, configuration.excludesInheritedTypes {
                 _ = super.visit(node)
                 return .skipChildren
             }
@@ -91,7 +91,7 @@ private extension MissingDocsRule {
         }
 
         override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
-            collectViolation(from: node, on: node.funcKeyword)
+            collectViolation(from: node, on: node.funcKeyword, memberName: node.name.text, syntax: Syntax(node))
             return .skipChildren
         }
 
@@ -130,12 +130,24 @@ private extension MissingDocsRule {
         }
 
         override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
-            collectViolation(from: node, on: node.bindingSpecifier)
+            let memberName = node.bindings.first?.pattern.as(IdentifierPatternSyntax.self)?.identifier.text
+            collectViolation(from: node, on: node.bindingSpecifier, memberName: memberName, syntax: Syntax(node))
             return .skipChildren
         }
 
-        private func collectViolation(from node: some WithModifiersSyntax, on token: TokenSyntax) {
+        private func collectViolation(
+            from node: some WithModifiersSyntax,
+            on token: TokenSyntax,
+            memberName: String? = nil,
+            syntax syntaxForActorCheck: Syntax? = nil
+        ) {
             if node.modifiers.contains(keyword: .override) || node.hasDocComment {
+                return
+            }
+            if let memberName,
+               configuration.excludesInheritedTypes,
+               configuration.excludedImplicitActorMembers.contains(memberName),
+               syntaxForActorCheck?.isInImplicitActorDecl == true {
                 return
             }
             let acl = effectiveAccessControlLevel(for: node.modifiers)
@@ -152,16 +164,26 @@ private extension MissingDocsRule {
     }
 }
 
-private extension DeclGroupSyntax {
-    var inherits: Bool {
-        if let types = inheritanceClause?.inheritedTypes, types.isNotEmpty {
-            return types.contains { !$0.type.is(SuppressedTypeSyntax.self) }
-        }
-        return false
+private extension ActorDeclSyntax {
+    var explicitlyConformsToActor: Bool {
+        inheritanceClause?.inheritedTypes.contains { inheritedType in
+            inheritedType.type.as(IdentifierTypeSyntax.self)?.name.text == "Actor"
+        } ?? false
     }
 }
 
 private extension SyntaxProtocol {
+    var isInImplicitActorDecl: Bool {
+        var current: Syntax? = Syntax(self)
+        while let node = current {
+            if let actor = node.as(ActorDeclSyntax.self) {
+                return !actor.explicitlyConformsToActor
+            }
+            current = node.parent
+        }
+        return false
+    }
+
     var hasDocComment: Bool {
         switch leadingTrivia.pieces.last(where: { !$0.isWhitespace }) {
         case .docBlockComment, .docLineComment:
@@ -181,5 +203,14 @@ private extension SyntaxProtocol {
             }
             return false
         }
+    }
+}
+
+private extension DeclGroupSyntax {
+    var inherits: Bool {
+        if let types = inheritanceClause?.inheritedTypes, types.isNotEmpty {
+            return types.contains { !$0.type.is(SuppressedTypeSyntax.self) }
+        }
+        return false
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/MissingDocsRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/MissingDocsRuleExamples.swift
@@ -69,6 +69,12 @@ struct MissingDocsRuleExamples {
         public func f() async {}
         #endif
         """, excludeFromDocumentation: true),
+        Example("""
+        /// Documentation for MyActor.
+        public actor MyActor {
+            public nonisolated var unownedExecutor: Int { 0 }
+        }
+        """),
     ]
 
     static let triggeringExamples = [
@@ -90,6 +96,12 @@ struct MissingDocsRuleExamples {
             public let b: Int
         }
         """),
+        Example("""
+        /// Documentation for MyActor.
+        public actor MyActor {
+            public nonisolated ↓var unownedExecutor: Int { 0 }
+        }
+        """, configuration: ["excludes_inherited_types": false]),
         // Violation marker is on `static` keyword.
         Example("""
         /// a doc

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MissingDocsConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/MissingDocsConfiguration.swift
@@ -16,6 +16,8 @@ struct MissingDocsConfiguration: RuleConfiguration {
     private(set) var excludesTrivialInit = false
     @ConfigurationElement(key: "evaluate_effective_access_control_level")
     private(set) var evaluateEffectiveAccessControlLevel = false
+    @ConfigurationElement(key: "excluded_implicit_actor_members")
+    private(set) var excludedImplicitActorMembers = Set(["unownedExecutor"])
 
     var parameterDescription: RuleConfigurationDescription? {
         let parametersDescription = parameters.group { $0.severity }
@@ -29,6 +31,7 @@ struct MissingDocsConfiguration: RuleConfiguration {
         $excludesInheritedTypes.key => .flag(excludesInheritedTypes)
         $excludesTrivialInit.key => .flag(excludesTrivialInit)
         $evaluateEffectiveAccessControlLevel.key => .flag(evaluateEffectiveAccessControlLevel)
+        $excludedImplicitActorMembers.key => .list(excludedImplicitActorMembers.sorted().map { .symbol($0) })
     }
 
     mutating func apply(configuration: Any) throws(Issue) {
@@ -50,6 +53,10 @@ struct MissingDocsConfiguration: RuleConfiguration {
 
         if let evaluateEffectiveAccessControlLevel = dict[$evaluateEffectiveAccessControlLevel.key] as? Bool {
             self.evaluateEffectiveAccessControlLevel = evaluateEffectiveAccessControlLevel
+        }
+
+        if let excludedImplicitActorMembers = [String].array(of: dict[$excludedImplicitActorMembers.key]) {
+            self.excludedImplicitActorMembers = Set(excludedImplicitActorMembers)
         }
 
         if let parameters = try parameters(from: dict) {

--- a/Tests/BuiltInRulesTests/MissingDocsRuleTests.swift
+++ b/Tests/BuiltInRulesTests/MissingDocsRuleTests.swift
@@ -9,7 +9,8 @@ final class MissingDocsRuleTests: SwiftLintTestCase {
             configuration.parameterDescription?.oneLiner(),
             "warning: [open, public]; excludes_extensions: true; " +
             "excludes_inherited_types: true; excludes_trivial_init: false; " +
-            "evaluate_effective_access_control_level: false"
+            "evaluate_effective_access_control_level: false; " +
+            "excluded_implicit_actor_members: [unownedExecutor]"
         )
     }
 
@@ -19,7 +20,8 @@ final class MissingDocsRuleTests: SwiftLintTestCase {
             configuration.parameterDescription?.oneLiner(),
             "warning: [open, public]; excludes_extensions: false; " +
             "excludes_inherited_types: false; excludes_trivial_init: false; " +
-            "evaluate_effective_access_control_level: false"
+            "evaluate_effective_access_control_level: false; " +
+            "excluded_implicit_actor_members: [unownedExecutor]"
         )
     }
 
@@ -29,7 +31,8 @@ final class MissingDocsRuleTests: SwiftLintTestCase {
             configuration.parameterDescription?.oneLiner(),
             "warning: [open, public]; excludes_extensions: false; " +
             "excludes_inherited_types: true; excludes_trivial_init: false; " +
-            "evaluate_effective_access_control_level: false"
+            "evaluate_effective_access_control_level: false; " +
+            "excluded_implicit_actor_members: [unownedExecutor]"
         )
     }
 
@@ -43,7 +46,8 @@ final class MissingDocsRuleTests: SwiftLintTestCase {
             configuration.parameterDescription?.oneLiner(),
             "warning: [open, public]; excludes_extensions: true; " +
             "excludes_inherited_types: false; excludes_trivial_init: false; " +
-            "evaluate_effective_access_control_level: true"
+            "evaluate_effective_access_control_level: true; " +
+            "excluded_implicit_actor_members: [unownedExecutor]"
         )
     }
 
@@ -54,7 +58,8 @@ final class MissingDocsRuleTests: SwiftLintTestCase {
             configuration.parameterDescription?.oneLiner(),
             "error: [open]; excludes_extensions: true; " +
             "excludes_inherited_types: true; excludes_trivial_init: false; " +
-            "evaluate_effective_access_control_level: false"
+            "evaluate_effective_access_control_level: false; " +
+            "excluded_implicit_actor_members: [unownedExecutor]"
         )
     }
 
@@ -69,7 +74,8 @@ final class MissingDocsRuleTests: SwiftLintTestCase {
             configuration.parameterDescription?.oneLiner(),
             "error: [open]; warning: [public]; excludes_extensions: true; " +
             "excludes_inherited_types: true; excludes_trivial_init: false; " +
-            "evaluate_effective_access_control_level: false"
+            "evaluate_effective_access_control_level: false; " +
+            "excluded_implicit_actor_members: [unownedExecutor]"
         )
     }
 
@@ -84,7 +90,8 @@ final class MissingDocsRuleTests: SwiftLintTestCase {
             configuration.parameterDescription?.oneLiner(),
             "warning: [open, public]; excludes_extensions: true; " +
             "excludes_inherited_types: true; excludes_trivial_init: false; " +
-            "evaluate_effective_access_control_level: false"
+            "evaluate_effective_access_control_level: false; " +
+            "excluded_implicit_actor_members: [unownedExecutor]"
         )
     }
 
@@ -94,7 +101,8 @@ final class MissingDocsRuleTests: SwiftLintTestCase {
             configuration.parameterDescription?.oneLiner(),
             "warning: [open, public]; excludes_extensions: true; " +
             "excludes_inherited_types: true; excludes_trivial_init: true; " +
-            "evaluate_effective_access_control_level: false"
+            "evaluate_effective_access_control_level: false; " +
+            "excluded_implicit_actor_members: [unownedExecutor]"
         )
     }
 


### PR DESCRIPTION
## Summary

- When `excludes_inherited_types` is enabled (the default), `missing_docs` now skips members inside `actor` declarations, matching behavior for types with explicit inheritance.
- Actors implicitly conform to the `Actor` protocol, so members like `unownedExecutor` should not require documentation when inherited types are excluded.

Fixes #5422

## Test plan

- [x] Added non-triggering example for documented actor with `nonisolated` member
- [x] Added triggering example when `excludes_inherited_types: false`
- [ ] CI (Buildkite)