### PR TITLE
fix: unused_declaration skip _modify accessors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@
 
 ### Bug Fixes
 
+* Fix `unused_declaration` false positives for `_modify` subscript accessors.  
+  [leno23](https://github.com/leno23)
+  [#5094](https://github.com/realm/SwiftLint/issues/5094)
+
 * Avoid false positives in `prefer_self_in_static_references` for generic
   constraints and generic parameter bounds such as `where A: P` and `<A: P>`
   in classes and extensions.  

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedDeclarationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedDeclarationRule.swift
@@ -134,6 +134,10 @@ private extension SwiftLintFile {
             .genericTypeParam,
         ]
 
+        if indexEntity.name == "_modify" {
+            return nil
+        }
+
         guard let stringKind = indexEntity.kind,
               stringKind.starts(with: "source.lang.swift.decl."),
               !stringKind.contains(".accessor."),

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedDeclarationRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedDeclarationRuleExamples.swift
@@ -80,7 +80,7 @@ struct UnusedDeclarationRuleExamples {
             S().f()
         """),
         Example("""
-        struct Box<T> {
+        struct Box {
             private var _data: [String: Any] = [:]
 
             subscript<T: Hashable>(key: String) -> T {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedDeclarationRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedDeclarationRuleExamples.swift
@@ -80,21 +80,6 @@ struct UnusedDeclarationRuleExamples {
             S().f()
         """),
         Example("""
-        struct Box {
-            private var _data: [String: Any] = [:]
-
-            subscript<T: Hashable>(key: String) -> T {
-                get { _data[key] as! T }
-                set { _data[key] = newValue }
-                _modify {
-                    var value = _data[key] as! T
-                    defer { _data[key] = value }
-                    yield &value
-                }
-            }
-        }
-        """),
-        Example("""
         enum Component {
           case string(StaticString)
           indirect case array([Component])

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedDeclarationRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedDeclarationRuleExamples.swift
@@ -80,6 +80,21 @@ struct UnusedDeclarationRuleExamples {
             S().f()
         """),
         Example("""
+        struct Box<T> {
+            private var _data: [String: Any] = [:]
+
+            subscript<T: Hashable>(key: String) -> T {
+                get { _data[key] as! T }
+                set { _data[key] = newValue }
+                _modify {
+                    var value = _data[key] as! T
+                    defer { _data[key] = value }
+                    yield &value
+                }
+            }
+        }
+        """),
+        Example("""
         enum Component {
           case string(StaticString)
           indirect case array([Component])


### PR DESCRIPTION
## Summary

- Skip index entities named `_modify` in `unused_declaration` since they are compiler-synthesized accessor bodies like `get`/`set`.

## Test plan

- [x] Added non-triggering example with subscript `_modify` block from #5094

Fixes #5094

Made with [Cursor](https://cursor.com)