### PR TITLE
Ignore unowned(unsafe) captures by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@
 
 ### Bug Fixes
 
+* Make `unowned_variable_capture` ignore `unowned(unsafe)` captures by
+  default and add an `include_unsafe` option for projects that still want them
+  reported.  
+  [Yurii Bakurov](https://github.com/Yurii201811)
+  [#6817](https://github.com/realm/SwiftLint/issues/6817)
+
 * Fix baseline writing to store file locations as paths relative to the current working directory,
   restoring baseline portability and avoiding absolute `file://` paths in generated baseline files.  
   [SimplyDanny](https://github.com/SimplyDanny)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,8 @@
 
 ### Bug Fixes
 
-* Make `unowned_variable_capture` ignore `unowned(unsafe)` captures by
-  default and add an `include_unsafe` option for projects that still want them
-  reported.  
+* Add an opt-in `allow_explicit_unsafe_unowned` option to let the
+  `unowned_variable_capture` rule accept explicit `unowned(unsafe)` captures.  
   [Yurii Bakurov](https://github.com/Yurii201811)
   [#6817](https://github.com/realm/SwiftLint/issues/6817)
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnownedVariableCaptureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnownedVariableCaptureRule.swift
@@ -3,7 +3,7 @@ import SwiftSyntax
 
 @SwiftSyntaxRule(optIn: true)
 struct UnownedVariableCaptureRule: Rule {
-    var configuration = SeverityConfiguration<Self>(.warning)
+    var configuration = UnownedVariableCaptureConfiguration()
 
     static let description = RuleDescription(
         identifier: "unowned_variable_capture",
@@ -15,6 +15,7 @@ struct UnownedVariableCaptureRule: Rule {
             "foo { [weak self] param in _ }",
             "foo { [weak bar] in _ }",
             "foo { [weak bar] param in _ }",
+            "foo { [unowned(unsafe) self] in _ }",
             "foo { bar in _ }",
             "foo { $0 }",
             """
@@ -30,7 +31,10 @@ struct UnownedVariableCaptureRule: Rule {
         triggeringExamples: #examples([
             "foo { [↓unowned self] in _ }",
             "foo { [↓unowned bar] in _ }",
+            "foo { [↓unowned(safe) self] in _ }",
             "foo { [bar, ↓unowned self] in _ }",
+            "foo { [↓unowned(unsafe) self] in _ }"
+                .asExample(configuration: ["include_unsafe": true]),
         ])
     )
 }
@@ -38,7 +42,13 @@ struct UnownedVariableCaptureRule: Rule {
 private extension UnownedVariableCaptureRule {
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: TokenSyntax) {
-            if case .keyword(.unowned) = node.tokenKind, node.parent?.is(ClosureCaptureSpecifierSyntax.self) == true {
+            guard case .keyword(.unowned) = node.tokenKind,
+                  let specifier = node.parent?.as(ClosureCaptureSpecifierSyntax.self) else {
+                return
+            }
+
+            let isUnsafe = specifier.tokens(viewMode: .sourceAccurate).contains { $0.text == "unsafe" }
+            if !isUnsafe || configuration.includeUnsafe {
                 violations.append(node.positionAfterSkippingLeadingTrivia)
             }
         }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnownedVariableCaptureRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnownedVariableCaptureRule.swift
@@ -15,7 +15,8 @@ struct UnownedVariableCaptureRule: Rule {
             "foo { [weak self] param in _ }",
             "foo { [weak bar] in _ }",
             "foo { [weak bar] param in _ }",
-            "foo { [unowned(unsafe) self] in _ }",
+            "foo { [unowned(unsafe) self] in _ }"
+                .asExample(configuration: ["allow_explicit_unsafe_unowned": true]),
             "foo { bar in _ }",
             "foo { $0 }",
             """
@@ -33,23 +34,21 @@ struct UnownedVariableCaptureRule: Rule {
             "foo { [↓unowned bar] in _ }",
             "foo { [↓unowned(safe) self] in _ }",
             "foo { [bar, ↓unowned self] in _ }",
-            "foo { [↓unowned(unsafe) self] in _ }"
-                .asExample(configuration: ["include_unsafe": true]),
+            "foo { [↓unowned(unsafe) self] in _ }",
         ])
     )
 }
 
 private extension UnownedVariableCaptureRule {
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
-        override func visitPost(_ node: TokenSyntax) {
-            guard case .keyword(.unowned) = node.tokenKind,
-                  let specifier = node.parent?.as(ClosureCaptureSpecifierSyntax.self) else {
+        override func visitPost(_ node: ClosureCaptureSpecifierSyntax) {
+            guard case .keyword(.unowned) = node.specifier.tokenKind else {
                 return
             }
 
-            let isUnsafe = specifier.tokens(viewMode: .sourceAccurate).contains { $0.text == "unsafe" }
-            if !isUnsafe || configuration.includeUnsafe {
-                violations.append(node.positionAfterSkippingLeadingTrivia)
+            let isUnsafe = node.detail?.tokenKind == .keyword(.unsafe)
+            if !isUnsafe || !configuration.allowExplicitUnsafeUnowned {
+                violations.append(node.specifier.positionAfterSkippingLeadingTrivia)
             }
         }
     }

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnownedVariableCaptureConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnownedVariableCaptureConfiguration.swift
@@ -1,0 +1,9 @@
+import SwiftLintCore
+
+@AutoConfigParser
+struct UnownedVariableCaptureConfiguration: SeverityBasedRuleConfiguration {
+    @ConfigurationElement(key: "severity")
+    private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement(key: "include_unsafe")
+    private(set) var includeUnsafe = false
+}

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnownedVariableCaptureConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/UnownedVariableCaptureConfiguration.swift
@@ -4,6 +4,6 @@ import SwiftLintCore
 struct UnownedVariableCaptureConfiguration: SeverityBasedRuleConfiguration {
     @ConfigurationElement(key: "severity")
     private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
-    @ConfigurationElement(key: "include_unsafe")
-    private(set) var includeUnsafe = false
+    @ConfigurationElement(key: "allow_explicit_unsafe_unowned")
+    private(set) var allowExplicitUnsafeUnowned = false
 }

--- a/Tests/IntegrationTests/Resources/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/Resources/default_rule_configurations.yml
@@ -1335,6 +1335,7 @@ unneeded_throws_rethrows:
     correctable: true
 unowned_variable_capture:
   severity: warning
+  include_unsafe: false
   meta:
     opt-in: true
     correctable: false

--- a/Tests/IntegrationTests/Resources/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/Resources/default_rule_configurations.yml
@@ -1335,7 +1335,7 @@ unneeded_throws_rethrows:
     correctable: true
 unowned_variable_capture:
   severity: warning
-  include_unsafe: false
+  allow_explicit_unsafe_unowned: false
   meta:
     opt-in: true
     correctable: false


### PR DESCRIPTION
## Summary

Ignore `unowned(unsafe)` captures by default while preserving an opt-in `include_unsafe` setting.

## Background

The explicit unsafe spelling communicates the intended lifetime tradeoff.

Closes #6817

## Changes

- add `include_unsafe`, defaulting to `false`
- distinguish unsafe capture specifiers from `unowned` and `unowned(safe)`
- cover default and configured behavior
- update generated configuration metadata and changelog

## Verification

- [ ] generated rule tests
- [ ] full Swift tests
- [ ] SwiftLint self-lint
- [ ] remaining platform gates or CI