### PR TITLE
fix: accessibility_trait_for_button with #available traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@
 
 ### Enhancements
 
+* Add `excluded_members` configuration to `empty_enum_arguments` to skip members
+  that require empty parentheses (e.g. HealthKit static functions).  
+  [leno23](https://github.com/leno23)
+  [#5269](https://github.com/realm/SwiftLint/issues/5269)
+
+* Fix `unused_enumerated` false positives when offset and element are used in
+  separate chained trailing closures after `.enumerated()`.  
+  [leno23](https://github.com/leno23)
+  [#5600](https://github.com/realm/SwiftLint/issues/5600)
+
+* Treat macro declarations like function declarations for `line_length` when
+  `ignores_function_declarations` is enabled.  
+  [leno23](https://github.com/leno23)
+  [#5648](https://github.com/realm/SwiftLint/issues/5648)
+
 * Print fixed code read from stdin to stdout.  
   [SimplyDanny](https://github.com/SimplyDanny)
   [#6501](https://github.com/realm/SwiftLint/issues/6501)
@@ -77,6 +92,18 @@
   [#6620](https://github.com/realm/SwiftLint/issues/6620)
 
 ### Bug Fixes
+
+* Fix `accessibility_trait_for_button` false positives when `.isButton` or
+  `.isLink` is provided via a closure or `if #available` in
+  `accessibilityAddTraits`.  
+  [leno23](https://github.com/leno23)
+  [#6446](https://github.com/realm/SwiftLint/issues/6446)
+
+* Treat actors as implicitly inheriting from `Actor` in `missing_docs` when
+  `excludes_inherited_types` is enabled, avoiding false positives on members
+  such as `unownedExecutor`.  
+  [leno23](https://github.com/leno23)
+  [#5422](https://github.com/realm/SwiftLint/issues/5422)
 
 * Detect and autocorrect missing whitespace before `else` in `guard`
   statements for the `statement_position` rule.  
@@ -693,7 +720,12 @@
   or other error.  
   [Martin Redington](https://github.com/mildm8nnered)
   [#6052](https://github.com/realm/SwiftLint/issues/6052)
-  
+
+* Fall back to default configuration when a nested `.swiftlint.yml` cannot be parsed
+  instead of aborting (e.g. duplicate YAML keys in a subdirectory).  
+  [leno23](https://github.com/leno23)
+  [#6052](https://github.com/realm/SwiftLint/issues/6052)
+
 * Keep the default severity levels when neither `warning` nor `error` values are configured.
   Ensure especially that the `error` level is not set to `nil` when the `warning` level
   isn't set either.  

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityTraitForButtonRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityTraitForButtonRule.swift
@@ -246,15 +246,83 @@ private extension FunctionCallExprSyntax {
     }
 
     private static func expressionContainsButtonOrLinkTrait(_ expression: ExprSyntax) -> Bool {
+        if expressionProvidesButtonOrLinkTrait(expression) {
+            return true
+        }
+
+        if let ifExpr = expression.as(IfExprSyntax.self) {
+            return expressionProvidesButtonOrLinkTraitInAllBranches(ifExpr)
+        }
+
+        if let closure = expression.as(ClosureExprSyntax.self) {
+            return codeBlockProvidesButtonOrLinkTrait(closure.statements)
+        }
+
+        if let functionCall = expression.as(FunctionCallExprSyntax.self),
+           let closure = functionCall.calledExpression.as(ClosureExprSyntax.self) {
+            return codeBlockProvidesButtonOrLinkTrait(closure.statements)
+        }
+
+        return false
+    }
+
+    private static func expressionProvidesButtonOrLinkTrait(_ expression: ExprSyntax) -> Bool {
         if let memberAccess = expression.as(MemberAccessExprSyntax.self) {
             let traitName = memberAccess.declName.baseName.text
             return traitName == "isButton" || traitName == "isLink"
         }
+
         if let arrayExpr = expression.as(ArrayExprSyntax.self) {
             return arrayExpr.elements.contains { element in
-                self.expressionContainsButtonOrLinkTrait(element.expression)
+                expressionProvidesButtonOrLinkTrait(element.expression)
             }
         }
+
+        return false
+    }
+
+    private static func expressionProvidesButtonOrLinkTraitInAllBranches(_ ifExpr: IfExprSyntax) -> Bool {
+        guard codeBlockProvidesButtonOrLinkTrait(ifExpr.body.statements) else {
+            return false
+        }
+
+        guard let elseBody = ifExpr.elseBody else {
+            return false
+        }
+
+        switch elseBody {
+        case .ifExpr(let elseIfExpr):
+            return expressionProvidesButtonOrLinkTraitInAllBranches(elseIfExpr)
+        case .codeBlock(let codeBlock):
+            return codeBlockProvidesButtonOrLinkTrait(codeBlock.statements)
+        }
+    }
+
+    private static func codeBlockProvidesButtonOrLinkTrait(_ statements: CodeBlockItemListSyntax) -> Bool {
+        for statement in statements {
+            switch statement.item {
+            case .expr(let expression):
+                if !expressionContainsButtonOrLinkTrait(expression) {
+                    return false
+                }
+            case .stmt(let statementSyntax):
+                if !statementProvidesButtonOrLinkTrait(statementSyntax) {
+                    return false
+                }
+            default:
+                return false
+            }
+        }
+
+        return !statements.isEmpty
+    }
+
+    private static func statementProvidesButtonOrLinkTrait(_ statement: StmtSyntax) -> Bool {
+        if let expressionStatement = statement.as(ExpressionStmtSyntax.self),
+           let ifExpr = expressionStatement.expression.as(IfExprSyntax.self) {
+            return expressionProvidesButtonOrLinkTraitInAllBranches(ifExpr)
+        }
+
         return false
     }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityTraitForButtonRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/AccessibilityTraitForButtonRuleExamples.swift
@@ -169,6 +169,23 @@ internal struct AccessibilityTraitForButtonRuleExamples {
             }
         }
         """),
+        Example("""
+        struct MyView: View {
+            var body: some View {
+                Text("Learn more")
+                    .onTapGesture {
+                        print("tapped")
+                    }
+                    .accessibilityAddTraits({
+                        if #available(iOS 17, *) {
+                            [.isToggle, .isButton]
+                        } else {
+                            .isButton
+                        }
+                    }())
+            }
+        }
+        """),
     ]
 
     static let triggeringExamples = [


### PR DESCRIPTION
## Summary

Fixes #6446. The rule did not treat `.isButton` / `.isLink` as present when passed via an immediately invoked closure or `if #available` branches in `accessibilityAddTraits`.

## Changes

- Recurse into closure bodies and `IfExprSyntax` branches when checking traits
- Add a non-triggering example matching the issue report

## Test plan

- [x] `swift test --filter AccessibilityTraitForButtonRuleGeneratedTests`