### PR TITLE
Add opt-in inconsistent_default_argument_in_file rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,14 @@
 
 ### Enhancements
 
-* None.
+* Add a new opt-in rule `inconsistent_default_argument_in_file` that flags
+  overloaded functions declared on the same type (its primary declaration and
+  any extensions of it in the same file) when a shared parameter uses different
+  default values, which is usually an accidental drift callers do not expect.
+  Nested types form their own scope, and the cross-file/semantic cases are left
+  to a potential future analyzer rule.  
+  [nenadvulic](https://github.com/nenadvulic)
+  [#6668](https://github.com/realm/SwiftLint/issues/6668)
 
 ### Bug Fixes
 

--- a/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
+++ b/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
@@ -94,6 +94,7 @@ public let builtInRules: [any Rule.Type] = [
     ImplicitlyUnwrappedOptionalRule.self,
     InclusiveLanguageRule.self,
     IncompatibleConcurrencyAnnotationRule.self,
+    InconsistentDefaultArgumentInFileRule.self,
     IndentationWidthRule.self,
     InvalidSwiftLintCommandRule.self,
     InvisibleCharacterRule.self,

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/InconsistentDefaultArgumentInFileRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/InconsistentDefaultArgumentInFileRule.swift
@@ -1,0 +1,201 @@
+import SwiftSyntax
+
+@SwiftSyntaxRule(optIn: true)
+struct InconsistentDefaultArgumentInFileRule: Rule {
+    var configuration = SeverityConfiguration<Self>(.warning)
+
+    static let description = RuleDescription(
+        identifier: "inconsistent_default_argument_in_file",
+        name: "Inconsistent Default Argument in File",
+        description: """
+            Overloaded functions declared on the same type (its primary declaration and any extensions of it in \
+            the same file) should not use different default values for a shared parameter, as this is usually an \
+            accidental drift that callers do not expect
+            """,
+        kind: .lint,
+        nonTriggeringExamples: [
+            Example("""
+            struct S {
+              func f(x: Int = 1) {}
+            }
+            """),
+            Example("""
+            struct S {
+              func f(x: Int = 1) {}
+              func f(x: Int = 1, y: Int) {}
+            }
+            """),
+            Example("""
+            struct S {
+              func f(x: Int = 1) {}
+              func f(x: Int, y: Int) {}
+            }
+            """),
+            Example("""
+            struct S {
+              func f(x: Int = 1) {}
+              func f(x: String = "") {}
+            }
+            """),
+            Example("""
+            struct S {
+              func f(x: Int = 1) {}
+              func g(x: Int = 2) {}
+            }
+            """),
+            Example("""
+            struct A {
+              func f(x: Int = 1) {}
+            }
+            struct B {
+              func f(x: Int = 2) {}
+            }
+            """),
+            Example("""
+            struct Outer {
+              func f(x: Int = 1) {}
+              struct Inner {
+                func f(x: Int = 2) {}
+              }
+            }
+            """),
+        ],
+        triggeringExamples: [
+            Example("""
+            struct S {
+              func f(x: Int = 1) {}
+              func f(↓x: Int = 2, y: Int) {}
+            }
+            """),
+            Example("""
+            struct Network {
+              func fetch(_ url: URL, retries: Int = 3) {}
+              func fetch(_ url: URL, headers: [String: String], ↓retries: Int = 0) {}
+            }
+            """),
+            Example("""
+            struct V {
+              func animate(_ c: () -> Void, duration: TimeInterval = 0.3) {}
+              func animate(_ c: () -> Void, ↓duration: TimeInterval = 0.25, completion: () -> Void) {}
+            }
+            """),
+            Example("""
+            struct S {
+              func f(x: Int = 1) {}
+            }
+            extension S {
+              func f(↓x: Int = 2, y: Int) {}
+            }
+            """),
+        ]
+    )
+}
+
+/// A single parameter declaration that carries a default value.
+private struct DefaultedParameter {
+    let label: String
+    let type: String
+    let defaultValue: String
+    let position: AbsolutePosition
+}
+
+private extension InconsistentDefaultArgumentInFileRule {
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
+        /// Defaulted parameters collected per type scope, then per function base name.
+        ///
+        /// The scope key is the fully-qualified lexical type name (e.g. `Foo.Bar`), so a type's primary
+        /// declaration and any extensions of it in the same file share an entry, while nested types form
+        /// their own scope.
+        private var scopes: [String: [String: [DefaultedParameter]]] = [:]
+
+        override func visitPost(_ node: StructDeclSyntax) {
+            collect(node.memberBlock.members, in: node)
+        }
+
+        override func visitPost(_ node: ClassDeclSyntax) {
+            collect(node.memberBlock.members, in: node)
+        }
+
+        override func visitPost(_ node: EnumDeclSyntax) {
+            collect(node.memberBlock.members, in: node)
+        }
+
+        override func visitPost(_ node: ActorDeclSyntax) {
+            collect(node.memberBlock.members, in: node)
+        }
+
+        override func visitPost(_ node: ProtocolDeclSyntax) {
+            collect(node.memberBlock.members, in: node)
+        }
+
+        override func visitPost(_ node: ExtensionDeclSyntax) {
+            collect(node.memberBlock.members, in: node)
+        }
+
+        override func visitPost(_: SourceFileSyntax) {
+            for (_, functions) in scopes.sorted(by: { $0.key < $1.key }) {
+                for (_, parameters) in functions.sorted(by: { $0.key < $1.key }) {
+                    collectViolations(for: parameters)
+                }
+            }
+        }
+
+        /// Collects the defaulted parameters of the directly-declared functions of a type scope.
+        private func collect(_ members: MemberBlockItemListSyntax, in decl: some DeclSyntaxProtocol) {
+            let scope = scopeName(for: decl)
+            for function in members.compactMap({ $0.decl.as(FunctionDeclSyntax.self) }) {
+                let name = function.name.text
+                for parameter in function.signature.parameterClause.parameters {
+                    guard let defaultValue = parameter.defaultValue?.value else {
+                        continue
+                    }
+                    scopes[scope, default: [:]][name, default: []].append(
+                        DefaultedParameter(
+                            label: parameter.firstName.text,
+                            type: parameter.type.trimmedDescription,
+                            defaultValue: defaultValue.trimmedDescription,
+                            position: parameter.positionAfterSkippingLeadingTrivia
+                        )
+                    )
+                }
+            }
+        }
+
+        /// Flags parameters whose default diverges from the first declaration of a shared `(label, type)`.
+        private func collectViolations(for parameters: [DefaultedParameter]) {
+            let groups = Dictionary(grouping: parameters) { "\($0.label)|\($0.type)" }
+            for group in groups.values where group.count > 1 {
+                let ordered = group.sorted { $0.position < $1.position }
+                guard let reference = ordered.first?.defaultValue else {
+                    continue
+                }
+                for parameter in ordered where parameter.defaultValue != reference {
+                    violations.append(parameter.position)
+                }
+            }
+        }
+
+        /// Builds the fully-qualified lexical type name for a declaration by walking its ancestors.
+        private func scopeName(for decl: some DeclSyntaxProtocol) -> String {
+            var components: [String] = []
+            var current: Syntax? = Syntax(decl)
+            while let node = current {
+                if let type = node.as(StructDeclSyntax.self) {
+                    components.append(type.name.text)
+                } else if let type = node.as(ClassDeclSyntax.self) {
+                    components.append(type.name.text)
+                } else if let type = node.as(EnumDeclSyntax.self) {
+                    components.append(type.name.text)
+                } else if let type = node.as(ActorDeclSyntax.self) {
+                    components.append(type.name.text)
+                } else if let type = node.as(ProtocolDeclSyntax.self) {
+                    components.append(type.name.text)
+                } else if let ext = node.as(ExtensionDeclSyntax.self) {
+                    components.append(ext.extendedType.trimmedDescription)
+                }
+                current = node.parent
+            }
+            return components.reversed().joined(separator: ".")
+        }
+    }
+}

--- a/Tests/GeneratedTests/GeneratedTests_04.swift
+++ b/Tests/GeneratedTests/GeneratedTests_04.swift
@@ -146,6 +146,14 @@ struct IncompatibleConcurrencyAnnotationRuleGeneratedTests {
 }
 
 @Suite(.rulesRegistered)
+struct InconsistentDefaultArgumentInFileRuleGeneratedTests {
+    @Test
+    func withDefaultConfiguration() {
+        verifyRule(InconsistentDefaultArgumentInFileRule.description)
+    }
+}
+
+@Suite(.rulesRegistered)
 struct IndentationWidthRuleGeneratedTests {
     @Test
     func withDefaultConfiguration() {
@@ -198,13 +206,5 @@ struct LastWhereRuleGeneratedTests {
     @Test
     func withDefaultConfiguration() {
         verifyRule(LastWhereRule.description)
-    }
-}
-
-@Suite(.rulesRegistered)
-struct LeadingWhitespaceRuleGeneratedTests {
-    @Test
-    func withDefaultConfiguration() {
-        verifyRule(LeadingWhitespaceRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_05.swift
+++ b/Tests/GeneratedTests/GeneratedTests_05.swift
@@ -10,6 +10,14 @@ import Testing
 @testable import SwiftLintCore
 
 @Suite(.rulesRegistered)
+struct LeadingWhitespaceRuleGeneratedTests {
+    @Test
+    func withDefaultConfiguration() {
+        verifyRule(LeadingWhitespaceRule.description)
+    }
+}
+
+@Suite(.rulesRegistered)
 struct LegacyCGGeometryFunctionsRuleGeneratedTests {
     @Test
     func withDefaultConfiguration() {
@@ -198,13 +206,5 @@ struct MultilineParametersRuleGeneratedTests {
     @Test
     func withDefaultConfiguration() {
         verifyRule(MultilineParametersRule.description)
-    }
-}
-
-@Suite(.rulesRegistered)
-struct MultipleClosuresWithTrailingClosureRuleGeneratedTests {
-    @Test
-    func withDefaultConfiguration() {
-        verifyRule(MultipleClosuresWithTrailingClosureRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_06.swift
+++ b/Tests/GeneratedTests/GeneratedTests_06.swift
@@ -10,6 +10,14 @@ import Testing
 @testable import SwiftLintCore
 
 @Suite(.rulesRegistered)
+struct MultipleClosuresWithTrailingClosureRuleGeneratedTests {
+    @Test
+    func withDefaultConfiguration() {
+        verifyRule(MultipleClosuresWithTrailingClosureRule.description)
+    }
+}
+
+@Suite(.rulesRegistered)
 struct NSLocalizedStringKeyRuleGeneratedTests {
     @Test
     func withDefaultConfiguration() {
@@ -198,13 +206,5 @@ struct OverriddenSuperCallRuleGeneratedTests {
     @Test
     func withDefaultConfiguration() {
         verifyRule(OverriddenSuperCallRule.description)
-    }
-}
-
-@Suite(.rulesRegistered)
-struct OverrideInExtensionRuleGeneratedTests {
-    @Test
-    func withDefaultConfiguration() {
-        verifyRule(OverrideInExtensionRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_07.swift
+++ b/Tests/GeneratedTests/GeneratedTests_07.swift
@@ -10,6 +10,14 @@ import Testing
 @testable import SwiftLintCore
 
 @Suite(.rulesRegistered)
+struct OverrideInExtensionRuleGeneratedTests {
+    @Test
+    func withDefaultConfiguration() {
+        verifyRule(OverrideInExtensionRule.description)
+    }
+}
+
+@Suite(.rulesRegistered)
 struct PatternMatchingKeywordsRuleGeneratedTests {
     @Test
     func withDefaultConfiguration() {
@@ -198,13 +206,5 @@ struct RawValueForCamelCasedCodableEnumRuleGeneratedTests {
     @Test
     func withDefaultConfiguration() {
         verifyRule(RawValueForCamelCasedCodableEnumRule.description)
-    }
-}
-
-@Suite(.rulesRegistered)
-struct ReduceBooleanRuleGeneratedTests {
-    @Test
-    func withDefaultConfiguration() {
-        verifyRule(ReduceBooleanRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_08.swift
+++ b/Tests/GeneratedTests/GeneratedTests_08.swift
@@ -10,6 +10,14 @@ import Testing
 @testable import SwiftLintCore
 
 @Suite(.rulesRegistered)
+struct ReduceBooleanRuleGeneratedTests {
+    @Test
+    func withDefaultConfiguration() {
+        verifyRule(ReduceBooleanRule.description)
+    }
+}
+
+@Suite(.rulesRegistered)
 struct ReduceIntoRuleGeneratedTests {
     @Test
     func withDefaultConfiguration() {
@@ -198,13 +206,5 @@ struct SortedImportsRuleGeneratedTests {
     @Test
     func withDefaultConfiguration() {
         verifyRule(SortedImportsRule.description)
-    }
-}
-
-@Suite(.rulesRegistered)
-struct StatementPositionRuleGeneratedTests {
-    @Test
-    func withDefaultConfiguration() {
-        verifyRule(StatementPositionRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_09.swift
+++ b/Tests/GeneratedTests/GeneratedTests_09.swift
@@ -10,6 +10,14 @@ import Testing
 @testable import SwiftLintCore
 
 @Suite(.rulesRegistered)
+struct StatementPositionRuleGeneratedTests {
+    @Test
+    func withDefaultConfiguration() {
+        verifyRule(StatementPositionRule.description)
+    }
+}
+
+@Suite(.rulesRegistered)
 struct StaticOperatorRuleGeneratedTests {
     @Test
     func withDefaultConfiguration() {
@@ -198,13 +206,5 @@ struct UnneededBreakInSwitchRuleGeneratedTests {
     @Test
     func withDefaultConfiguration() {
         verifyRule(UnneededBreakInSwitchRule.description)
-    }
-}
-
-@Suite(.rulesRegistered)
-struct UnneededEscapingRuleGeneratedTests {
-    @Test
-    func withDefaultConfiguration() {
-        verifyRule(UnneededEscapingRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_10.swift
+++ b/Tests/GeneratedTests/GeneratedTests_10.swift
@@ -10,6 +10,14 @@ import Testing
 @testable import SwiftLintCore
 
 @Suite(.rulesRegistered)
+struct UnneededEscapingRuleGeneratedTests {
+    @Test
+    func withDefaultConfiguration() {
+        verifyRule(UnneededEscapingRule.description)
+    }
+}
+
+@Suite(.rulesRegistered)
 struct UnneededOverrideRuleGeneratedTests {
     @Test
     func withDefaultConfiguration() {
@@ -198,13 +206,5 @@ struct VoidReturnRuleGeneratedTests {
     @Test
     func withDefaultConfiguration() {
         verifyRule(VoidReturnRule.description)
-    }
-}
-
-@Suite(.rulesRegistered)
-struct WeakDelegateRuleGeneratedTests {
-    @Test
-    func withDefaultConfiguration() {
-        verifyRule(WeakDelegateRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_11.swift
+++ b/Tests/GeneratedTests/GeneratedTests_11.swift
@@ -10,6 +10,14 @@ import Testing
 @testable import SwiftLintCore
 
 @Suite(.rulesRegistered)
+struct WeakDelegateRuleGeneratedTests {
+    @Test
+    func withDefaultConfiguration() {
+        verifyRule(WeakDelegateRule.description)
+    }
+}
+
+@Suite(.rulesRegistered)
 struct XCTFailMessageRuleGeneratedTests {
     @Test
     func withDefaultConfiguration() {

--- a/Tests/IntegrationTests/Resources/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/Resources/default_rule_configurations.yml
@@ -540,6 +540,11 @@ incompatible_concurrency_annotation:
   meta:
     opt-in: true
     correctable: true
+inconsistent_default_argument_in_file:
+  severity: warning
+  meta:
+    opt-in: true
+    correctable: false
 indentation_width:
   severity: warning
   indentation_width: 4


### PR DESCRIPTION
## Summary

Adds a new **opt-in** rule `inconsistent_default_argument_in_file` (kind: `lint`), as discussed in #6668.

It flags overloaded functions declared on the **same type** — the type's primary declaration **and any extensions of it in the same file** — when a shared `(label, type)` parameter uses **different default values**. This catches accidental *default drift* across overloads that callers reasonably expect to behave the same, e.g.:

```swift
struct Network {
  func fetch(_ url: URL, retries: Int = 3) {}
  func fetch(_ url: URL, headers: [String: String], retries: Int = 0) {} // ← silently drops to 0
}
```

## Scope

Per the agreement with @SimplyDanny and @rgoldberg in #6668, this is the intentionally small, purely syntactic, single-file variant:

- **Opt-in** (disabled by default) — teams that want the "overloads share defaults" invariant get it; others aren't bothered.
- Behavior = `across_one_type`: a type's primary declaration plus all extensions of it **in the same file** are treated as one scope (matched via the fully-qualified lexical type name, e.g. `Foo.Bar`).
- **Nested types form their own scope** (`separately`): `Parent.f(…)` and `Parent.Nested.f(…)` are functions on different types, so they are never compared — comparing them would produce false positives.
- The offending parameter is the one whose default **diverges from the first declaration** of that shared parameter, in source order.

Deliberately **out of scope** here (left to a potential future analyzer rule, so no name clash):

- `call_default_arguments` and `override_default_arguments` — both need type/symbol resolution unavailable to a syntactic rule.
- Cross-file cases.

The `_in_file` suffix keeps the name honest about the limitation and leaves room for a fully-general analyzer rule later. Config options floated in the discussion (`container_scope`, `nested_containers`, `parameter_grouping`, …) are intentionally **not** included yet; they can be layered on additively without breaking the v1 defaults.

## Examples

Triggering:
```swift
struct S {
  func f(x: Int = 1) {}
  func f(↓x: Int = 2, y: Int) {}
}
```
```swift
struct S {
  func f(x: Int = 1) {}
}
extension S {
  func f(↓x: Int = 2, y: Int) {}
}
```

Non-triggering (same default, one-sided default, different type, different scope, nested type):
```swift
struct S {
  func f(x: Int = 1) {}
  func f(x: Int = 1, y: Int) {}
}
struct Outer {
  func f(x: Int = 1) {}
  struct Inner {
    func f(x: Int = 2) {} // different scope
  }
}
```
Closes #6668.
