### PR TITLE
fix(nesting): ignore typealiases in nesting depth by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,11 @@
 
 ### Bug Fixes
 
+* Enable `ignore_typealiases_and_associatedtypes` by default in the `nesting` rule
+  so typealiases and associated types no longer count toward type nesting depth.  
+  [leno23](https://github.com/leno23)
+  [#3183](https://github.com/realm/SwiftLint/issues/3183)
+
 * Detect and autocorrect missing whitespace before `else` in `guard`
   statements for the `statement_position` rule.  
   [theamodhshetty](https://github.com/theamodhshetty)

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/NestingRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/NestingRuleExamples.swift
@@ -4,6 +4,7 @@ private let detectingTypes = ["actor", "class", "struct", "enum"]
 
 internal struct NestingRuleExamples {
     static let nonTriggeringExamples = nonTriggeringTypeExamples
+        + nonTriggeringTypeAliasExamples
         + nonTriggeringFunctionExamples
         + nonTriggeringClosureAndStatementExamples
         + nonTriggeringProtocolExamples
@@ -52,6 +53,17 @@ internal struct NestingRuleExamples {
                     """),
             ]
         }
+
+    private static let nonTriggeringTypeAliasExamples: [Example] = [
+        .init("""
+        struct AStruct {
+            struct BStruct {
+                typealias GreatType = C.Type
+            }
+            struct CStruct {}
+        }
+        """),
+    ]
 
     private static let nonTriggeringFunctionExamples: [Example] = [
         // default maximum function nesting level

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NestingConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NestingConfiguration.swift
@@ -13,7 +13,7 @@ struct NestingConfiguration: RuleConfiguration {
     @ConfigurationElement(key: "always_allow_one_type_in_functions")
     private(set) var alwaysAllowOneTypeInFunctions = false
     @ConfigurationElement(key: "ignore_typealiases_and_associatedtypes")
-    private(set) var ignoreTypealiasesAndAssociatedtypes = false
+    private(set) var ignoreTypealiasesAndAssociatedtypes = true
     @ConfigurationElement(key: "ignore_coding_keys")
     private(set) var ignoreCodingKeys = false
 

--- a/Tests/BuiltInRulesTests/NestingRuleTests.swift
+++ b/Tests/BuiltInRulesTests/NestingRuleTests.swift
@@ -511,7 +511,7 @@ final class NestingRuleTests: SwiftLintTestCase {
         verifyRule(description, ruleConfiguration: ["check_nesting_in_closures_and_statements": false])
     }
 
-    func testNestingWithoutTypealiasAndAssociatedtype() {
+    func testNestingIgnoresTypealiasesAndAssociatedtypesByDefault() {
         var nonTriggeringExamples = NestingRule.description.nonTriggeringExamples
         nonTriggeringExamples.append(contentsOf: detectingTypes.flatMap { type -> [Example] in
             [
@@ -553,6 +553,25 @@ final class NestingRuleTests: SwiftLintTestCase {
 
         let description = NestingRule.description.with(nonTriggeringExamples: nonTriggeringExamples)
 
-        verifyRule(description, ruleConfiguration: ["ignore_typealiases_and_associatedtypes": true])
+        verifyRule(description)
+    }
+
+    func testNestingCountsTypealiasesWhenNotIgnored() {
+        let triggeringExamples = detectingTypes.flatMap { type -> [Example] in
+            [
+                .init("""
+                    \(type) Example_0 {
+                        \(type) Example_1 {
+                            ↓typealias Example_2_Type = Example_2.Type
+                        }
+                        \(type) Example_2 {}
+                    }
+                """),
+            ]
+        }
+
+        let description = NestingRule.description.with(triggeringExamples: triggeringExamples)
+
+        verifyRule(description, ruleConfiguration: ["ignore_typealiases_and_associatedtypes": false])
     }
 }

--- a/Tests/IntegrationTests/Resources/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/Resources/default_rule_configurations.yml
@@ -738,7 +738,7 @@ nesting:
     warning: 2
   check_nesting_in_closures_and_statements: true
   always_allow_one_type_in_functions: false
-  ignore_typealiases_and_associatedtypes: false
+  ignore_typealiases_and_associatedtypes: true
   ignore_coding_keys: false
   meta:
     opt-in: false


### PR DESCRIPTION
## Summary

- Default `ignore_typealiases_and_associatedtypes` to `true` in the `nesting` rule.
- Typealiases and associated types no longer count toward type nesting depth unless users opt out with `ignore_typealiases_and_associatedtypes: false`.

Fixes #3183

## Test plan

- [x] Added non-triggering example from the issue report
- [x] Renamed/updated tests for default behavior and opt-out via `false`
- [ ] CI (Buildkite)

## Note

The `ignore_typealiases_and_associatedtypes` option already existed; this change only updates the default to match expected behavior described in the issue.