### PR TITLE
fix: unused_declaration skip cross-file protocol witnesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@
 
 ### Bug Fixes
 
+* Fix `unused_declaration` false positives for protocol requirements implemented in
+  extensions when conformance is declared in another file.  
+  [leno23](https://github.com/leno23)
+  [#3763](https://github.com/realm/SwiftLint/issues/3763)
+
 * Avoid false positives in `prefer_self_in_static_references` for generic
   constraints and generic parameter bounds such as `where A: P` and `<A: P>`
   in classes and extensions.  

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedDeclarationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedDeclarationRule.swift
@@ -194,8 +194,14 @@ private extension SwiftLintFile {
         // with "related names", which appears to be similarly named declarations (i.e. overloads) that are
         // programmatically unrelated to the current cursor-info declaration. Those similarly named declarations
         // aren't in `key.related` so confirm that that one is also populated.
-        if cursorInfo?.value["key.related_decls"] != nil, indexEntity.value["key.related"] != nil {
-            return nil
+        if cursorInfo?.value["key.related_decls"] != nil {
+            if indexEntity.value["key.related"] != nil {
+                return nil
+            }
+            if SwiftDeclarationKind.functionKinds.contains(kind),
+               cursorInfo?.satisfiesProtocolRequirementWitness == true {
+                return nil
+            }
         }
 
         return .init(usr: usr, nameOffset: nameOffset)
@@ -326,6 +332,22 @@ private extension SourceKittenDictionary {
         ]
 
         return resultBuilderStaticMethods.contains(name)
+    }
+
+    var satisfiesProtocolRequirementWitness: Bool {
+        guard let relatedDecls = value["key.related_decls"] as? [[String: any SourceKitRepresentable]] else {
+            return false
+        }
+        return relatedDecls.contains { relatedEntity in
+            let entity = SourceKittenDictionary(relatedEntity)
+            if entity.typeName?.hasSuffix("Protocol") == true {
+                return true
+            }
+            if let kind = entity.kind, kind.contains("protocol") {
+                return true
+            }
+            return false
+        }
     }
 
     func extends(reference other: Self) -> Bool {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedDeclarationRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedDeclarationRuleExamples.swift
@@ -80,6 +80,20 @@ struct UnusedDeclarationRuleExamples {
             S().f()
         """),
         Example("""
+        protocol SomethingProtocol {
+            func someFunction1()
+            func someFunction3()
+        }
+
+        final class Something: SomethingProtocol {
+            func someFunction1() {}
+        }
+
+        extension Something {
+            func someFunction3() {}
+        }
+        """),
+        Example("""
         enum Component {
           case string(StaticString)
           indirect case array([Component])


### PR DESCRIPTION
## Summary

- When `key.related_decls` references a protocol requirement (`*Protocol` type name or protocol declaration kind), do not report the implementing function as unused.
- Fixes false positives for protocol methods implemented in extensions in a different file than the conformance.

## Test plan

- [x] `swift build --product swiftlint`
- [x] Non-triggering example modeled on #3763 (`Something` / `SomethingProtocol`)

Fixes #3763

Made with [Cursor](https://cursor.com)