### PR TITLE
fix(attributes): apply arguments-on-new-line to types and functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,12 @@
 
 ### Bug Fixes
 
+* Apply `attributes_with_arguments_always_on_line_above` to functions and types,
+  allowing attributes without arguments on the same line while requiring a new
+  line when arguments are present.  
+  [leno23](https://github.com/leno23)
+  [#5011](https://github.com/realm/SwiftLint/issues/5011)
+
 * Detect and autocorrect missing whitespace before `else` in `guard`
   statements for the `statement_position` rule.  
   [theamodhshetty](https://github.com/theamodhshetty)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
@@ -162,7 +162,7 @@ private struct RuleHelper {
                     linesWithAttributes.contains(attributeStartLine)
                 linesWithAttributes.insert(attributeStartLine)
                 if hasViolation {
-                    if attributesWithArgumentsAlwaysOnNewLine, shouldBeOnSameLine {
+                    if attributesWithArgumentsAlwaysOnNewLine, attribute.arguments != nil {
                         return .argumentsAlwaysOnNewLineViolation
                     }
                     return .violation
@@ -185,6 +185,11 @@ private extension AttributeListSyntax {
                 }
                 if configuration.alwaysOnNewLine.contains(atPrefixedName) {
                     return (attribute, .dedicatedLine)
+                }
+                if configuration.attributesWithArgumentsAlwaysOnNewLine, !shouldBeOnSameLine {
+                    return attribute.arguments != nil
+                        ? (attribute, .dedicatedLine)
+                        : (attribute, .sameLineAsDeclaration)
                 }
                 if attribute.arguments != nil, configuration.attributesWithArgumentsAlwaysOnNewLine {
                     return (attribute, .dedicatedLine)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRuleExamples.swift
@@ -86,6 +86,17 @@ internal struct AttributesRuleExamples {
         @MainActor
         final class AppDelegate: NSAppDelegate {}
         """),
+        Example("""
+        @objc(Foo)
+        class Foo: NSObject {
+            @objc func foo() {}
+        }
+        """),
+        Example("""
+        @objc class Foo: NSObject {
+            @objc func foo() {}
+        }
+        """),
         Example(#"""
         @_spi(Private) import SomeFramework
 
@@ -112,6 +123,8 @@ internal struct AttributesRuleExamples {
         Example("@NSManaged\n ↓func addSomeObject(book: SomeObject)"),
         Example("@IBAction\n ↓func buttonPressed(button: UIButton)"),
         Example("@IBAction\n @objc\n ↓func buttonPressed(button: UIButton)"),
+        Example("@objc(Foo) ↓class Foo: NSObject {}"),
+        Example("@objc(Foo) ↓func foo() {}"),
         Example("@available(iOS 9.0, *) ↓func animate(view: UIStackView)"),
         Example("@nonobjc final ↓class X {}"),
         Example("@available(iOS 9.0, *) ↓class UIStackView {}"),


### PR DESCRIPTION
## Summary

- When `attributes_with_arguments_always_on_line_above` is enabled (default), functions and types now follow the same rule as variables and imports: attributes without arguments may appear on the same line, while attributes with arguments must be on a separate line.
- Improves violation messaging for misplaced attributes that include arguments.

Fixes #5011

## Test plan

- [x] Added non-triggering examples for `@objc(Foo)` / `@objc` on classes and functions
- [x] Added triggering examples for `@objc(Foo)` on the same line as declarations
- [ ] CI (Buildkite)