### PR TITLE
Fix `literal_expression_end_indentation` correction deleting code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,14 @@
 
 ### Bug Fixes
 
+* Fix `literal_expression_end_indentation` autocorrection deleting source code
+  when the closing bracket of a multiline literal shares a line with the end of
+  a multiline last element (e.g. `...))]`). The corrector assumed everything
+  before the bracket on that line was indentation and replaced it; it now moves
+  only the bracket to its own line at the expected indentation.  
+  [Luan Câmara](https://github.com/luancamara)
+  [#2823](https://github.com/realm/SwiftLint/issues/2823)
+
 * Don't rewrite the type operand of an `is` / `as?` / `as!` cast (such as
   `x is A`) to `Self` in `prefer_self_in_static_references` when inside a
   class-like scope. `Self` is the dynamic type, so the rewrite silently changed

--- a/Source/SwiftLintBuiltInRules/Rules/Style/LiteralExpressionEndIndentationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/LiteralExpressionEndIndentationRule.swift
@@ -69,6 +69,12 @@ struct LiteralExpressionEndIndentationRule: Rule, OptInRule {
                key: value
                ↓]
             """),
+            Example("""
+            let x = [
+               foo(
+                  1,
+                  2)↓]
+            """),
         ],
         corrections: [
             Example("""
@@ -117,6 +123,18 @@ struct LiteralExpressionEndIndentationRule: Rule, OptInRule {
             ] + [
                3,
                4
+            ]
+            """),
+            Example("""
+            let x = [
+               foo(
+                  1,
+                  2)↓]
+            """): Example("""
+            let x = [
+               foo(
+                  1,
+                  2)
             ]
             """),
         ]
@@ -176,7 +194,11 @@ extension LiteralExpressionEndIndentationRule: CorrectableRule {
         }
 
         let correction = contents.substring(from: expected.location, length: expected.length)
-        contents = contents.replacingCharacters(in: actualIndices, with: correction)
+        if contents[actualIndices].allSatisfy(\.isWhitespace) {
+            contents = contents.replacingCharacters(in: actualIndices, with: correction)
+        } else {
+            contents.insert(contentsOf: "\n" + correction, at: actualIndices.upperBound)
+        }
 
         return true
     }


### PR DESCRIPTION
Fixes #2823.

(The fix targets the rule's corrector; detection behavior is unchanged.)

## Bug

When the closing bracket of a multiline literal shares a line with the end of a multiline last element, the `literal_expression_end_indentation` corrector deletes source code and produces non-compiling output.

Minimal reproduction (SwiftLint 0.63.3, config `only_rules: [literal_expression_end_indentation]`):

```swift
let x = [
   foo(
      1,
      2)]
```

`swiftlint --fix` rewrites the last line to `]`, deleting `2)`. Real-world case we hit: `font: .caption(.regular))],` became `],` — an entire argument silently dropped. We only caught it because the parentheses became unbalanced; a balanced collapse would have been a silent behavior change.

## Root cause

`correct(contents:expected:actual:)` assumes everything before the bracket on its line is indentation and replaces that whole range with the expected indentation. The violation geometry (`actualRange` covers the full line prefix before `]`) admits ranges containing code when the last element is multiline.

## Fix

Only perform the in-place replacement when the range is all whitespace; otherwise insert a newline plus the expected indentation right before the bracket, moving just the bracket to its own line. Detection behavior is unchanged; the rule's built-in re-correct pass converges (verified idempotent).

## Testing

- New triggering and correction examples in the rule covering the multiline-last-element pattern.
- `swift test --filter LiteralExpressionEndIndentation` passes.
- End-to-end with the patched binary on the original repro: content preserved, only the bracket moves, and a second `--fix` run makes no changes.

