### PR TITLE
Ignore macro declarations with function setting in `line_length`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,11 @@
   [systemBlue](https://github.com/systemblueio)
   [#5037](https://github.com/realm/SwiftLint/issues/5037)
 
+* Treat macro declarations like function declarations for `line_length` when
+  `ignores_function_declarations` is enabled.  
+  [leno23](https://github.com/leno23)
+  [#5648](https://github.com/realm/SwiftLint/issues/5648)
+
 * Avoid false positives in `prefer_self_in_static_references` for generic
   constraints and generic parameter bounds such as `where A: P` and `<A: P>`
   in classes and extensions.  

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/LineLengthRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/LineLengthRule.swift
@@ -35,7 +35,7 @@ private extension LineLengthRule {
         private var regexLiteralLines = Set<Int>()
 
         override func visit(_ node: SourceFileSyntax) -> SyntaxVisitorContinueKind {
-            // Populate functionDeclarationLines if ignores_function_declarations is true
+            // Populate declaration lines for functions and macros when ignoring function declarations
             if configuration.ignoresFunctionDeclarations {
                 let funcVisitor = FunctionLineVisitor(locationConverter: locationConverter)
                 functionDeclarationLines = funcVisitor.walk(tree: node, handler: \.lines)
@@ -147,7 +147,7 @@ private extension LineLengthRule {
 
 // MARK: - Helper Visitors for Pre-computation
 
-// Visitor to find lines spanned by function declaration signatures
+// Visitor to find lines spanned by function and macro declaration signatures
 private final class FunctionLineVisitor: SyntaxVisitor {
     let locationConverter: SourceLocationConverter
     var lines = Set<Int>()
@@ -178,6 +178,13 @@ private final class FunctionLineVisitor: SyntaxVisitor {
             from: node.positionAfterSkippingLeadingTrivia,
             to: node.genericWhereClause?.endPositionBeforeTrailingTrivia
                 ?? node.returnClause.endPositionBeforeTrailingTrivia
+        )
+    }
+
+    override func visitPost(_ node: MacroDeclSyntax) {
+        collectLines(
+            from: node.positionAfterSkippingLeadingTrivia,
+            to: node.endPositionBeforeTrailingTrivia
         )
     }
 

--- a/Tests/BuiltInRulesTests/LineLengthRuleTests.swift
+++ b/Tests/BuiltInRulesTests/LineLengthRuleTests.swift
@@ -60,6 +60,14 @@ final class LineLengthRuleTests: SwiftLintTestCase {
             """),
     ]
 
+    private let longMacroDeclarations = [
+        Example("""
+            @freestanding(expression)
+            public macro obfuscate(_ value: String) -> String \
+            = #externalMacro(module: \"ObfuscatedStringMacros\", type: \"ObfuscationMacro\")
+            """),
+    ]
+
     private let longComment = Example(String(repeating: "/", count: 121) + "\n")
     private let longBlockComment = Example("/*" + String(repeating: " ", count: 121) + "*/\n")
     private let longRealBlockComment = Example("""
@@ -133,7 +141,10 @@ final class LineLengthRuleTests: SwiftLintTestCase {
     func testLineLengthWithIgnoreFunctionDeclarationsEnabled() {
         let baseDescription = LineLengthRule.description
         let description = baseDescription.with(
-            nonTriggeringExamples: baseDescription.nonTriggeringExamples + longFunctionDeclarations,
+            nonTriggeringExamples:
+                baseDescription.nonTriggeringExamples +
+                longFunctionDeclarations +
+                longMacroDeclarations,
             triggeringExamples: longFunctionCalls
         )
 
@@ -147,14 +158,19 @@ final class LineLengthRuleTests: SwiftLintTestCase {
 
     func testLineLengthWithIgnoreCommentsEnabled() {
         let baseDescription = LineLengthRule.description
-        let triggeringExamples = longFunctionDeclarations + [declarationWithTrailingLongComment]
+        let triggeringExamples = longFunctionDeclarations + [declarationWithTrailingLongComment] + longMacroDeclarations
         let nonTriggeringExamples = [longComment, longBlockComment, longRealBlockComment]
 
         let description = baseDescription.with(nonTriggeringExamples: nonTriggeringExamples)
                                          .with(triggeringExamples: triggeringExamples)
 
-        verifyRule(description, ruleConfiguration: ["ignores_comments": true],
-                   commentDoesntViolate: false, stringDoesntViolate: false, skipCommentTests: true)
+        verifyRule(
+            description,
+            ruleConfiguration: ["ignores_comments": true],
+            commentDoesntViolate: false,
+            stringDoesntViolate: false,
+            skipCommentTests: true
+        )
     }
 
     func testLineLengthWithIgnoreURLsEnabled() {


### PR DESCRIPTION
Fixes #5648.