### PR TITLE
Fix unused_setter_value false positives for empty setter bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@
 
 ### Bug Fixes
 
+* Fix `unused_setter_value` false positives for empty setter bodies, including
+  `set() { }` and protocol witness implementations with `set { }`.  
+  [leno23](https://github.com/leno23)
+  [#3863](https://github.com/realm/SwiftLint/issues/3863)
+
 * Avoid false positives in `prefer_self_in_static_references` for generic
   constraints and generic parameter bounds such as `where A: P` and `<A: P>`
   in classes and extensions.  

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedSetterValueRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedSetterValueRule.swift
@@ -62,6 +62,18 @@ struct UnusedSetterValueRule: Rule {
                 set {}
             }
             """, excludeFromDocumentation: true),
+            Example("""
+            private var abc: Int {
+                get { 123 }
+                set() { }
+            }
+            """),
+            Example("""
+            var aPointPosition: TimeInterval? {
+                get { nil }
+                set { }
+            }
+            """),
         ],
         triggeringExamples: [
             Example("""
@@ -140,12 +152,9 @@ private extension UnusedSetterValueRule {
 
             let variableName = node.parameters?.name.text ?? "newValue"
             let visitor = NewValueUsageVisitor(variableName: variableName)
-            if !visitor.walk(tree: node, handler: \.isVariableUsed) {
-                if Syntax(node).closestVariableOrSubscript()?.modifiers?.contains(keyword: .override) == true,
-                   let body = node.body, body.statements.isEmpty {
-                    return
-                }
-
+            if !visitor.walk(tree: node, handler: \.isVariableUsed),
+               let body = node.body,
+               !body.statements.isEmpty {
                 violations.append(node.positionAfterSkippingLeadingTrivia)
             }
         }


### PR DESCRIPTION
## Summary

- Skip `unused_setter_value` when the setter accessor body has no statements (e.g. `set { }`, `set() { }`, `set {}`).
- Covers protocol witness stubs and other intentional empty setters discussed in #3863.

## Test plan

- [x] `swift test --filter UnusedSetterValueRuleGeneratedTests`
- [x] Manual lint on issue reproducers (`set() { }`, `set { }` with empty body)

Fixes #3863

Made with [Cursor](https://cursor.com)