### PR TITLE
fix: redundant_nil_coalescing skip double optional lhs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@
 
 ### Bug Fixes
 
+* Fix `redundant_nil_coalescing` false positives when the left-hand side is a double
+  optional (`?? nil` is not redundant).  
+  [leno23](https://github.com/leno23)
+  [#4738](https://github.com/realm/SwiftLint/issues/4738)
+
 * Avoid false positives in `prefer_self_in_static_references` for generic
   constraints and generic parameter bounds such as `where A: P` and `<A: P>`
   in classes and extensions.  

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantNilCoalescingRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/RedundantNilCoalescingRule.swift
@@ -10,7 +10,15 @@ struct RedundantNilCoalescingRule: Rule {
         description: "Coalescing operator with right-hand side nil is redundant",
         kind: .idiomatic,
         nonTriggeringExamples: [
-            Example("var myVar: Int?; myVar ?? 0")
+            Example("var myVar: Int?; myVar ?? 0"),
+            Example("""
+            func myFirstFunc() -> String?? {
+                nil
+            }
+            func mySecondFunc() -> String? {
+                return myFirstFunc() ?? nil
+            }
+            """),
         ],
         triggeringExamples: [
             Example("var myVar: Int? = nil; myVar ↓?? nil")
@@ -26,22 +34,89 @@ struct RedundantNilCoalescingRule: Rule {
 
 private extension RedundantNilCoalescingRule {
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
+        private lazy var typeInfo = DoubleOptionalTypeInfoCollector.collect(from: file)
+
         override func visitPost(_ node: InfixOperatorExprSyntax) {
-            if node.operator.isNilCoalescingOperator, node.rightOperand.is(NilLiteralExprSyntax.self) {
-                violations.append(node.operator.positionAfterSkippingLeadingTrivia)
+            guard node.operator.isNilCoalescingOperator,
+                  node.rightOperand.is(NilLiteralExprSyntax.self),
+                  !node.leftOperand.isDoubleOptional(using: typeInfo) else {
+                return
             }
+
+            violations.append(node.operator.positionAfterSkippingLeadingTrivia)
         }
     }
 
     final class Rewriter: ViolationsSyntaxRewriter<ConfigurationType> {
+        private lazy var typeInfo = DoubleOptionalTypeInfoCollector.collect(from: file)
+
         override func visit(_ node: InfixOperatorExprSyntax) -> ExprSyntax {
             guard node.operator.isNilCoalescingOperator,
-                  node.rightOperand.is(NilLiteralExprSyntax.self) else {
+                  node.rightOperand.is(NilLiteralExprSyntax.self),
+                  !node.leftOperand.isDoubleOptional(using: typeInfo) else {
                 return super.visit(node)
             }
             numberOfCorrections += 1
             return super.visit(node.leftOperand.with(\.trailingTrivia, []))
         }
+    }
+}
+
+private struct DoubleOptionalTypeInfo {
+    var functionReturnTypes = [String: TypeSyntax]()
+    var variableTypes = [String: TypeSyntax]()
+}
+
+private enum DoubleOptionalTypeInfoCollector {
+    static func collect(from file: SwiftLintFile) -> DoubleOptionalTypeInfo {
+        DoubleOptionalTypeInfoVisitor(viewMode: .sourceAccurate)
+            .walk(tree: file.syntaxTree, handler: \.typeInfo)
+    }
+}
+
+private final class DoubleOptionalTypeInfoVisitor: SyntaxVisitor {
+    private(set) var typeInfo = DoubleOptionalTypeInfo()
+
+    override func visitPost(_ node: FunctionDeclSyntax) {
+        if let returnType = node.signature.returnClause?.type {
+            typeInfo.functionReturnTypes[node.name.text] = returnType
+        }
+    }
+
+    override func visitPost(_ node: VariableDeclSyntax) {
+        for binding in node.bindings {
+            guard let pattern = binding.pattern.as(IdentifierPatternSyntax.self),
+                  let type = binding.typeAnnotation?.type else {
+                continue
+            }
+
+            typeInfo.variableTypes[pattern.identifier.text] = type
+        }
+    }
+}
+
+private extension ExprSyntax {
+    func isDoubleOptional(using typeInfo: DoubleOptionalTypeInfo) -> Bool {
+        if let reference = `as`(DeclReferenceExprSyntax.self) {
+            return typeInfo.variableTypes[reference.baseName.text]?.isDoubleOptional == true
+        }
+
+        if let call = `as`(FunctionCallExprSyntax.self),
+           let name = call.calledExpression.as(DeclReferenceExprSyntax.self)?.baseName.text {
+            return typeInfo.functionReturnTypes[name]?.isDoubleOptional == true
+        }
+
+        return false
+    }
+}
+
+private extension TypeSyntax {
+    var isDoubleOptional: Bool {
+        guard let optionalType = `as`(OptionalTypeSyntax.self) else {
+            return false
+        }
+
+        return optionalType.wrappedType.is(OptionalTypeSyntax.self)
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #4738. `?? nil` is not redundant when the left-hand side is a double optional (e.g. `String??`), but the rule treated all `?? nil` as redundant.

## Changes

- Collect function return types and variable type annotations in the file
- Skip violations when the left-hand expression is a double optional

## Test plan

- [x] `swift test --filter RedundantNilCoalescingRuleGeneratedTests`

Made with [Cursor](https://cursor.com)