### PR TITLE
fix: unused_declaration skip property wrapper projectedValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@
 
 ### Bug Fixes
 
+* Fix `unused_declaration` false positives for `projectedValue` and `wrappedValue` in
+  `@propertyWrapper` types.  
+  [leno23](https://github.com/leno23)
+  [#3237](https://github.com/realm/SwiftLint/issues/3237)
+
 * Avoid false positives in `prefer_self_in_static_references` for generic
   constraints and generic parameter bounds such as `where A: P` and `<A: P>`
   in classes and extensions.  

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedDeclarationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedDeclarationRule.swift
@@ -110,13 +110,19 @@ private extension SwiftLintFile {
                       editorOpen: SourceKittenDictionary,
                       compilerArguments: [String],
                       configuration: UnusedDeclarationConfiguration) -> Set<UnusedDeclarationRule.DeclaredUSR> {
-        Set(index.traverseEntitiesDepthFirst { _, indexEntity in
-            self.declaredUSR(indexEntity: indexEntity, editorOpen: editorOpen, compilerArguments: compilerArguments,
-                             configuration: configuration)
+        Set(index.traverseEntitiesDepthFirst { parentEntity, indexEntity in
+            self.declaredUSR(
+                indexEntity: indexEntity,
+                parentEntity: parentEntity,
+                editorOpen: editorOpen,
+                compilerArguments: compilerArguments,
+                configuration: configuration
+            )
         })
     }
 
     func declaredUSR(indexEntity: SourceKittenDictionary,
+                     parentEntity: SourceKittenDictionary,
                      editorOpen: SourceKittenDictionary,
                      compilerArguments: [String],
                      configuration: UnusedDeclarationConfiguration) -> UnusedDeclarationRule.DeclaredUSR? {
@@ -146,7 +152,11 @@ private extension SwiftLintFile {
             return nil
         }
 
-        if shouldIgnoreEntity(indexEntity, relatedUSRsToSkip: configuration.relatedUSRsToSkip) {
+        if shouldIgnoreEntity(
+            indexEntity,
+            parentEntity: parentEntity,
+            relatedUSRsToSkip: configuration.relatedUSRsToSkip
+        ) {
             return nil
         }
 
@@ -208,7 +218,13 @@ private extension SwiftLintFile {
         return (try? request.sendIfNotDisabled()).map(SourceKittenDictionary.init)
     }
 
-    private func shouldIgnoreEntity(_ indexEntity: SourceKittenDictionary, relatedUSRsToSkip: Set<String>) -> Bool {
+    private func shouldIgnoreEntity(_ indexEntity: SourceKittenDictionary,
+                                    parentEntity: SourceKittenDictionary,
+                                    relatedUSRsToSkip: Set<String>) -> Bool {
+        if indexEntity.shouldSkipPropertyWrapperMember(in: parentEntity) {
+            return true
+        }
+
         let declarationAttributesToSkip: Set<SwiftDeclarationAttributeKind> = [
             .ibsegueaction,
             .ibaction,
@@ -326,6 +342,23 @@ private extension SourceKittenDictionary {
         ]
 
         return resultBuilderStaticMethods.contains(name)
+    }
+
+    func shouldSkipPropertyWrapperMember(in parentEntity: SourceKittenDictionary) -> Bool {
+        guard let name, name == "projectedValue" || name == "wrappedValue" else {
+            return false
+        }
+
+        return parentEntity.hasPropertyWrapperAttribute
+    }
+
+    var hasPropertyWrapperAttribute: Bool {
+        swiftAttributes.contains { attributeEntity in
+            guard let attribute = attributeEntity.attribute else {
+                return false
+            }
+            return attribute.lowercased().contains("propertywrapper")
+        }
     }
 
     func extends(reference other: Self) -> Bool {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedDeclarationRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedDeclarationRuleExamples.swift
@@ -80,6 +80,17 @@ struct UnusedDeclarationRuleExamples {
             S().f()
         """),
         Example("""
+        @propertyWrapper
+        final class LockedWhenRead<Value: Equatable> {
+            var projectedValue: LockedWhenRead<Value> { self }
+
+            var wrappedValue: Value {
+                get { fatalError() }
+                set { fatalError() }
+            }
+        }
+        """),
+        Example("""
         enum Component {
           case string(StaticString)
           indirect case array([Component])


### PR DESCRIPTION
## Summary

- Skip `projectedValue` and `wrappedValue` declarations when the parent type has a `@propertyWrapper` attribute.
- These members are used by the compiler for wrapper synthesis and are often not directly referenced in source.

## Test plan

- [x] `swift build --product swiftlint`
- [x] Added non-triggering example from #3237

Fixes #3237

Made with [Cursor](https://cursor.com)