### PR TITLE
Fix duplicated_key false positives for computed property keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@
 
 ### Bug Fixes
 
+* Fix `duplicated_key_in_dictionary_literal` false positives when dictionary keys use a
+  computed property that returns a different value on each access.  
+  [leno23](https://github.com/leno23)
+  [#5077](https://github.com/realm/SwiftLint/issues/5077)
+
 * Avoid false positives in `prefer_self_in_static_references` for generic
   constraints and generic parameter bounds such as `where A: P` and `<A: P>`
   in classes and extensions.  

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/DuplicatedKeyInDictionaryLiteralRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/DuplicatedKeyInDictionaryLiteralRule.swift
@@ -40,6 +40,20 @@ struct DuplicatedKeyInDictionaryLiteralRule: Rule {
                     #line: "2"
                 ]
                 """),
+            Example("""
+                var currentValue = 0
+                var generateNewValue: Int {
+                    let current = currentValue
+                    currentValue += 1
+                    return current
+                }
+
+                let testDict = [
+                    generateNewValue: "",
+                    generateNewValue: "",
+                    generateNewValue: "",
+                ]
+                """),
         ],
         triggeringExamples: [
             Example("""
@@ -81,9 +95,27 @@ struct DuplicatedKeyInDictionaryLiteralRule: Rule {
 
 private extension DuplicatedKeyInDictionaryLiteralRule {
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
+        private var computedPropertyNames = Set<String>()
+
+        override func visitPost(_ node: VariableDeclSyntax) {
+            for binding in node.bindings {
+                guard binding.accessorBlock != nil,
+                      let pattern = binding.pattern.as(IdentifierPatternSyntax.self) else {
+                    continue
+                }
+
+                computedPropertyNames.insert(pattern.identifier.text)
+            }
+        }
+
         override func visitPost(_ list: DictionaryElementListSyntax) {
             let keys = list.map(\.key).compactMap { expr -> DictionaryKey? in
-                expr.stringContent.map {
+                if let identifier = expr.as(DeclReferenceExprSyntax.self),
+                   computedPropertyNames.contains(identifier.baseName.text) {
+                    return nil
+                }
+
+                return expr.stringContent.map {
                     DictionaryKey(position: expr.positionAfterSkippingLeadingTrivia, content: $0)
                 }
             }


### PR DESCRIPTION
## Summary

- Skip duplicate-key detection when a dictionary literal key references a computed property, since each access can produce a different value at runtime.
- Add a regression example from #5077.

## Test plan

- [x] `swift test --filter DuplicatedKeyInDictionaryLiteralRuleGeneratedTests`
- [x] `swift build --product swiftlint`

Fixes #5077

Made with [Cursor](https://cursor.com)