### PR TITLE
fix: unneeded_throws_rethrows skip protocol-required throws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@
 
 ### Bug Fixes
 
+* Fix `unneeded_throws_rethrows` false positives when `throws` is required by a
+  protocol conformance in the same file.  
+  [leno23](https://github.com/leno23)
+  [#6437](https://github.com/realm/SwiftLint/issues/6437)
+
 * Avoid false positives in `prefer_self_in_static_references` for generic
   constraints and generic parameter bounds such as `where A: P` and `<A: P>`
   in classes and extensions.  

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnneededThrowsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnneededThrowsRule.swift
@@ -23,6 +23,8 @@ private extension UnneededThrowsRule {
 
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         private var scopes = Stack<Scope>()
+        private var conformedProtocolsStack = Stack<[String]>()
+        private lazy var throwingProtocolRequirements = ThrowingProtocolRequirementsCollector.requirements(in: file)
 
         override var skippableDeclarations: [any DeclSyntaxProtocol.Type] {
             [
@@ -63,13 +65,53 @@ private extension UnneededThrowsRule {
             }
         }
 
+        override func visit(_ node: ActorDeclSyntax) -> SyntaxVisitorContinueKind {
+            conformedProtocolsStack.push(node.inheritedProtocolNames)
+            return .visitChildren
+        }
+
+        override func visitPost(_: ActorDeclSyntax) {
+            conformedProtocolsStack.closeScope()
+        }
+
+        override func visit(_ node: ClassDeclSyntax) -> SyntaxVisitorContinueKind {
+            conformedProtocolsStack.push(node.inheritedProtocolNames)
+            return .visitChildren
+        }
+
+        override func visitPost(_: ClassDeclSyntax) {
+            conformedProtocolsStack.closeScope()
+        }
+
+        override func visit(_ node: StructDeclSyntax) -> SyntaxVisitorContinueKind {
+            conformedProtocolsStack.push(node.inheritedProtocolNames)
+            return .visitChildren
+        }
+
+        override func visitPost(_: StructDeclSyntax) {
+            conformedProtocolsStack.closeScope()
+        }
+
+        override func visit(_ node: ExtensionDeclSyntax) -> SyntaxVisitorContinueKind {
+            conformedProtocolsStack.push(node.inheritedProtocolNames)
+            return .visitChildren
+        }
+
+        override func visitPost(_: ExtensionDeclSyntax) {
+            conformedProtocolsStack.closeScope()
+        }
+
         override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
             scopes.openScope(with: node.signature.effectSpecifiers?.throwsClause)
             return .visitChildren
         }
 
-        override func visitPost(_: FunctionDeclSyntax) {
+        override func visitPost(_ node: FunctionDeclSyntax) {
             if let closedScope = scopes.closeScope() {
+                guard !isThrowsRequiredByProtocolConformance(functionName: node.name.text) else {
+                    return
+                }
+
                 validate(
                     scope: closedScope,
                     construct: "body of this function"
@@ -165,6 +207,16 @@ private extension UnneededThrowsRule {
             scopes.markCurrentScopeAsThrowing()
         }
 
+        private func isThrowsRequiredByProtocolConformance(functionName: String) -> Bool {
+            for protocolName in conformedProtocolsStack.flatMap({ $0 }) {
+                if throwingProtocolRequirements[protocolName]?.contains(functionName) == true {
+                    return true
+                }
+            }
+
+            return false
+        }
+
         private func validate(scope: Scope, construct: String) {
             guard let throwsClause = scope.throwsClause else { return }
             violations.append(
@@ -180,6 +232,72 @@ private extension UnneededThrowsRule {
                 )
             )
         }
+    }
+}
+
+private enum ThrowingProtocolRequirementsCollector {
+    static func requirements(in file: SwiftLintFile) -> [String: Set<String>] {
+        ThrowingProtocolRequirementsVisitor(viewMode: .sourceAccurate)
+            .walk(tree: file.syntaxTree, handler: \.requirements)
+    }
+}
+
+private final class ThrowingProtocolRequirementsVisitor: SyntaxVisitor {
+    private(set) var requirements = [String: Set<String>]()
+
+    override func visitPost(_ node: ProtocolDeclSyntax) {
+        var throwingMethods = Set<String>()
+
+        for member in node.memberBlock.members {
+            guard let function = member.decl.as(FunctionDeclSyntax.self),
+                  function.signature.effectSpecifiers?.throwsClause != nil else {
+                continue
+            }
+
+            throwingMethods.insert(function.name.text)
+        }
+
+        if throwingMethods.isNotEmpty {
+            requirements[node.name.text] = throwingMethods
+        }
+    }
+}
+
+private extension Stack where Element == [String] {
+    mutating func closeScope() {
+        pop()
+    }
+}
+
+private extension InheritedTypeListSyntax {
+    var protocolNames: [String] {
+        compactMap { inheritedType in
+            inheritedType.type.as(IdentifierTypeSyntax.self)?.name.text
+        }
+    }
+}
+
+private extension ActorDeclSyntax {
+    var inheritedProtocolNames: [String] {
+        inheritanceClause?.inheritedTypes.protocolNames ?? []
+    }
+}
+
+private extension ClassDeclSyntax {
+    var inheritedProtocolNames: [String] {
+        inheritanceClause?.inheritedTypes.protocolNames ?? []
+    }
+}
+
+private extension StructDeclSyntax {
+    var inheritedProtocolNames: [String] {
+        inheritanceClause?.inheritedTypes.protocolNames ?? []
+    }
+}
+
+private extension ExtensionDeclSyntax {
+    var inheritedProtocolNames: [String] {
+        inheritanceClause?.inheritedTypes.protocolNames ?? []
     }
 }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnneededThrowsRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnneededThrowsRuleExamples.swift
@@ -36,6 +36,17 @@ struct UnneededThrowsRuleExamples { // swiftlint:disable:this type_body_length
             }
             """),
         Example("""
+            protocol Throwing {
+                func doSomething() throws
+            }
+
+            struct SomeType: Throwing {
+                func doSomething() throws {
+                    print("Hello")
+                }
+            }
+            """),
+        Example("""
             func foo() throws {
                 guard false else {
                     throw Example.failure


### PR DESCRIPTION
## Summary

Fixes #6437. Implementations that must declare `throws` to satisfy a protocol requirement in the same file were incorrectly flagged as unneeded.

## Changes

- Index throwing methods declared in `protocol` blocks in the file
- Track conformed protocol names on types and extensions
- Skip violations when the function name matches a throwing protocol requirement

## Test plan

- [x] `swift test --filter UnneededThrowsRuleGeneratedTests`

Made with [Cursor](https://cursor.com)