### PR TITLE
fix: unavailable_function skip methods overridden in file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,11 @@
 
 ### Bug Fixes
 
+* Fix `unavailable_function` false positives on base class methods that are
+  overridden in a subclass in the same file.  
+  [leno23](https://github.com/leno23)
+  [#6222](https://github.com/realm/SwiftLint/issues/6222)
+
 * Detect and autocorrect missing whitespace before `else` in `guard`
   statements for the `statement_position` rule.  
   [theamodhshetty](https://github.com/theamodhshetty)

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnavailableFunctionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/UnavailableFunctionRule.swift
@@ -37,6 +37,14 @@ struct UnavailableFunctionRule: Rule {
                 fatalError("Onboarding re-start crash.")
             }
             """),
+            Example("""
+            class Base {
+                func greet() { fatalError("Subclasses must override greet()") }
+            }
+            class Derived: Base {
+                override func greet() { print("Hello World") }
+            }
+            """),
         ],
         triggeringExamples: [
             Example("""
@@ -74,11 +82,14 @@ struct UnavailableFunctionRule: Rule {
 
 private extension UnavailableFunctionRule {
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
+        private lazy var overriddenMethods = OverriddenMethodCollector.overriddenMethods(in: file)
+
         override func visitPost(_ node: FunctionDeclSyntax) {
             guard !node.returnsNever,
                   !node.attributes.hasUnavailableAttribute,
                   node.body.containsTerminatingCall,
-                  !node.body.containsReturn else {
+                  !node.body.containsReturn,
+                  !node.isOverridden(in: overriddenMethods) else {
                 return
             }
 
@@ -88,12 +99,112 @@ private extension UnavailableFunctionRule {
         override func visitPost(_ node: InitializerDeclSyntax) {
             guard !node.attributes.hasUnavailableAttribute,
                   node.body.containsTerminatingCall,
-                  !node.body.containsReturn else {
+                  !node.body.containsReturn,
+                  !node.isOverridden(in: overriddenMethods) else {
                 return
             }
 
             violations.append(node.initKeyword.positionAfterSkippingLeadingTrivia)
         }
+    }
+}
+
+private struct OverriddenMethodKey: Hashable {
+    let className: String
+    let methodName: String
+}
+
+private enum OverriddenMethodCollector {
+    static func overriddenMethods(in file: SwiftLintFile) -> Set<OverriddenMethodKey> {
+        OverriddenMethodVisitor(viewMode: .sourceAccurate)
+            .walk(tree: file.syntaxTree, handler: \.overriddenMethods)
+    }
+}
+
+private final class OverriddenMethodVisitor: SyntaxVisitor {
+    private(set) var overriddenMethods = Set<OverriddenMethodKey>()
+    private var classInheritance = [String: [String]]()
+
+    override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+        classInheritance[node.name.text] = node.inheritedTypeNames
+        return .visitChildren
+    }
+
+    override func visitPost(_ node: FunctionDeclSyntax) {
+        guard node.modifiers.contains(keyword: .override),
+              let subclassName = node.parentClassDecl?.name.text else {
+            return
+        }
+
+        for className in allAncestors(of: subclassName) {
+            overriddenMethods.insert(OverriddenMethodKey(className: className, methodName: node.name.text))
+        }
+    }
+
+    override func visitPost(_ node: InitializerDeclSyntax) {
+        guard node.modifiers.contains(keyword: .override),
+              let subclassName = node.parentClassDecl?.name.text else {
+            return
+        }
+
+        for className in allAncestors(of: subclassName) {
+            overriddenMethods.insert(OverriddenMethodKey(className: className, methodName: "init"))
+        }
+    }
+
+    private func allAncestors(of className: String) -> [String] {
+        var ancestors = [String]()
+        var pending = classInheritance[className] ?? []
+
+        while let ancestor = pending.popLast() {
+            ancestors.append(ancestor)
+            pending.append(contentsOf: classInheritance[ancestor] ?? [])
+        }
+
+        return ancestors
+    }
+}
+
+private extension ClassDeclSyntax {
+    var inheritedTypeNames: [String] {
+        inheritanceClause?.inheritedTypes.compactMap {
+            $0.type.as(IdentifierTypeSyntax.self)?.name.text
+        } ?? []
+    }
+}
+
+private extension SyntaxProtocol {
+    var parentClassDecl: ClassDeclSyntax? {
+        var current: Syntax? = Syntax(self)
+
+        while let node = current {
+            if let classDecl = node.as(ClassDeclSyntax.self) {
+                return classDecl
+            }
+            current = node.parent
+        }
+
+        return nil
+    }
+}
+
+private extension FunctionDeclSyntax {
+    func isOverridden(in overriddenMethods: Set<OverriddenMethodKey>) -> Bool {
+        guard let className = parentClassDecl?.name.text else {
+            return false
+        }
+
+        return overriddenMethods.contains(OverriddenMethodKey(className: className, methodName: name.text))
+    }
+}
+
+private extension InitializerDeclSyntax {
+    func isOverridden(in overriddenMethods: Set<OverriddenMethodKey>) -> Bool {
+        guard let className = parentClassDecl?.name.text else {
+            return false
+        }
+
+        return overriddenMethods.contains(OverriddenMethodKey(className: className, methodName: "init"))
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #6222. `unavailable_function` reported base class methods that only call `fatalError` even when a subclass in the same file overrides them with a real implementation.

## Changes

- Collect `override` methods per class hierarchy within the file
- Skip violations on base methods that are overridden in a subclass

## Test plan

- [x] `swift test --filter UnavailableFunctionRuleGeneratedTests`

Made with [Cursor](https://cursor.com)