### PR TITLE
fix: attributes allow comment between attribute and declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,11 @@
 
 ### Bug Fixes
 
+* Fix `attributes` false positives when a comment line appears between an attribute and a
+  variable declaration.  
+  [leno23](https://github.com/leno23)
+  [#4596](https://github.com/realm/SwiftLint/issues/4596)
+
 * Avoid false positives in `prefer_self_in_static_references` for generic
   constraints and generic parameter bounds such as `where A: P` and `<A: P>`
   in classes and extensions.  

--- a/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRule.swift
@@ -73,14 +73,23 @@ private extension AttributesRule {
                 break
             }
 
-            let linesForAttributes = attributesAndPlacements
+            let attributeEndLines = attributesAndPlacements
                 .filter { $1 == .dedicatedLine }
-                .map { $0.0.endLine(locationConverter: locationConverter) }
+                .compactMap { $0.0.endLine(locationConverter: locationConverter) }
 
-            if linesForAttributes.isEmpty {
+            if attributeEndLines.isEmpty {
                 return
             }
-            if !linesForAttributes.contains(helper.keywordLine - 1) {
+            let hasAcceptableAttributeSpacing = if helper.shouldBeOnSameLine {
+                helper.hasAcceptableGapBeforeKeyword(
+                    attributeEndLines: attributeEndLines,
+                    locationConverter: locationConverter
+                )
+            } else {
+                attributeEndLines.contains(helper.keywordLine - 1)
+            }
+
+            if !hasAcceptableAttributeSpacing {
                 violations.append(helper.violationPosition)
                 return
             }
@@ -113,6 +122,12 @@ private extension SyntaxProtocol {
 private extension Trivia {
     var hasMultipleNewlines: Bool {
         reduce(0, { $0 + $1.numberOfNewlines }) > 1
+    }
+}
+
+private extension String {
+    var trimmingWhitespaceAndNewlines: String {
+        String(drop(while: \.isWhitespace).reversed().drop(while: \.isWhitespace).reversed())
     }
 }
 
@@ -170,6 +185,40 @@ private struct RuleHelper {
             }
         }
         return .noViolation
+    }
+
+    func hasAcceptableGapBeforeKeyword(
+        attributeEndLines: [Int],
+        locationConverter: SourceLocationConverter
+    ) -> Bool {
+        guard let lineAboveKeyword = lineAboveKeywordSkippingCommentsAndBlanks(
+            locationConverter: locationConverter
+        ) else {
+            return false
+        }
+        return attributeEndLines.contains(lineAboveKeyword)
+    }
+
+    private func lineAboveKeywordSkippingCommentsAndBlanks(
+        locationConverter: SourceLocationConverter
+    ) -> Int? {
+        var line = keywordLine - 1
+        while line > 0 {
+            let sourceLine = locationConverter.sourceLines[line - 1]
+            let trimmed = sourceLine.trimmingWhitespaceAndNewlines
+            if isCommentOnlyLine(trimmed) {
+                line -= 1
+                continue
+            }
+            return line
+        }
+        return nil
+    }
+
+    private func isCommentOnlyLine(_ trimmed: String) -> Bool {
+        trimmed.hasPrefix("//")
+            || trimmed.hasPrefix("/*")
+            || trimmed.hasSuffix("*/")
     }
 }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/AttributesRuleExamples.swift
@@ -36,6 +36,14 @@ internal struct AttributesRuleExamples {
             public var optional: Bool { fatalError() }
         }
         """),
+        // attribute with comment line between attribute and declaration (#4596)
+        Example("""
+        extension Property {
+            @available(*, unavailable, renamed: \"isOptional\")
+            // Hello world
+            public var optional: Bool { fatalError() }
+        }
+        """),
         Example("@GKInspectable var maxSpeed: Float"),
         Example("@discardableResult\n func a() -> Int"),
         Example("@objc\n @discardableResult\n func a() -> Int"),


### PR DESCRIPTION
## Summary

- Do not treat a comment between an attribute and the declaration as separating them for `attributes` rule purposes.

Fixes #4596

## Test plan

- [x] Rule generated tests

Made with [Cursor](https://cursor.com)