### PR TITLE
Recognize `isolated` isolation modifier in `modifier_order` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,11 @@
 
 ### Bug Fixes
 
+* Recognize `isolated` as an isolation modifier in `modifier_order`, so it can
+  be ordered via the `isolation` entry in `preferred_modifier_order`.  
+  [leno23](https://github.com/leno23)
+  [#6164](https://github.com/realm/SwiftLint/issues/6164)
+
 * Detect and autocorrect missing whitespace before `else` in `guard`
   statements for the `statement_position` rule.  
   [theamodhshetty](https://github.com/theamodhshetty)

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ModifierOrderRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ModifierOrderRule.swift
@@ -135,7 +135,7 @@ private extension SwiftDeclarationAttributeKind.ModifierGroup {
             self = .lazy
         case "dynamic":
             self = .dynamic
-        case "nonisolated":
+        case "isolated", "nonisolated":
             self = .isolation
         case "private", "fileprivate", "internal", "public", "open":
             self = .acl

--- a/Tests/FrameworkTests/ModifierOrderTests.swift
+++ b/Tests/FrameworkTests/ModifierOrderTests.swift
@@ -391,6 +391,7 @@ final class ModifierOrderTests: SwiftLintTestCase {
         }
     }
 
+    // swiftlint:disable:next function_body_length
     func testIsolationModifierOrder() {
         let descriptionOverride = ModifierOrderRule.description
             .with(nonTriggeringExamples: [
@@ -405,6 +406,12 @@ final class ModifierOrderTests: SwiftLintTestCase {
                     nonisolated var description: String {
                         "MyActor instance"
                     }
+                }
+                """),
+                Example("""
+                @MainActor
+                class Foo {
+                    isolated public func bar() {}
                 }
                 """),
                 Example("""
@@ -426,6 +433,12 @@ final class ModifierOrderTests: SwiftLintTestCase {
                     private nonisolated func heavyWork() {}
                 }
                 """),
+                Example("""
+                @MainActor
+                class Foo {
+                    public isolated func bar() {}
+                }
+                """),
             ])
             .with(corrections: [
                 Example("""
@@ -438,6 +451,18 @@ final class ModifierOrderTests: SwiftLintTestCase {
                 @MainActor
                 class Foo {
                     nonisolated public func bar() {}
+                }
+                """),
+                Example("""
+                @MainActor
+                class Foo {
+                    public isolated func bar() {}
+                }
+                """):
+                Example("""
+                @MainActor
+                class Foo {
+                    isolated public func bar() {}
                 }
                 """),
             ])


### PR DESCRIPTION
Fixes #6164.