### PR TITLE
Re-add @-prefixed response files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@
   them across the built-in rules.  
   [ZevEisenberg](https://github.com/ZevEisenberg)
 
+* (Re)add `@`-prefixed response file support to `lint` and `analyze` commands.
+  [dflems](https://github.com/dflems)
+  [#issue_number](https://github.com/realm/SwiftLint/pull/6815)
+
 ### Bug Fixes
 
 * Fix baseline writing to store file locations as paths relative to the current working directory,

--- a/Source/SwiftLintCore/Extensions/URL+SwiftLint.swift
+++ b/Source/SwiftLintCore/Extensions/URL+SwiftLint.swift
@@ -91,6 +91,25 @@ public extension URL {
     }
 }
 
+public extension [String] {
+    /// Replace any `@`-prefixed response file arguments with the newline-delimited
+    /// contents of the referenced file. Expansion is recursive. If a response file
+    /// cannot be read, the original argument is preserved.
+    var expandingResponseFiles: [String] {
+        flatMap { arg -> [String] in
+            guard arg.hasPrefix("@") else {
+                return [arg]
+            }
+            let responseFile = String(arg.dropFirst())
+            return (try? String(contentsOf: URL(filePath: responseFile, directoryHint: .notDirectory))).flatMap {
+                $0.trimmingCharacters(in: .newlines)
+                    .components(separatedBy: "\n")
+                    .expandingResponseFiles
+            } ?? [arg]
+        }
+    }
+}
+
 public extension String {
     func url(relativeTo base: URL? = nil, directoryHint: URL.DirectoryHint = .inferFromPath) -> URL {
         var resolvedBase = base ?? URL.cwd

--- a/Source/SwiftLintFramework/CompilerArgumentsExtractor.swift
+++ b/Source/SwiftLintFramework/CompilerArgumentsExtractor.swift
@@ -57,21 +57,6 @@ private func partiallyFilter(arguments args: [String]) -> ([String], Bool) {
 }
 
 extension Array where Element == String {
-    /// Return the full list of compiler arguments, replacing any response files with their contents.
-    fileprivate var expandingResponseFiles: [String] {
-        flatMap { arg -> [String] in
-            guard arg.starts(with: "@") else {
-                return [arg]
-            }
-            let responseFile = String(arg.dropFirst())
-            return (try? String(contentsOf: URL(filePath: responseFile, directoryHint: .notDirectory))).flatMap {
-                $0.trimmingCharacters(in: .newlines)
-                    .components(separatedBy: "\n")
-                    .expandingResponseFiles
-            } ?? [arg]
-        }
-    }
-
     /// Returns filtered compiler arguments from `xcodebuild` to something that SourceKit/Clang will accept.
     var filteringCompilerArguments: [String] {
         var args = self

--- a/Source/swiftlint/Commands/Analyze.swift
+++ b/Source/swiftlint/Commands/Analyze.swift
@@ -15,14 +15,12 @@ extension SwiftLint {
         @Option(help: "The path of a compilation database to use when running AnalyzerRules.")
         var compileCommands: String?
         @Argument(help: pathsArgumentDescription(for: .analyze))
-        var paths = [URL]()
+        var paths = [String]()
 
         func run() async throws {
-            // Analyze files in current working directory if no paths were specified.
-            let allPaths = paths.isNotEmpty ? paths : [URL.cwd]
             let options = LintOrAnalyzeOptions(
                 mode: .analyze,
-                paths: allPaths,
+                paths: resolvedPaths(from: paths),
                 useSTDIN: false,
                 configurationFiles: common.config,
                 strict: common.leniency == .strict,

--- a/Source/swiftlint/Commands/Lint.swift
+++ b/Source/swiftlint/Commands/Lint.swift
@@ -26,7 +26,7 @@ extension SwiftLint {
         )
         var disableSourceKit = false
         @Argument(help: pathsArgumentDescription(for: .lint))
-        var paths = [URL]()
+        var paths = [String]()
 
         func run() async throws {
             Issue.printDeprecationWarnings = !silenceDeprecationWarnings
@@ -35,11 +35,9 @@ extension SwiftLint {
                 Issue.genericWarning("The option --\(leniency) has no effect together with --fix.").print()
             }
 
-            // Lint files in current working directory if no paths were specified.
-            let allPaths = paths.isNotEmpty ? paths : [URL.cwd]
             let options = LintOrAnalyzeOptions(
                 mode: .lint,
-                paths: allPaths,
+                paths: resolvedPaths(from: paths),
                 useSTDIN: useSTDIN,
                 configurationFiles: common.config,
                 strict: common.leniency == .strict,

--- a/Source/swiftlint/Common/LintOrAnalyzeArguments.swift
+++ b/Source/swiftlint/Common/LintOrAnalyzeArguments.swift
@@ -77,6 +77,13 @@ func quietOptionDescription(for mode: LintOrAnalyzeMode) -> ArgumentHelp {
     "Don't print status logs like '\(mode.verb.capitalized) <file>' & 'Done \(mode.verb)'."
 }
 
+func resolvedPaths(from paths: [String]) -> [URL] {
+    // Lint/analyze files in current working directory if no paths were specified.
+    paths.isNotEmpty
+        ? paths.expandingResponseFiles.map { URL(filePath: $0) }
+        : [URL.cwd]
+}
+
 extension URL: @retroactive ExpressibleByArgument {
     public init?(argument: String) {
         self.init(filePath: argument)

--- a/Tests/CoreTests/URLExtensionTests.swift
+++ b/Tests/CoreTests/URLExtensionTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import SwiftLintCore
+import Testing
+
+@Suite
+final class URLExtensionTests {
+    private let tempDir = FileManager.default.temporaryDirectory
+        .appending(path: "swiftlint-response-test-\(UUID().uuidString)")
+
+    init() throws {
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+    }
+
+    deinit {
+        do {
+            try FileManager.default.removeItem(at: tempDir)
+        } catch {
+            Issue.record("Failed to remove temporary directory: \(error)")
+        }
+    }
+
+    @Test
+    func expandingResponseFilesPassesThroughRegularPaths() {
+        let paths = ["/a.swift", "/b.swift"]
+        #expect(paths.expandingResponseFiles == paths)
+    }
+
+    @Test
+    func expandingResponseFilesExpandsResponseFile() throws {
+        let responseFile = tempDir.appending(path: "files.txt")
+        try "foo.swift\nbar.swift\n".write(to: responseFile, atomically: true, encoding: .utf8)
+
+        let expanded = ["@\(responseFile.filepath)"].expandingResponseFiles
+        #expect(expanded == ["foo.swift", "bar.swift"])
+    }
+
+    @Test
+    func expandingResponseFilesTrimsTrailingNewlines() throws {
+        let responseFile = tempDir.appending(path: "files.txt")
+        try "foo.swift\nbar.swift\n".write(to: responseFile, atomically: true, encoding: .utf8)
+
+        let expanded = ["@\(responseFile.filepath)"].expandingResponseFiles
+        #expect(expanded == ["foo.swift", "bar.swift"])
+    }
+
+    @Test
+    func expandingResponseFilesMixesRegularAndResponsePaths() throws {
+        let responseFile = tempDir.appending(path: "files.txt")
+        try "b.swift\nc.swift".write(to: responseFile, atomically: true, encoding: .utf8)
+
+        let expanded = ["/a.swift", "@\(responseFile.filepath)", "/d.swift"].expandingResponseFiles
+        #expect(expanded == ["/a.swift", "b.swift", "c.swift", "/d.swift"])
+    }
+
+    @Test
+    func expandingResponseFilesRecursivelyExpands() throws {
+        let inner = tempDir.appending(path: "inner.txt")
+        try "c.swift".write(to: inner, atomically: true, encoding: .utf8)
+
+        let outer = tempDir.appending(path: "outer.txt")
+        try "a.swift\n@\(inner.filepath)\nb.swift".write(to: outer, atomically: true, encoding: .utf8)
+
+        let expanded = ["@\(outer.filepath)"].expandingResponseFiles
+        #expect(expanded == ["a.swift", "c.swift", "b.swift"])
+    }
+
+    @Test
+    func expandingResponseFilesPreservesUnreadableArgs() {
+        let expanded = ["@/nonexistent/missing.txt"].expandingResponseFiles
+        #expect(expanded == ["@/nonexistent/missing.txt"])
+    }
+
+    @Test
+    func expandingResponseFilesPreservesEmptyFile() throws {
+        let responseFile = tempDir.appending(path: "empty.txt")
+        try "".write(to: responseFile, atomically: true, encoding: .utf8)
+
+        let expanded = ["@\(responseFile.filepath)"].expandingResponseFiles
+        #expect(expanded == [""])
+    }
+}


### PR DESCRIPTION
Once upon a time, SwiftLint supported `@`-prefixed response/param files in the `lint` and `analyze` subcommands. Like `xcfilelist` files, these would be expanded in-place in the command. It seems this functionality was (perhaps accidentally) removed in [#5811](https://github.com/realm/SwiftLint/pull/5811/changes#diff-8e36888368a9bdd5a03fed70ca7328fb0e1e863154864b7500f08dca8f803b39L97) (`0.57.1`) with the last (unused) vestiges of it removed in [#6125](https://github.com/realm/SwiftLint/pull/6125/changes#diff-8e36888368a9bdd5a03fed70ca7328fb0e1e863154864b7500f08dca8f803b39L60-L69).

This PR adds it back. It repurposes a bit of code from `CompilerArgumentsExtractor` and shares it across both use cases. Practically there's no major difference other than that `@`-prefixed arguments are expanded in-place.