### PR TITLE
fix(modifier_order): recognize isolated isolation modifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,11 @@
 
 ### Bug Fixes
 
+* Recognize `isolated` as an isolation modifier in `modifier_order`, so it can
+  be ordered via the `isolation` entry in `preferred_modifier_order`.  
+  [leno23](https://github.com/leno23)
+  [#6164](https://github.com/realm/SwiftLint/issues/6164)
+
 * Detect and autocorrect missing whitespace before `else` in `guard`
   statements for the `statement_position` rule.  
   [theamodhshetty](https://github.com/theamodhshetty)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ModifierOrderRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ModifierOrderRule.swift
@@ -135,7 +135,7 @@ private extension SwiftDeclarationAttributeKind.ModifierGroup {
             self = .lazy
         case "dynamic":
             self = .dynamic
-        case "nonisolated":
+        case "isolated", "nonisolated":
             self = .isolation
         case "private", "fileprivate", "internal", "public", "open":
             self = .acl

--- a/Tests/FrameworkTests/ModifierOrderTests.swift
+++ b/Tests/FrameworkTests/ModifierOrderTests.swift
@@ -391,6 +391,7 @@ final class ModifierOrderTests: SwiftLintTestCase {
         }
     }
 
+    // swiftlint:disable:next function_body_length
     func testIsolationModifierOrder() {
         let descriptionOverride = ModifierOrderRule.description
             .with(nonTriggeringExamples: [

--- a/Tests/FrameworkTests/ModifierOrderTests.swift
+++ b/Tests/FrameworkTests/ModifierOrderTests.swift
@@ -408,6 +408,12 @@ final class ModifierOrderTests: SwiftLintTestCase {
                 }
                 """),
                 Example("""
+                @MainActor
+                class Foo {
+                    isolated public func bar() {}
+                }
+                """),
+                Example("""
                 class RegularClass {
                     @MainActor public func bar() {}
                 }
@@ -426,6 +432,12 @@ final class ModifierOrderTests: SwiftLintTestCase {
                     private nonisolated func heavyWork() {}
                 }
                 """),
+                Example("""
+                @MainActor
+                class Foo {
+                    public isolated func bar() {}
+                }
+                """),
             ])
             .with(corrections: [
                 Example("""
@@ -438,6 +450,18 @@ final class ModifierOrderTests: SwiftLintTestCase {
                 @MainActor
                 class Foo {
                     nonisolated public func bar() {}
+                }
+                """),
+                Example("""
+                @MainActor
+                class Foo {
+                    public isolated func bar() {}
+                }
+                """):
+                Example("""
+                @MainActor
+                class Foo {
+                    isolated public func bar() {}
                 }
                 """),
             ])


### PR DESCRIPTION
## Summary

- Map the `isolated` declaration modifier to the existing `isolation` modifier group in `modifier_order`.
- Users can now order `isolated` via `isolation` in `preferred_modifier_order`, consistent with `nonisolated`.

Fixes #6164

## Test plan

- [x] Extended `testIsolationModifierOrder` with `isolated` non-triggering/triggering/correction examples
- [ ] CI (Buildkite)