### PR TITLE
feat(cli): add --parent-config for lint and analyze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 
 ### Enhancements
 
+* Add `--parent-config` to `lint` and `analyze` to merge parent configuration files
+  without specifying `parent_config` in `.swiftlint.yml`.  
+  [leno23](https://github.com/leno23)
+  [#5421](https://github.com/realm/SwiftLint/issues/5421)
+
 * Print fixed code read from stdin to stdout.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#6501](https://github.com/realm/SwiftLint/issues/6501)

--- a/Source/SwiftLintFramework/Configuration+CommandLine.swift
+++ b/Source/SwiftLintFramework/Configuration+CommandLine.swift
@@ -287,9 +287,29 @@ extension Configuration {
 
     // MARK: LintOrAnalyze Command
 
+    /// Resolves configuration file paths when `--parent-config` is used on the command line.
+    ///
+    /// Parent configs are prepended so they are merged before the child configuration,
+    /// matching the `parent_config` YAML key behavior.
+    package static func resolvedConfigurationFiles(
+        parentConfig: [String],
+        configurationFiles: [String]
+    ) -> [String] {
+        guard parentConfig.isNotEmpty else {
+            return configurationFiles
+        }
+        let childConfigurationFiles = configurationFiles.isEmpty
+            ? [Self.defaultFileName]
+            : configurationFiles
+        return parentConfig + childConfigurationFiles
+    }
+
     init(options: LintOrAnalyzeOptions) {
         self.init(
-            configurationFiles: options.configurationFiles,
+            configurationFiles: Self.resolvedConfigurationFiles(
+                parentConfig: options.parentConfig,
+                configurationFiles: options.configurationFiles
+            ),
             enableAllRules: options.enableAllRules,
             onlyRule: options.onlyRule,
             cachePath: options.cachePath

--- a/Source/SwiftLintFramework/LintOrAnalyzeCommand.swift
+++ b/Source/SwiftLintFramework/LintOrAnalyzeCommand.swift
@@ -34,6 +34,7 @@ package struct LintOrAnalyzeOptions {
     let paths: [String]
     let useSTDIN: Bool
     let configurationFiles: [String]
+    let parentConfig: [String]
     let strict: Bool
     let lenient: Bool
     let forceExclude: Bool
@@ -63,6 +64,7 @@ package struct LintOrAnalyzeOptions {
                  paths: [String],
                  useSTDIN: Bool,
                  configurationFiles: [String],
+                 parentConfig: [String] = [],
                  strict: Bool,
                  lenient: Bool,
                  forceExclude: Bool,
@@ -91,6 +93,7 @@ package struct LintOrAnalyzeOptions {
         self.paths = paths
         self.useSTDIN = useSTDIN
         self.configurationFiles = configurationFiles
+        self.parentConfig = parentConfig
         self.strict = strict
         self.lenient = lenient
         self.forceExclude = forceExclude

--- a/Source/swiftlint/Commands/Analyze.swift
+++ b/Source/swiftlint/Commands/Analyze.swift
@@ -24,6 +24,7 @@ extension SwiftLint {
                 paths: allPaths,
                 useSTDIN: false,
                 configurationFiles: common.config,
+                parentConfig: common.parentConfig,
                 strict: common.leniency == .strict,
                 lenient: common.leniency == .lenient,
                 forceExclude: common.forceExclude,

--- a/Source/swiftlint/Commands/Lint.swift
+++ b/Source/swiftlint/Commands/Lint.swift
@@ -41,6 +41,7 @@ extension SwiftLint {
                 paths: allPaths,
                 useSTDIN: useSTDIN,
                 configurationFiles: common.config,
+                parentConfig: common.parentConfig,
                 strict: common.leniency == .strict,
                 lenient: common.leniency == .lenient,
                 forceExclude: common.forceExclude,

--- a/Source/swiftlint/Common/LintOrAnalyzeArguments.swift
+++ b/Source/swiftlint/Common/LintOrAnalyzeArguments.swift
@@ -20,6 +20,8 @@ enum LeniencyOptions: String, EnumerableFlag {
 struct LintOrAnalyzeArguments: ParsableArguments {
     @Option(help: "The path to one or more SwiftLint configuration files, evaluated as a parent-child hierarchy.")
     var config = [String]()
+    @Option(help: "The path to one or more parent configuration files to merge before the child configuration.")
+    var parentConfig = [String]()
     @Flag(name: [.long, .customLong("autocorrect")], help: "Correct violations whenever possible.")
     var fix = false
 

--- a/Tests/FileSystemAccessTests/ConfigurationTests+MultipleConfigs.swift
+++ b/Tests/FileSystemAccessTests/ConfigurationTests+MultipleConfigs.swift
@@ -234,6 +234,18 @@ extension ConfigurationTests {
         )
     }
 
+    func testNestedConfigurationWithInvalidYamlFallsBackToDefault() async throws {
+        XCTAssert(FileManager.default.changeCurrentDirectoryPath(Mock.Dir.duplicateYamlKeys))
+
+        let console = try await Issue.captureConsole {
+            let config = Configuration(configurationFiles: [])
+            _ = config.configuration(for: SwiftLintFile(path: Mock.Swift.duplicateYamlKeysSub)!)
+        }
+
+        XCTAssertTrue(console.contains("Cannot parse YAML file"))
+        XCTAssertTrue(console.contains("Falling back to default configuration"))
+    }
+
     func testNestedConfigurationForOnePathPassedIn() {
         // If a path to one or more configuration files is specified, nested configurations should be ignored
         let config = Configuration(configurationFiles: [Mock.Yml._0])
@@ -277,6 +289,20 @@ extension ConfigurationTests {
                 Configuration(configurationFiles: ["expected.yml"])
             )
         }
+    }
+
+    func testParentConfigCommandLineOption() {
+        XCTAssert(FileManager.default.changeCurrentDirectoryPath(Mock.Dir.parentConfigTest2))
+
+        let viaYaml = Configuration(configurationFiles: ["main.yml"])
+        let viaCLI = Configuration(
+            configurationFiles: Configuration.resolvedConfigurationFiles(
+                parentConfig: ["parent1.yml"],
+                configurationFiles: ["main_without_parent.yml"]
+            )
+        )
+
+        assertEqualExceptForFileGraph(viaYaml, viaCLI)
     }
 
     func testCommandLineChildConfigs() {

--- a/Tests/FileSystemAccessTests/Resources/ProjectMock/ParentConfig/Test2/main_without_parent.yml
+++ b/Tests/FileSystemAccessTests/Resources/ProjectMock/ParentConfig/Test2/main_without_parent.yml
@@ -1,0 +1,12 @@
+opt_in_rules:
+  - identifier_name
+
+disabled_rules:
+  - trailing_closure
+  - empty_count
+
+line_length: 80
+
+identifier_name:
+  excluded:
+    - abc


### PR DESCRIPTION
## Summary

- Add `--parent-config` to `lint` and `analyze` commands.
- Parent configuration paths are prepended to the configuration hierarchy, equivalent to using `parent_config` in YAML without editing the child file.

Fixes #5421

## Test plan

- [x] `testParentConfigCommandLineOption` compares CLI resolution with existing `ParentConfig/Test2` YAML fixture
- [ ] CI (Buildkite)

## Usage

```bash
swiftlint lint --parent-config path/to/parent.yml
swiftlint lint --parent-config parent.yml --config .swiftlint.yml
```