### PR TITLE
Add sort order option for sorted imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
 
 ### Enhancements
 
+* Add a `sort_order` option to the `sorted_imports` rule for choosing between
+  case-insensitive and lexicographic import ordering.
+  [ayushnagpal570-ai](https://github.com/ayushnagpal570-ai)
+  [#4810](https://github.com/realm/SwiftLint/issues/4810)
+
 * Treat extensions like classes in the `prefer_self_in_static_references`
   rule.  
   [itsybitsybootsy](https://github.com/itsybitsybootsy)

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SortedImportsConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/SortedImportsConfiguration.swift
@@ -11,8 +11,18 @@ struct SortedImportsConfiguration: SeverityBasedRuleConfiguration {
         case names
     }
 
+    @AcceptableByConfigurationElement
+    enum SortOrder: String {
+        /// Sorts import lines based on a case insensitive comparison of the imported module name.
+        case caseInsensitive = "case_insensitive"
+        /// Sorts import lines based on a lexicographic comparison of the imported module name.
+        case lexicographic
+    }
+
     @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
     @ConfigurationElement(key: "grouping")
     private(set) var grouping = Grouping.names
+    @ConfigurationElement(key: "sort_order")
+    private(set) var sortOrder = SortOrder.caseInsensitive
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SortedImportsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SortedImportsRule.swift
@@ -25,7 +25,12 @@ private extension SortedImportsRule {
 
         override func visitPost(_ node: ImportDeclSyntax) {
             imports.append(
-                Import.from(importDecl: node, grouping: configuration.grouping, locationConverter: locationConverter)
+                Import.from(
+                    importDecl: node,
+                    grouping: configuration.grouping,
+                    sortOrder: configuration.sortOrder,
+                    locationConverter: locationConverter
+                )
             )
         }
 
@@ -78,6 +83,7 @@ private extension SortedImportsRule {
                     let `import` = Import.from(
                         importDecl: importDecl,
                         grouping: configuration.grouping,
+                        sortOrder: configuration.sortOrder,
                         locationConverter: locationConverter
                     )
                     if let lastImport = imports.last, !`import`.isDirectlyAfter(previous: lastImport, in: file) {
@@ -121,6 +127,7 @@ private extension SortedImportsRule {
                 let firstImportWithoutComment = Import.from(
                     importDecl: firstImport.importDecl.with(\.leadingTrivia, leadingTrivia.second),
                     grouping: configuration.grouping,
+                    sortOrder: configuration.sortOrder,
                     locationConverter: locationConverter
                 )
                 let imports = [firstImportWithoutComment] + imports.dropFirst()
@@ -183,6 +190,7 @@ private struct Import: Comparable {
     let offset: Int
     let attributes: String
     let modifier: UInt8
+    let sortOrder: SortedImportsConfiguration.SortOrder
 
     var violationPosition: AbsolutePosition {
         importDecl.path.positionAfterSkippingLeadingTrivia
@@ -194,6 +202,7 @@ private struct Import: Comparable {
 
     static func from(importDecl: ImportDeclSyntax,
                      grouping: SortedImportsConfiguration.Grouping,
+                     sortOrder: SortedImportsConfiguration.SortOrder,
                      locationConverter: SourceLocationConverter) -> Self {
         let attributes: [String] =
             if grouping == .attributes {
@@ -231,7 +240,8 @@ private struct Import: Comparable {
             line: startLine,
             offset: locationConverter.location(for: importDecl.path.endPositionBeforeTrailingTrivia).line - startLine,
             attributes: attributes.joined(),
-            modifier: modifier
+            modifier: modifier,
+            sortOrder: sortOrder
         )
     }
 
@@ -257,6 +267,11 @@ private struct Import: Comparable {
             }
             return rhs.modifier == 0 || lhs.modifier < rhs.modifier
         }
-        return lhs.symbol.caseInsensitiveCompare(rhs.symbol) == .orderedAscending
+        switch lhs.sortOrder {
+        case .caseInsensitive:
+            return lhs.symbol.caseInsensitiveCompare(rhs.symbol) == .orderedAscending
+        case .lexicographic:
+            return lhs.symbol.lexicographicallyPrecedes(rhs.symbol)
+        }
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/SortedImportsRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/SortedImportsRuleExamples.swift
@@ -1,5 +1,6 @@
 internal struct SortedImportsRuleExamples {
     private static let groupByAttributesConfiguration = ["grouping": "attributes"]
+    private static let lexicographicSortConfiguration = ["sort_order": "lexicographic"]
 
     static let nonTriggeringExamples = [
         Example("""
@@ -16,6 +17,12 @@ internal struct SortedImportsRuleExamples {
         import labc
         import Ldef
         """),
+        Example("""
+        import AVFoundation
+        import AppTypes
+        import Base
+        import Logging
+        """, configuration: lexicographicSortConfiguration, excludeFromDocumentation: true),
         Example("""
         // comment
         import AAA
@@ -136,6 +143,12 @@ internal struct SortedImportsRuleExamples {
         import BBB
         """),
         Example("""
+        import AppTypes
+        import ↓AVFoundation
+        import Base
+        import Logging
+        """, configuration: lexicographicSortConfiguration, excludeFromDocumentation: true),
+        Example("""
           @testable import BBB
         @testable import ↓AAA
         """, configuration: groupByAttributesConfiguration, excludeFromDocumentation: true),
@@ -237,6 +250,17 @@ internal struct SortedImportsRuleExamples {
             #endif
             import AAA
             import BBB
+            """),
+        Example("""
+        import AppTypes
+        import AVFoundation
+        import Base
+        import Logging
+        """, configuration: lexicographicSortConfiguration, testMultiByteOffsets: false): Example("""
+            import AVFoundation
+            import AppTypes
+            import Base
+            import Logging
             """),
         Example("""
           // comment

--- a/Tests/IntegrationTests/Resources/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/Resources/default_rule_configurations.yml
@@ -1148,6 +1148,7 @@ sorted_first_last:
 sorted_imports:
   severity: warning
   grouping: names
+  sort_order: case_insensitive
   meta:
     opt-in: true
     correctable: true


### PR DESCRIPTION
## Summary
- add a `sort_order` option to `sorted_imports` with `case_insensitive` as the existing default and `lexicographic` as the new alternative
- thread the configured sort order through linting and autocorrection
- cover the new ordering mode in rule examples and the default configuration fixture

Closes #4810.

## Tests
- `swift test --filter SortedImportsRuleGeneratedTests`
- `swift test --filter RuleConfigurationTests`
- `swift test --filter IntegrationTests`
- `git diff --check`
