### PR TITLE
Honor excluded paths for projects under /private-symlinked directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,11 @@
 
 ### Bug Fixes
 
-* None.
+* Honor `excluded` paths when the linted project is located under a system directory
+  on macOS that resolves through a symlink, such as `/var` and `/tmp` (which point
+  to `/private/var` and `/private/tmp`).  
+  [tumata](https://github.com/tumata)
+  [#6782](https://github.com/realm/SwiftLint/issues/6782)
 
 ## 0.64.0: All Windows Opened
 

--- a/Source/SwiftLintFramework/Extensions/FileManager+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/FileManager+SwiftLint.swift
@@ -33,15 +33,36 @@ public enum Excluder {
     /// An excluder that does not exclude any files.
     case noExclusion
 
+    private static let privatePrefix = "/private"
+
     func excludes(path: URL) -> Bool {
-        switch self {
-        case let .matching(matchers):
-            matchers.contains(where: { $0.match(filename: path.path) })
-        case let .byPrefix(prefixes):
-            prefixes.contains(where: { path.path.hasPrefix($0) })
-        case .noExclusion:
-            false
+        if case .noExclusion = self {
+            return false
         }
+
+        // Exclusion matchers and prefixes are derived from standardized URLs (see `String.url()`),
+        // which on macOS drops a leading `/private` from paths under firmlinks such as `/tmp` and
+        // `/var`. Paths produced by `FileManager`'s directory enumerator keep that prefix, so a
+        // file under a `/private`-resolved directory (e.g. CI workspaces or `mktemp` directories)
+        // would never match. Compare against the path with and without the `/private` prefix to
+        // bridge the gap without touching the filesystem; standardizing every candidate via
+        // `standardizedFileURL` would `stat` each path and is measurably slower.
+        let fullPath = path.path
+        let strippedPath = fullPath.hasPrefix(Self.privatePrefix + "/")
+            ? String(fullPath.dropFirst(Self.privatePrefix.count))
+            : nil
+        return switch self {
+            case let .matching(matchers):
+                matchers.contains { matcher in
+                    matcher.match(filename: fullPath) || strippedPath.map { matcher.match(filename: $0) } == true
+                }
+            case let .byPrefix(prefixes):
+                prefixes.contains { prefix in
+                    fullPath.hasPrefix(prefix) || strippedPath?.hasPrefix(prefix) == true
+                }
+            case .noExclusion:
+                queuedFatalError("Unreachable case; should have been handled at the beginning of the method")
+            }
     }
 }
 

--- a/Tests/FileSystemAccessTests/ConfigurationTests.swift
+++ b/Tests/FileSystemAccessTests/ConfigurationTests.swift
@@ -293,6 +293,33 @@ final class ConfigurationTests: SwiftLintTestCase { // swiftlint:disable:this ty
         assertEqual(["directory/File1.swift", "directory/File2.swift"], paths)
     }
 
+    // On macOS the system temporary directory resolves through a `/private` symlink (e.g.
+    // `/var/folders/…` -> `/private/var/folders/…`). The directory enumerator yields file
+    // paths carrying the `/private` prefix, whereas exclusion patterns are standardized
+    // without it. Excludes must still be honored regardless of the `/private` discrepancy.
+    func testExcludedPathsUnderSymlinkedDirectory() throws {
+        let rootDir = URL.temporaryDirectory
+            .appending(path: "SwiftLintExcludeTest-" + UUID().uuidString, directoryHint: .isDirectory)
+        let nestedDir = rootDir.appending(path: "Sources/Nested", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: nestedDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: rootDir) }
+        try Data().write(to: rootDir.appending(path: "Sources/Included.swift"))
+        try Data().write(to: nestedDir.appending(path: "Excluded.swift"))
+
+        let configuration = Configuration(
+            includedPaths: [rootDir.appending(path: "Sources")],
+            excludedPaths: [rootDir.appending(path: "Sources/**/Excluded.swift")]
+        )
+
+        let paths = configuration.lintablePaths(
+            inPath: rootDir,
+            forceExclude: false,
+            excludeByPrefix: false
+        )
+
+        XCTAssertEqual(Set(paths.map(\.lastPathComponent)), ["Included.swift"])
+    }
+
     func testForceExcludesFile() {
         XCTAssert(FileManager.default.changeCurrentDirectoryPath(Mock.Dir.exclusionTests.filepath))
         let configuration = Configuration(excludedPaths: ["directory/ExcludedFile.swift".url()])


### PR DESCRIPTION
## Summary

Fixes #6782.

`excluded` paths are silently ignored and the files get linted anyway when the linted project's real path is located under a `/private`-symlinked directory. On macOS that includes anything under `/tmp`, `/var`, and `/var/folders` (firmlinks to `/private/tmp`, `/private/var`, …), so it commonly affects CI workspaces and `mktemp` directories. This is a regression introduced in 0.64.0.

## Root cause

Exclusion matchers/prefixes are built from `excludedPaths`, whose URLs are produced by `String.url()`, which applies `.standardizedFileURL`. On macOS, standardization **strips a leading `/private`** (so `/private/var/x` → `/var/x`).

The file paths to be linted, however, come from `FileManager`'s directory enumerator, which yields paths that **keep** the `/private` prefix (`/private/var/x/...`).

So `Excluder.excludes(path:)` compares `/private/...` file paths against `/...` patterns, and the `FilenameMatcher` / prefix check never matches. Under `/Users` there is no `/private` to strip, which is why the bug looks machine-dependent.

## Fix

In `Excluder.excludes(path:)`, compare each candidate against the path **both with and without** a leading `/private` prefix, using string operations only. This bridges the discrepancy without touching the filesystem, and unlike standardizing every candidate it leaves matching behavior for non-`/private` paths exactly as it was.

## Performance

An earlier iteration of this fix standardized every candidate via `standardizedFileURL`, which `stat`s each path and regressed linting performance noticeably. The current string-only approach avoids that. Measured with `tools/oss-check`'s command (`lint --no-cache --enable-all-rules`, 5-run average) on the performance corpus:

| | avg | vs `main` |
|---|---|---|
| `main` | 0.18 s | N/A |
| `standardizedFileURL` approach | 0.28 s | +55% |
| this PR (string-only) | 0.20 s | +10% (within noise) |

Same violation count in all cases.

## Test

Added `ConfigurationTests.testExcludedPathsUnderSymlinkedDirectory`, which creates a small project under the system temporary directory (resolves under `/private/var/folders/…` on macOS) and asserts the excluded file is not linted. Verified it **fails without the fix** (the excluded file leaks into the lintable set) and **passes with it**. The full `FileSystemAccessTests` suite passes.
