### PR TITLE
fix: unused_parameter recognize binding closure parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,26 @@
 
 ### Bug Fixes
 
+* Fix `overridden_super_call` false positives when `super` is called once per mutually
+  exclusive branch (e.g. in an `if` completion handler and in the `else` branch).  
+  [leno23](https://github.com/leno23)
+  [#5655](https://github.com/realm/SwiftLint/issues/5655)
+
+* Fix `void_function_in_ternary` false positives in `switch` and `if` expression branches that
+  implicitly return non-Void values.  
+  [leno23](https://github.com/leno23)
+  [#5611](https://github.com/realm/SwiftLint/issues/5611)
+
+* Fix `unused_parameter` false positives for `$`-prefixed closure binding parameters when the
+  projected name is used (e.g. `$historyItem` with `historyItem.url`).  
+  [leno23](https://github.com/leno23)
+  [#5740](https://github.com/realm/SwiftLint/issues/5740)
+
+* Fix `unused_setter_value` false positives for empty setter bodies, including
+  `set() { }` and protocol witness implementations with `set { }`.  
+  [leno23](https://github.com/leno23)
+  [#3863](https://github.com/realm/SwiftLint/issues/3863)
+
 * Avoid false positives in `prefer_self_in_static_references` for generic
   constraints and generic parameter bounds such as `where A: P` and `<A: P>`
   in classes and extensions.  

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedParameterRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedParameterRule.swift
@@ -67,6 +67,13 @@ struct UnusedParameterRule: Rule {
             Example("""
             func f(_a: Int) {}
             """, configuration: allowUnderscorePrefixedNames),
+            Example("""
+            func f(_ history: [Item]) {
+                List($history) { $historyItem in
+                    Foo(url: historyItem.url)
+                }
+            }
+            """),
         ],
         triggeringExamples: [
             Example("""
@@ -184,8 +191,14 @@ private extension UnusedParameterRule {
         // MARK: Reference collection
 
         override func visitPost(_ node: DeclReferenceExprSyntax) {
-            if node.keyPathInParent != \MemberAccessExprSyntax.declName {
-                addReference(node.baseName.text)
+            guard node.keyPathInParent != \MemberAccessExprSyntax.declName else {
+                return
+            }
+
+            let name = node.baseName.text
+            addReference(name)
+            if name.hasPrefix("$"), name.count > 1 {
+                addReference(String(name.dropFirst()))
             }
         }
 

--- a/Source/SwiftLintCore/Visitors/DeclaredIdentifiersTrackingVisitor.swift
+++ b/Source/SwiftLintCore/Visitors/DeclaredIdentifiersTrackingVisitor.swift
@@ -41,9 +41,27 @@ public enum IdentifierDeclaration: Hashable {
         }
         if disregardBackticks {
             let backticks = CharacterSet(charactersIn: "`")
-            return id.trimmingCharacters(in: backticks) == name.trimmingCharacters(in: backticks)
+            let normalizedId = id.trimmingCharacters(in: backticks)
+            let normalizedName = name.trimmingCharacters(in: backticks)
+            if normalizedId == normalizedName {
+                return true
+            }
+            if case .parameter = self,
+               normalizedName.hasPrefix("$"),
+               normalizedId == String(normalizedName.dropFirst()) {
+                return true
+            }
+            return false
         }
-        return id == name
+        if id == name {
+            return true
+        }
+        if case .parameter = self,
+           name.hasPrefix("$"),
+           id == String(name.dropFirst()) {
+            return true
+        }
+        return false
     }
 }
 


### PR DESCRIPTION
## Summary

- Treat `$foo` references as uses of parameter `foo`
- Treat projected `foo` references as uses of `$foo` closure binding parameters

Fixes #5740

## Test plan

- [x] Rule generated tests

Made with [Cursor](https://cursor.com)