### PR TITLE
fix: vertical_parameter_alignment false positive with UTF-8 function names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@
 
 ### Bug Fixes
 
+* Fix `vertical_parameter_alignment` false positives when function names contain
+  multi-byte UTF-8 characters by comparing character columns instead of UTF-8
+  byte columns.  
+  [leno23](https://github.com/leno23)
+  [#5037](https://github.com/realm/SwiftLint/issues/5037)
+
 * Avoid false positives in `prefer_self_in_static_references` for generic
   constraints and generic parameter bounds such as `where A: P` and `<A: P>`
   in classes and extensions.  

--- a/Source/SwiftLintBuiltInRules/Rules/Style/VerticalParameterAlignmentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/VerticalParameterAlignmentRule.swift
@@ -37,15 +37,42 @@ private extension VerticalParameterAlignmentRule {
 
             guard let firstParamLoc = paramLocations.first else { return [] }
 
+            let firstParamCharacterColumn = characterColumn(
+                onLine: firstParamLoc.line,
+                utf8Column: firstParamLoc.column
+            )
+
             var violations: [AbsolutePosition] = []
             for (index, paramLoc) in paramLocations.enumerated() where index > 0 && paramLoc.line > firstParamLoc.line {
                 let previousParamLoc = paramLocations[index - 1]
-                if previousParamLoc.line < paramLoc.line, firstParamLoc.column != paramLoc.column {
+                let paramCharacterColumn = characterColumn(onLine: paramLoc.line, utf8Column: paramLoc.column)
+                if previousParamLoc.line < paramLoc.line,
+                   firstParamCharacterColumn != paramCharacterColumn {
                     violations.append(paramLoc.position)
                 }
             }
 
             return violations
+        }
+
+        private func characterColumn(onLine lineNumber: Int, utf8Column: Int) -> Int {
+            let line = locationConverter.sourceLines[lineNumber - 1]
+            guard utf8Column > 0 else { return 0 }
+
+            let utf8Offset = utf8Column - 1
+            var byteCount = 0
+            var characterCount = 0
+
+            for character in line {
+                let characterUtf8Length = character.utf8.count
+                if byteCount + characterUtf8Length > utf8Offset {
+                    return characterCount
+                }
+                byteCount += characterUtf8Length
+                characterCount += 1
+            }
+
+            return characterCount
         }
     }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/VerticalParameterAlignmentRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/VerticalParameterAlignmentRuleExamples.swift
@@ -60,6 +60,15 @@ internal struct VerticalParameterAlignmentRuleExamples {
                  bar: String)
         }
         """),
+        // Regression: Cyrillic function name must not affect UTF-8 vs display column alignment (#5037).
+        Example("""
+        func сheckprofileexistence(_ param: Bool,
+                                   param1: Bool,
+                                   param2: Bool,
+                                   param3: Bool) -> Bool {
+            false
+        }
+        """),
     ]
 
     static let triggeringExamples: [Example] = [


### PR DESCRIPTION
## Summary

- Compare parameter alignment using Swift **character** columns instead of UTF-8 byte columns from `Location`.
- Fixes false positives when the function name contains multi-byte characters (e.g. Cyrillic `с` in `сheckprofileexistence`).

## Test plan

- [x] `swift test --filter VerticalParameterAlignmentRuleGeneratedTests`
- [x] Added non-triggering regression example from #5037

Fixes #5037

Made with [Cursor](https://cursor.com)