### PR TITLE
fix: void_function_in_ternary skip switch/if expression branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,21 @@
 
 ### Bug Fixes
 
+* Fix `overridden_super_call` false positives when `super` is called once per mutually
+  exclusive branch (e.g. in an `if` completion handler and in the `else` branch).  
+  [leno23](https://github.com/leno23)
+  [#5655](https://github.com/realm/SwiftLint/issues/5655)
+
+* Fix `void_function_in_ternary` false positives in `switch` and `if` expression branches that
+  implicitly return non-Void values.  
+  [leno23](https://github.com/leno23)
+  [#5611](https://github.com/realm/SwiftLint/issues/5611)
+
+* Fix `unused_setter_value` false positives for empty setter bodies, including
+  `set() { }` and protocol witness implementations with `set { }`.  
+  [leno23](https://github.com/leno23)
+  [#3863](https://github.com/realm/SwiftLint/issues/3863)
+
 * Avoid false positives in `prefer_self_in_static_references` for generic
   constraints and generic parameter bounds such as `where A: P` and `<A: P>`
   in classes and extensions.  

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/VoidFunctionInTernaryConditionRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/VoidFunctionInTernaryConditionRule.swift
@@ -60,6 +60,23 @@ struct VoidFunctionInTernaryConditionRule: Rule {
                 index == 0 ? defaultValue() : compute(index)
             """),
             Example("""
+            func size(isEditing: Bool, section: Int) -> CGSize {
+                switch section {
+                case 0: isEditing ? CGSize(width: 150, height: 20) : CGSize(width: 100, height: 20)
+                default: .zero
+                }
+            }
+            """),
+            Example("""
+            func size(isEditing: Bool, section: Int) -> CGSize {
+                if section == 0 {
+                    isEditing ? CGSize(width: 150, height: 20) : CGSize(width: 100, height: 20)
+                } else {
+                    .zero
+                }
+            }
+            """),
+            Example("""
             var a = b ? c() : d()
             a += b ? c() : d()
             a -= b ? c() : d()
@@ -184,7 +201,35 @@ private extension CodeBlockItemSyntax {
     var isImplicitReturn: Bool {
         isClosureImplicitReturn || isFunctionImplicitReturn ||
         isVariableImplicitReturn || isSubscriptImplicitReturn ||
-        isAccessorImplicitReturn
+        isAccessorImplicitReturn || isIfExprBranchImplicitReturn || isSwitchCaseImplicitReturn
+    }
+
+    var isIfExprBranchImplicitReturn: Bool {
+        guard let itemList = parent?.as(CodeBlockItemListSyntax.self),
+              itemList.children(viewMode: .sourceAccurate).count == 1,
+              let codeBlock = itemList.parent?.as(CodeBlockSyntax.self),
+              let ifExpr = codeBlock.parent?.as(IfExprSyntax.self) else {
+            return false
+        }
+
+        if ifExpr.body == codeBlock {
+            return true
+        }
+        if case let .codeBlock(elseBody) = ifExpr.elseBody, elseBody == codeBlock {
+            return true
+        }
+        return false
+    }
+
+    var isSwitchCaseImplicitReturn: Bool {
+        guard let itemList = parent?.as(CodeBlockItemListSyntax.self),
+              itemList.children(viewMode: .sourceAccurate).count == 1,
+              let switchCase = itemList.parent?.as(SwitchCaseSyntax.self),
+              switchCase.statements == itemList,
+              switchCase.parent?.parent?.is(SwitchExprSyntax.self) == true else {
+            return false
+        }
+        return true
     }
 
     var isClosureImplicitReturn: Bool {


### PR DESCRIPTION
## Summary

- Skip `void_function_in_ternary` when a ternary appears in a `switch` or `if` expression branch that implicitly returns a value
- Fixes false positives for ternaries returning types like `CGSize` in collection view layout methods

Fixes #5611

## Test plan

- [x] `swift test --filter VoidFunctionInTernaryConditionRuleGeneratedTests`

Made with [Cursor](https://cursor.com)