### PR TITLE
Tolerate unreadable directories and dedupe globs in linear time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,6 +186,16 @@
   be ordered via the `isolation` entry in `preferred_modifier_order`.  
   [leno23](https://github.com/leno23)
   [#6164](https://github.com/realm/SwiftLint/issues/6164)
+* Make `Glob.expandGlobstar` tolerant of unreadable directory entries on
+  large trees. `subpathsOfDirectory(atPath:)` aborted the entire glob
+  expansion on the first unreadable entry (permission denied, dangling
+  symlink, file removed mid-scan), causing most files in large projects to
+  be silently ignored. Replace the directory walk with a lazy `URL`
+  enumerator that has a per-item error handler so unreadable items are
+  skipped individually. Also dedupe glob results in linear time by adding
+  a `Hashable` overload of `Array.unique`, removing a quadratic dedup that
+  previously effectively hung 50k-file projects.  
+  [Chupik](https://github.com/Chupik)
 
 * Detect and autocorrect missing whitespace before `else` in `guard`
   statements for the `statement_position` rule.  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,15 @@
   [leno23](https://github.com/leno23)
   [#5648](https://github.com/realm/SwiftLint/issues/5648)
 
+* Make `Glob.expandGlobstar` tolerant of unreadable directory entries on
+  large trees. `subpathsOfDirectory(atPath:)` aborted the entire glob
+  expansion on the first unreadable entry (permission denied, dangling
+  symlink, file removed mid-scan), causing most files in large projects to
+  be silently ignored. Replace the directory walk with a lazy `URL`
+  enumerator that has a per-item error handler so unreadable items are
+  skipped individually.  
+  [Chupik](https://github.com/Chupik)
+
 * Avoid false positives in `prefer_self_in_static_references` for generic
   constraints and generic parameter bounds such as `where A: P` and `<A: P>`
   in classes and extensions.  
@@ -186,16 +195,6 @@
   be ordered via the `isolation` entry in `preferred_modifier_order`.  
   [leno23](https://github.com/leno23)
   [#6164](https://github.com/realm/SwiftLint/issues/6164)
-* Make `Glob.expandGlobstar` tolerant of unreadable directory entries on
-  large trees. `subpathsOfDirectory(atPath:)` aborted the entire glob
-  expansion on the first unreadable entry (permission denied, dangling
-  symlink, file removed mid-scan), causing most files in large projects to
-  be silently ignored. Replace the directory walk with a lazy `URL`
-  enumerator that has a per-item error handler so unreadable items are
-  skipped individually. Also dedupe glob results in linear time by adding
-  a `Hashable` overload of `Array.unique`, removing a quadratic dedup that
-  previously effectively hung 50k-file projects.  
-  [Chupik](https://github.com/Chupik)
 
 * Detect and autocorrect missing whitespace before `else` in `guard`
   statements for the `statement_position` rule.  

--- a/Source/SwiftLintCore/Extensions/Array+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/Array+SwiftLint.swift
@@ -13,15 +13,6 @@ public extension Array where Element: Equatable {
 }
 
 public extension Array where Element: Hashable {
-    /// The elements in this array, discarding duplicates after the first one.
-    /// Order-preserving. Runs in linear time; the `Equatable` overload above
-    /// is quadratic and is selected automatically only when the element type
-    /// does not also conform to `Hashable`.
-    var unique: [Element] {
-        var seen = Set<Element>()
-        return filter { seen.insert($0).inserted }
-    }
-
     /// Produces an array containing the passed `obj` value.
     /// If `obj` is an array already, return it.
     /// If `obj` is a set, copy its elements to a new array.

--- a/Source/SwiftLintCore/Extensions/Array+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/Array+SwiftLint.swift
@@ -13,6 +13,15 @@ public extension Array where Element: Equatable {
 }
 
 public extension Array where Element: Hashable {
+    /// The elements in this array, discarding duplicates after the first one.
+    /// Order-preserving. Runs in linear time; the `Equatable` overload above
+    /// is quadratic and is selected automatically only when the element type
+    /// does not also conform to `Hashable`.
+    var unique: [Element] {
+        var seen = Set<Element>()
+        return filter { seen.insert($0).inserted }
+    }
+
     /// Produces an array containing the passed `obj` value.
     /// If `obj` is an array already, return it.
     /// If `obj` is a set, copy its elements to a new array.

--- a/Source/SwiftLintFramework/Helpers/Glob.swift
+++ b/Source/SwiftLintFramework/Helpers/Glob.swift
@@ -149,16 +149,27 @@ struct Glob {
             return []
         }
         let searchPath = firstPart.isEmpty ? fileManager.currentDirectoryPath : firstPart
-        var directories = [URL]()
-        do {
-            directories = try fileManager.subpathsOfDirectory(atPath: searchPath).compactMap { subpath in
-                let fullPath = firstPart.url().appending(path: subpath)
-                guard fullPath.isDirectory else { return nil }
-                return fullPath
+        // Enumerate lazily with a per-item error handler. `subpathsOfDirectory(atPath:)`, used
+        // previously, is all-or-nothing: a single unreadable entry (permission denied, dangling
+        // symlink, a file removed mid-scan, …) makes it throw, discarding every directory found
+        // so far. On large trees (50k+ files) hitting such an entry is likely, which left only
+        // the root directory to be globbed and silently ignored all nested files.
+        let enumerator = fileManager.enumerator(
+            at: URL(fileURLWithPath: searchPath, isDirectory: true),
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [],
+            errorHandler: { _, error in
+                Issue.genericWarning("Error parsing file system item: \(error)").print()
+                return true
             }
-        } catch {
-            Issue.genericWarning("Error parsing file system item: \(error)").print()
-        }
+        )
+        var directories: [String] = enumerator?.compactMap { item in
+            guard let url = item as? URL,
+                  (try? url.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true else {
+                return nil
+            }
+            return url.path
+        } ?? []
 
         // Check the base directory for the glob star as well.
         directories.insert(firstPart.url(), at: 0)

--- a/Source/SwiftLintFramework/Helpers/Glob.swift
+++ b/Source/SwiftLintFramework/Helpers/Glob.swift
@@ -144,42 +144,35 @@ struct Glob {
         }
         var parts = pattern.filepath.components(separatedBy: "**")
         let firstPart = parts.removeFirst()
-        let fileManager = FileManager.default
-        guard firstPart.isEmpty || fileManager.fileExists(atPath: firstPart) else {
+        guard firstPart.isEmpty || firstPart.url().exists else {
             return []
         }
-        let searchPath = firstPart.isEmpty ? fileManager.currentDirectoryPath : firstPart
-        // Enumerate lazily with a per-item error handler. `subpathsOfDirectory(atPath:)`, used
-        // previously, is all-or-nothing: a single unreadable entry (permission denied, dangling
-        // symlink, a file removed mid-scan, …) makes it throw, discarding every directory found
-        // so far. On large trees (50k+ files) hitting such an entry is likely, which left only
-        // the root directory to be globbed and silently ignored all nested files.
-        let enumerator = fileManager.enumerator(
-            at: URL(fileURLWithPath: searchPath, isDirectory: true),
+        let searchPath = firstPart.isEmpty ? URL.cwd : firstPart.url(directoryHint: .isDirectory)
+        let enumerator = FileManager.default.enumerator(
+            at: searchPath,
             includingPropertiesForKeys: [.isDirectoryKey],
-            options: [],
             errorHandler: { _, error in
                 Issue.genericWarning("Error parsing file system item: \(error)").print()
                 return true
             }
         )
-        var directories: [String] = enumerator?.compactMap { item in
+        var directories = enumerator?.compactMap { item -> URL? in
             guard let url = item as? URL,
                   (try? url.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true else {
                 return nil
             }
-            return url.path
+            return url
         } ?? []
 
         // Check the base directory for the glob star as well.
-        directories.insert(firstPart.url(), at: 0)
+        directories.insert(firstPart.url(directoryHint: .isDirectory), at: 0)
 
         var lastPart = parts.joined(separator: "**")
         var results = [URL]()
 
         // Include the globstar root directory ("dir/") in a pattern like "dir/**" or "dir/**/"
         if lastPart.isEmpty {
-            results.append(firstPart.url())
+            results.append(firstPart.url(directoryHint: .isDirectory))
             lastPart = "*"
         }
 

--- a/Tests/FileSystemAccessTests/GlobTests.swift
+++ b/Tests/FileSystemAccessTests/GlobTests.swift
@@ -130,11 +130,14 @@ final class GlobTests: SwiftLintTestCase {
         XCTAssertEqual(lhs.sorted(by: compare), rhs.sorted(by: compare), file: file, line: line)
     }
 
+    // swiftlint:disable:next function_body_length
     func testGlobstarToleratesUnreadableSubdirectory() throws {
+#if !os(Windows)
         try XCTSkipIf(
             getuid() == 0,
             "Permission-bit tests cannot exercise the tolerance fix when running as root."
         )
+#endif
 
         let fileManager = FileManager.default
         let root = fileManager.temporaryDirectory.appendingPathComponent(
@@ -157,6 +160,43 @@ final class GlobTests: SwiftLintTestCase {
             try "let x = 1".write(to: path, atomically: true, encoding: .utf8)
         }
 
+#if os(Windows)
+        let username = ProcessInfo.processInfo.environment["USERNAME"] ?? ""
+        try XCTSkipIf(username.isEmpty, "Cannot determine current Windows username to set ACLs.")
+
+        // Deny read/list permissions for this directory to trigger traversal errors.
+        let icaclsPath = URL(filePath: "C:/Windows/System32/icacls.exe", directoryHint: .notDirectory)
+        func runIcacls(_ arguments: [String]) throws -> Int32 {
+            let process = Process()
+            process.executableURL = icaclsPath
+            process.arguments = arguments
+            try process.run()
+            process.waitUntilExit()
+            return process.terminationStatus
+        }
+
+        let denyExitCode = try runIcacls([
+            unreadableDir.filepath,
+            "/deny",
+            "\(username):(RX)",
+        ])
+        try XCTSkipIf(denyExitCode != 0, "Failed to make test directory unreadable on Windows.")
+
+        defer {
+            _ = try? runIcacls([
+                unreadableDir.filepath,
+                "/remove:d",
+                username,
+            ])
+            try? fileManager.removeItem(atPath: root.filepath)
+        }
+
+        let canStillAccess = (try? fileManager.contentsOfDirectory(atPath: unreadableDir.filepath)) != nil
+        try XCTSkipIf(
+            canStillAccess,
+            "User has elevated privileges allowing bypass of deny ACLs; cannot test tolerance on Windows runners."
+        )
+#else
         // Make `a/b/c` unreadable. This is what previously made
         // `subpathsOfDirectory(atPath:)` throw and drop every directory it had
         // collected so far, leaving only the search root globbed.
@@ -166,6 +206,7 @@ final class GlobTests: SwiftLintTestCase {
             try? fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: unreadableDir.filepath)
             try? fileManager.removeItem(atPath: root.filepath)
         }
+#endif
 
         let matches = Glob.resolveGlob(root.appending(components: "**", "*.swift"))
 

--- a/Tests/FileSystemAccessTests/GlobTests.swift
+++ b/Tests/FileSystemAccessTests/GlobTests.swift
@@ -130,10 +130,6 @@ final class GlobTests: SwiftLintTestCase {
         XCTAssertEqual(lhs.sorted(by: compare), rhs.sorted(by: compare), file: file, line: line)
     }
 
-    /// One unreadable subdirectory in the search tree must not cause the entire glob to drop every
-    /// nested file. The previous implementation used `subpathsOfDirectory(atPath:)`, which throws
-    /// on the first item it cannot access and discards everything collected so far — on a 50k-file
-    /// project that left only the search root globbed, silently ignoring all nested files.
     func testGlobstarToleratesUnreadableSubdirectory() throws {
         try XCTSkipIf(
             getuid() == 0,
@@ -141,52 +137,54 @@ final class GlobTests: SwiftLintTestCase {
         )
 
         let fileManager = FileManager.default
-        let root = NSTemporaryDirectory().stringByAppendingPathComponent(
+        let root = fileManager.temporaryDirectory.appendingPathComponent(
             "SwiftLintGlobTolerance-\(UUID().uuidString)"
         )
-        let unreadableDir = root.stringByAppendingPathComponent("a/b/c")
-        let openDir = root.stringByAppendingPathComponent("a/x")
-        try fileManager.createDirectory(atPath: unreadableDir, withIntermediateDirectories: true)
-        try fileManager.createDirectory(atPath: openDir, withIntermediateDirectories: true)
+        let unreadableDir = root.appending(path: "a/b/c")
+        let openDir = root.appending(path: "a/x")
+        try fileManager.createDirectory(at: unreadableDir, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: openDir, withIntermediateDirectories: true)
 
-        for path in [
-            root.stringByAppendingPathComponent("top.swift"),
-            root.stringByAppendingPathComponent("a/inA.swift"),
-            root.stringByAppendingPathComponent("a/b/inB.swift"),
-            unreadableDir.stringByAppendingPathComponent("inC.swift"),
-            openDir.stringByAppendingPathComponent("inX.swift"),
-        ] {
-            try "let x = 1".write(toFile: path, atomically: true, encoding: .utf8)
+        let paths = [
+            root.appending(path: "top.swift"),
+            root.appending(path: "a/inA.swift"),
+            root.appending(path: "a/b/inB.swift"),
+            unreadableDir.appending(path: "inC.swift"),
+            openDir.appending(path: "inX.swift"),
+        ]
+
+        for path in paths {
+            try "let x = 1".write(to: path, atomically: true, encoding: .utf8)
         }
 
         // Make `a/b/c` unreadable. This is what previously made
         // `subpathsOfDirectory(atPath:)` throw and drop every directory it had
         // collected so far, leaving only the search root globbed.
-        try fileManager.setAttributes([.posixPermissions: 0o000], ofItemAtPath: unreadableDir)
+        try fileManager.setAttributes([.posixPermissions: 0o000], ofItemAtPath: unreadableDir.filepath)
         defer {
             // Restore permissions so cleanup can remove the tree even if the test fails.
-            try? fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: unreadableDir)
-            try? fileManager.removeItem(atPath: root)
+            try? fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: unreadableDir.filepath)
+            try? fileManager.removeItem(atPath: root.filepath)
         }
 
-        let matches = Glob.resolveGlob(root.stringByAppendingPathComponent("**/*.swift"))
+        let matches = Glob.resolveGlob(root.appending(components: "**", "*.swift"))
 
         // Siblings of the unreadable subtree must still resolve. Without the fix only top.swift
         // (the search-root's own pattern) would have matched.
-        XCTAssertTrue(matches.contains { $0.hasSuffix("/top.swift") }, "top.swift missing")
+        XCTAssertTrue(matches.contains { $0.lastPathComponent == "top.swift" }, "top.swift missing")
         XCTAssertTrue(
-            matches.contains { $0.hasSuffix("/a/inA.swift") }, "a/inA.swift missing — tolerance regressed"
+            matches.contains { $0.path.hasSuffix("/a/inA.swift") }, "a/inA.swift missing — tolerance regressed"
         )
         XCTAssertTrue(
-            matches.contains { $0.hasSuffix("/a/b/inB.swift") }, "a/b/inB.swift missing — tolerance regressed"
+            matches.contains { $0.path.hasSuffix("/a/b/inB.swift") }, "a/b/inB.swift missing — tolerance regressed"
         )
         XCTAssertTrue(
-            matches.contains { $0.hasSuffix("/a/x/inX.swift") }, "a/x/inX.swift missing — tolerance regressed"
+            matches.contains { $0.path.hasSuffix("/a/x/inX.swift") }, "a/x/inX.swift missing — tolerance regressed"
         )
 
         // The unreadable subtree is genuinely inaccessible.
         XCTAssertFalse(
-            matches.contains { $0.hasSuffix("/inC.swift") }, "inC.swift should not be reachable"
+            matches.contains { $0.lastPathComponent == "inC.swift" }, "inC.swift should not be reachable"
         )
     }
 }

--- a/Tests/FileSystemAccessTests/GlobTests.swift
+++ b/Tests/FileSystemAccessTests/GlobTests.swift
@@ -129,4 +129,64 @@ final class GlobTests: SwiftLintTestCase {
         }
         XCTAssertEqual(lhs.sorted(by: compare), rhs.sorted(by: compare), file: file, line: line)
     }
+
+    /// One unreadable subdirectory in the search tree must not cause the entire glob to drop every
+    /// nested file. The previous implementation used `subpathsOfDirectory(atPath:)`, which throws
+    /// on the first item it cannot access and discards everything collected so far — on a 50k-file
+    /// project that left only the search root globbed, silently ignoring all nested files.
+    func testGlobstarToleratesUnreadableSubdirectory() throws {
+        try XCTSkipIf(
+            getuid() == 0,
+            "Permission-bit tests cannot exercise the tolerance fix when running as root."
+        )
+
+        let fileManager = FileManager.default
+        let root = NSTemporaryDirectory().stringByAppendingPathComponent(
+            "SwiftLintGlobTolerance-\(UUID().uuidString)"
+        )
+        let unreadableDir = root.stringByAppendingPathComponent("a/b/c")
+        let openDir = root.stringByAppendingPathComponent("a/x")
+        try fileManager.createDirectory(atPath: unreadableDir, withIntermediateDirectories: true)
+        try fileManager.createDirectory(atPath: openDir, withIntermediateDirectories: true)
+
+        for path in [
+            root.stringByAppendingPathComponent("top.swift"),
+            root.stringByAppendingPathComponent("a/inA.swift"),
+            root.stringByAppendingPathComponent("a/b/inB.swift"),
+            unreadableDir.stringByAppendingPathComponent("inC.swift"),
+            openDir.stringByAppendingPathComponent("inX.swift"),
+        ] {
+            try "let x = 1".write(toFile: path, atomically: true, encoding: .utf8)
+        }
+
+        // Make `a/b/c` unreadable. This is what previously made
+        // `subpathsOfDirectory(atPath:)` throw and drop every directory it had
+        // collected so far, leaving only the search root globbed.
+        try fileManager.setAttributes([.posixPermissions: 0o000], ofItemAtPath: unreadableDir)
+        defer {
+            // Restore permissions so cleanup can remove the tree even if the test fails.
+            try? fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: unreadableDir)
+            try? fileManager.removeItem(atPath: root)
+        }
+
+        let matches = Glob.resolveGlob(root.stringByAppendingPathComponent("**/*.swift"))
+
+        // Siblings of the unreadable subtree must still resolve. Without the fix only top.swift
+        // (the search-root's own pattern) would have matched.
+        XCTAssertTrue(matches.contains { $0.hasSuffix("/top.swift") }, "top.swift missing")
+        XCTAssertTrue(
+            matches.contains { $0.hasSuffix("/a/inA.swift") }, "a/inA.swift missing — tolerance regressed"
+        )
+        XCTAssertTrue(
+            matches.contains { $0.hasSuffix("/a/b/inB.swift") }, "a/b/inB.swift missing — tolerance regressed"
+        )
+        XCTAssertTrue(
+            matches.contains { $0.hasSuffix("/a/x/inX.swift") }, "a/x/inX.swift missing — tolerance regressed"
+        )
+
+        // The unreadable subtree is genuinely inaccessible.
+        XCTAssertFalse(
+            matches.contains { $0.hasSuffix("/inC.swift") }, "inC.swift should not be reachable"
+        )
+    }
 }


### PR DESCRIPTION
## Introduction

We noticed that SwiftLint sometimes has problems with our very large repository (50,000+ files). The problem is that SwiftLint occasionally fails to enumerate the files to lint. We finally reproduced the problem and used an LLM to investigate and fix it. As a side benefit, the LLM also identified a way to significantly improve linting performance - see the Performance section below. The explanation below was drafted with LLM assistance.

## Problem

`Glob.expandGlobstar` uses `subpathsOfDirectory(atPath:)` to discover nested directories before per-directory globbing. That API is all-or-nothing: it throws on the first item it cannot access, and the catch block discards every directory collected so far. After the throw, only the search root remains in `directories`, so the rest of `expandGlobstar` globs nothing more than the root pattern — every nested file is silently ignored.

Then in `Glob.resolveGlob`, matched paths are deduped with `Array.unique`, whose `Equatable` overload is O(n²) (`Array.contains` linear scan per element). On a 50k-file project that's ~2.5 billion string comparisons; in practice it effectively hangs.

So a large project with a `**` glob and any unreadable subdirectory (permission denied, dangling symlink, file removed mid-scan in CI) is hit by both bugs: most files are dropped, and the few that remain take very long to dedupe.

## Fix

1. Replace `subpathsOfDirectory(atPath:)` with a lazy `FileManager.enumerator(at:includingPropertiesForKeys:options:errorHandler:)`. The `errorHandler` returns `true`, so a single unreadable entry skips only itself rather than aborting the whole scan. Removed the now-unused `Glob.isDirectory(path:)` helper since `.isDirectoryKey` replaces its job (and is pre-cached by the enumerator).
2. Add a `Hashable` overload of `Array.unique` (linear time via `Set.insert`). Swift's overload resolution selects it automatically wherever the element type is `Hashable`, so every existing call site gets the speed-up with no other code changes — including the call inside `Glob.resolveGlob` that motivated this.

## Tests

`testGlobstarToleratesUnreadableSubdirectory` in `Tests/FileSystemAccessTests/GlobTests`: creates a temp tree, chmods one subdirectory `000`, runs `Glob.resolveGlob("**/*.swift")`, asserts that siblings of the unreadable subtree still resolve while the subtree itself stays inaccessible. Skipped under root since permission-bit tests can't exercise the tolerance fix as root.

## Performance

Measured on an internal iOS monorepo (58 133 `.swift` files; 43 643 of them lintable after `excluded:` filtering) using `swiftlint lint --no-cache --quiet --only-rule hardcoded_localizable_string --write-baseline …`. Runs alternated between the two binaries to even out OS page-cache effects.

| Run      | This branch | `realm/SwiftLint` 0.59.1 |  Speedup |
| -------- | ----------: | -----------------------: | -------: |
| 1        |    52.93 s  |                 83.74 s  |   1.58×  |
| 2        |    51.36 s  |                 82.33 s  |   1.60×  |
| 3        |    45.37 s  |                 79.58 s  |   1.75×  |
| **mean** | **49.89 s** |             **81.88 s**  | **1.64×** |
| min      |    45.37 s  |                 79.58 s  |   1.75×  |
| max      |    52.93 s  |                 83.74 s  |   1.58×  |

Baseline output is byte-identical between the two binaries, so the speedup is on the same workload (not a case of the new build doing less work):

| Metric                            |          New |          Old |
| --------------------------------- | -----------: | -----------: |
| Baseline JSON size                | 3 413 444 B  | 3 413 444 B  |
| Violations reported               |       6 072  |       6 072  |
| Distinct files with violations    |       1 750  |       1 750  |

## Notes for review

- **Symlink behavior** (intentional, worth flagging): the URL enumerator does not descend into symlinks to directories, whereas `subpathsOfDirectory` did. For glob expansion this is generally desirable — no symlink-cycle hangs, no double-linting — and matches the direction this codebase has already taken in `FileManager.collectFiles`. Happy to change if you'd rather preserve the old following behavior.
- **`Array.unique` public surface**: this adds a new computed property on `Array where Element: Hashable` alongside the existing `Array where Element: Equatable`. Overload resolution picks the Hashable one transparently, so no source breakage. If you'd prefer to scope the fix to a private `Set`-based dedup in `Glob.swift` and leave `Array.unique` untouched, that's a one-line alternative — let me know.
