### PR TITLE
Revive excludedPaths by stopping double resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@
   [#6798](https://github.com/realm/SwiftLint/issues/6798)
   [#6799](https://github.com/realm/SwiftLint/issues/6799)
 
+* Fix `excluded` configuration being ignored when file paths are passed as arguments.  
+  [Tomotaka Takahashi](https://github.com/tomotakatakahashi)
+  [#6795](https://github.com/realm/SwiftLint/issues/6795)
+
 ## 0.65.0: Fresh Folded Fixtures
 
 ### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@
   [Hokila](https://github.com/Hokila)
   [#6897](https://github.com/realm/SwiftLint/issues/6897)
 
+* Fix `excluded` configuration being ignored when file paths are passed as arguments.  
+  [Tomotaka Takahashi](https://github.com/tomotakatakahashi)
+  [#6795](https://github.com/realm/SwiftLint/issues/6795)
+
 ## 0.65.1: Fresh Folded Fixtures
 
 ### Breaking

--- a/Source/SwiftLintFramework/Configuration+CommandLine.swift
+++ b/Source/SwiftLintFramework/Configuration+CommandLine.swift
@@ -118,11 +118,9 @@ extension Configuration {
 
         return files.parallelFilterGroup { file in
             let fileConfiguration = configuration(for: file)
-            let fileConfigurationRootPath = fileConfiguration.rootDirectory
 
             // Files whose configuration specifies they should be excluded will be skipped
-            let shouldSkip = fileConfiguration.excludedPaths.contains { excludedRelativePath in
-                let excludedPath = fileConfigurationRootPath.appending(path: excludedRelativePath.relativePath)
+            let shouldSkip = fileConfiguration.excludedPaths.contains { excludedPath in
                 let filePathComponents = file.path?.pathComponents ?? []
                 let excludedPathComponents = excludedPath.pathComponents
                 return filePathComponents.starts(with: excludedPathComponents)

--- a/Tests/IntegrationTests/ConfigPathResolutionTests.swift
+++ b/Tests/IntegrationTests/ConfigPathResolutionTests.swift
@@ -99,10 +99,19 @@ struct ConfigPathResolutionTests {
 
     @Test
     func nestedConfigurationBasicWithCommandLine() async throws {
-        #expect(try await visitedLintableFilePaths(
-            in: "_4_nested_basic",
-            paths: ["ModuleA/File.swift", "ModuleA/Generated/File.swift", "ModuleB/File.swift"]
-        ) == ["ModuleA/File.swift", "ModuleB/File.swift"])
+        // `swiftlint --quiet --no-cache ModuleA/File.swift ModuleA/Generated/File.swift ModuleB/File.swift`
+        #expect(
+            try await visitedLintableFilePaths(
+                in: "_4_nested_basic",
+                paths: ["ModuleA/File.swift", "ModuleA/Generated/File.swift", "ModuleB/File.swift"]
+            ) == ["ModuleA/File.swift", "ModuleB/File.swift"]
+        )
+
+        // `swiftlint --quiet --no-cache`
+        #expect(
+            try await visitedLintableFilePaths(in: "_4_nested_basic", paths: [])
+                == ["ModuleA/File.swift", "ModuleB/File.swift"]
+        )
     }
 
     @Test
@@ -265,7 +274,8 @@ private extension LintOrAnalyzeOptions {
     static func lint(paths: [URL]) -> Self {
         Self(
             mode: .lint,
-            paths: paths,
+            // Lint files in the current working directory if no paths were specified, just like the command does.
+            paths: paths.isNotEmpty ? paths : [URL.cwd],
             useSTDIN: false,
             configurationFiles: [],
             strict: false,

--- a/Tests/IntegrationTests/ConfigPathResolutionTests.swift
+++ b/Tests/IntegrationTests/ConfigPathResolutionTests.swift
@@ -32,12 +32,21 @@ struct ConfigPathResolutionTests {
 
     /// Returns the paths of the files that are actually linted when the given paths are passed as command line
     /// arguments, relative to the fixture directory.
-    private func visitedLintableFilePaths(in scenario: String, paths: [String]) async throws -> [String] {
+    ///
+    /// Set `asRelativeArguments` to keep the paths relative to the working directory instead of standardizing
+    /// them, which is the shape `URL(filePath:)` produces for a relative command line argument.
+    private func visitedLintableFilePaths(
+        in scenario: String,
+        paths: [String],
+        asRelativeArguments: Bool = false
+    ) async throws -> [String] {
         let scenarioPath = fixturePath(scenario)
         return try await CurrentWorkingDirectory.$url.withValue(scenarioPath) {
             let config = Configuration(configurationFiles: [])
             let files = try await config.visitLintableFiles(
-                options: .lint(paths: paths.map { $0.url() }),
+                options: .lint(paths: paths.map {
+                    asRelativeArguments ? URL(filePath: $0, relativeTo: URL.cwd) : $0.url()
+                }),
                 storage: RuleStorage(),
                 visitorBlock: { _ in
                     // Only the set of visited files matters, not the violations found in them.
@@ -115,6 +124,23 @@ struct ConfigPathResolutionTests {
     }
 
     @Test
+    func relativePathArgumentDoesNotEscapeRootDirectory() async throws {
+        // `swiftlint --quiet --no-cache Sources/File.swift` in the `project` directory.
+        //
+        // A relative argument yields a URL that keeps the working directory as its base. Walking up such a URL
+        // never compares equal to the absolute `rootDirectory`, so the search for nested configurations climbs
+        // out of the working directory and picks up the configuration above it, whose `excluded: project` then
+        // swallows the file that was explicitly passed.
+        let visitedPaths = try await visitedLintableFilePaths(
+            in: "_10_relative_path_arguments/project",
+            paths: ["Sources/File.swift"],
+            asRelativeArguments: true
+        )
+
+        #expect(visitedPaths == ["Sources/File.swift"])
+    }
+
+    @Test
     func wildcardPatternCount() {
         #expect(
             lintableFilePaths(
@@ -124,7 +150,7 @@ struct ConfigPathResolutionTests {
             ) == ["project/Sources/Models/User.swift"]
         )
     }
-    
+
     @Test
     func wildCardPatternCountWithCommandLine() async throws {
         // `swiftlint --quiet --no-cache Sources/Models/User.swift Sources/Models/User.generated.swift`

--- a/Tests/IntegrationTests/ConfigPathResolutionTests.swift
+++ b/Tests/IntegrationTests/ConfigPathResolutionTests.swift
@@ -1,10 +1,10 @@
 import Foundation
 import SourceKittenFramework
-import SwiftLintFramework
 import TestHelpers
 import Testing
 
 @testable import SwiftLintCore
+@testable import SwiftLintFramework
 
 @Suite(.rulesRegistered)
 struct ConfigPathResolutionTests {
@@ -26,9 +26,31 @@ struct ConfigPathResolutionTests {
                 excludeByPrefix: false
             )
 
-            // swiftlint:disable:next force_try
-            return files.map { $0.path!.path.replacing(try! Regex(".+/\(scenario)/"), with: "") }.sorted()
+            return relativePaths(of: files, in: scenario)
         }
+    }
+
+    /// Returns the paths of the files that are actually linted when the given paths are passed as command line
+    /// arguments, relative to the fixture directory.
+    private func visitedFilePaths(in scenario: String, paths: [String]) async throws -> [String] {
+        let scenarioPath = fixturePath(scenario)
+        return try await CurrentWorkingDirectory.$url.withValue(scenarioPath) {
+            let config = Configuration(configurationFiles: [])
+            let files = try await config.visitLintableFiles(
+                options: LintOrAnalyzeOptions(paths: paths.map { $0.url() }),
+                storage: RuleStorage(),
+                visitorBlock: { _ in
+                    // Only the set of visited files matters, not the violations found in them.
+                }
+            )
+
+            return relativePaths(of: files, in: scenario)
+        }
+    }
+
+    private func relativePaths(of files: [SwiftLintFile], in scenario: String) -> [String] {
+        // swiftlint:disable:next force_try
+        files.map { $0.path!.path.replacing(try! Regex(".+/\(scenario)/"), with: "") }.sorted()
     }
 
     @Test
@@ -160,6 +182,18 @@ struct ConfigPathResolutionTests {
     }
 
     @Test
+    func nestedConfigurationExclusionAppliesToFilePathArguments() async throws {
+        // Passing a file explicitly bypasses the exclusion filter while collecting the files to lint. The
+        // exclusions of the configuration applying to each file must still be honored when grouping them.
+        let visitedPaths = try await visitedFilePaths(
+            in: "_4_nested_basic",
+            paths: ["ModuleA/File.swift", "ModuleA/Generated/File.swift", "ModuleB/File.swift"]
+        )
+
+        #expect(visitedPaths == ["ModuleA/File.swift", "ModuleB/File.swift"])
+    }
+
+    @Test
     func nestedConfigurationDisabledByConfigFlag() {
         let scenarioPath = fixturePath("_4_nested_basic")
 
@@ -228,4 +262,39 @@ struct ConfigPathResolutionTests {
         )
     }
     #endif
+}
+
+private extension LintOrAnalyzeOptions {
+    /// Options equivalent to running `swiftlint lint <paths>` without any other arguments.
+    init(paths: [URL]) {
+        self.init(mode: .lint,
+                  paths: paths,
+                  useSTDIN: false,
+                  configurationFiles: [],
+                  strict: false,
+                  lenient: false,
+                  forceExclude: false,
+                  useExcludingByPrefix: false,
+                  useScriptInputFiles: false,
+                  useScriptInputFileLists: false,
+                  benchmark: false,
+                  reporter: nil,
+                  baseline: nil,
+                  writeBaseline: nil,
+                  workingDirectory: nil,
+                  quiet: true,
+                  output: nil,
+                  progress: false,
+                  cachePath: nil,
+                  ignoreCache: true,
+                  enableAllRules: false,
+                  onlyRule: [],
+                  autocorrect: false,
+                  format: false,
+                  disableSourceKit: false,
+                  compilerLogPath: nil,
+                  compileCommands: nil,
+                  checkForUpdates: false
+        )
+    }
 }

--- a/Tests/IntegrationTests/ConfigPathResolutionTests.swift
+++ b/Tests/IntegrationTests/ConfigPathResolutionTests.swift
@@ -262,9 +262,9 @@ struct ConfigPathResolutionTests {
 
 private extension LintOrAnalyzeOptions {
     /// Options equivalent to running `swiftlint lint --quiet --no-cache <paths>`.
-    init(paths: [URL]) {
-        self.init(mode: .lint,
-                  paths: paths,
+    static func lint(paths: [URL]) -> Self {
+        Self(mode: .lint,
+             paths: paths,
                   useSTDIN: false,
                   configurationFiles: [],
                   strict: false,

--- a/Tests/IntegrationTests/ConfigPathResolutionTests.swift
+++ b/Tests/IntegrationTests/ConfigPathResolutionTests.swift
@@ -261,7 +261,7 @@ struct ConfigPathResolutionTests {
 }
 
 private extension LintOrAnalyzeOptions {
-    /// Options equivalent to running `swiftlint lint <paths>` without any other arguments.
+    /// Options equivalent to running `swiftlint lint --quiet --no-cache <paths>`.
     init(paths: [URL]) {
         self.init(mode: .lint,
                   paths: paths,
@@ -278,10 +278,12 @@ private extension LintOrAnalyzeOptions {
                   baseline: nil,
                   writeBaseline: nil,
                   workingDirectory: nil,
+                  // Avoid verbose stderr.
                   quiet: true,
                   output: nil,
                   progress: false,
                   cachePath: nil,
+                  // The default of visitLintableFiles does not use caches.
                   ignoreCache: true,
                   enableAllRules: false,
                   onlyRule: [],

--- a/Tests/IntegrationTests/ConfigPathResolutionTests.swift
+++ b/Tests/IntegrationTests/ConfigPathResolutionTests.swift
@@ -96,7 +96,7 @@ struct ConfigPathResolutionTests {
                 == ["ModuleA/File.swift", "ModuleA/Generated/File.swift", "ModuleB/File.swift"]
         )
     }
-    
+
     @Test
     func nestedConfigurationBasicWithCommandLine() async throws {
         #expect(try await visitedLintableFilePaths(

--- a/Tests/IntegrationTests/ConfigPathResolutionTests.swift
+++ b/Tests/IntegrationTests/ConfigPathResolutionTests.swift
@@ -124,6 +124,23 @@ struct ConfigPathResolutionTests {
             ) == ["project/Sources/Models/User.swift"]
         )
     }
+    
+    @Test
+    func wildCardPatternCountWithCommandLine() async throws {
+        // `swiftlint --quiet --no-cache Sources/Models/User.swift Sources/Models/User.generated.swift`
+        #expect(
+            try await visitedLintableFilePaths(
+                in: "_5_wildcard_patterns",
+                paths: ["project/Sources/Models/User.swift", "project/Sources/Models/User.generated.swift"]
+            ) == ["project/Sources/Models/User.generated.swift", "project/Sources/Models/User.swift"]
+        )
+
+        // `swiftlint --quiet --no-cache`
+            #expect(
+                try await visitedLintableFilePaths(in: "_5_wildcard_patterns", paths: [])
+                    == ["project/Sources/Generated/API.generated.swift", "project/Sources/Models/User.generated.swift", "project/Sources/Models/User.swift"]
+            )
+    }
 
     @Test
     func lintChildFolder() {

--- a/Tests/IntegrationTests/ConfigPathResolutionTests.swift
+++ b/Tests/IntegrationTests/ConfigPathResolutionTests.swift
@@ -263,36 +263,37 @@ struct ConfigPathResolutionTests {
 private extension LintOrAnalyzeOptions {
     /// Options equivalent to running `swiftlint lint --quiet --no-cache <paths>`.
     static func lint(paths: [URL]) -> Self {
-        Self(mode: .lint,
-             paths: paths,
-             useSTDIN: false,
-             configurationFiles: [],
-             strict: false,
-             lenient: false,
-             forceExclude: false,
-             useExcludingByPrefix: false,
-             useScriptInputFiles: false,
-             useScriptInputFileLists: false,
-             benchmark: false,
-             reporter: nil,
-             baseline: nil,
-             writeBaseline: nil,
-             workingDirectory: nil,
-             // Avoid verbose stderr.
-             quiet: true,
-             output: nil,
-             progress: false,
-             cachePath: nil,
-             // The default of visitLintableFiles does not use caches.
-             ignoreCache: true,
-             enableAllRules: false,
-             onlyRule: [],
-             autocorrect: false,
-             format: false,
-             disableSourceKit: false,
-             compilerLogPath: nil,
-             compileCommands: nil,
-             checkForUpdates: false
+        Self(
+            mode: .lint,
+            paths: paths,
+            useSTDIN: false,
+            configurationFiles: [],
+            strict: false,
+            lenient: false,
+            forceExclude: false,
+            useExcludingByPrefix: false,
+            useScriptInputFiles: false,
+            useScriptInputFileLists: false,
+            benchmark: false,
+            reporter: nil,
+            baseline: nil,
+            writeBaseline: nil,
+            workingDirectory: nil,
+            // Avoid verbose stderr.
+            quiet: true,
+            output: nil,
+            progress: false,
+            cachePath: nil,
+            // The default of visitLintableFiles does not use caches.
+            ignoreCache: true,
+            enableAllRules: false,
+            onlyRule: [],
+            autocorrect: false,
+            format: false,
+            disableSourceKit: false,
+            compilerLogPath: nil,
+            compileCommands: nil,
+            checkForUpdates: false
         )
     }
 }

--- a/Tests/IntegrationTests/ConfigPathResolutionTests.swift
+++ b/Tests/IntegrationTests/ConfigPathResolutionTests.swift
@@ -37,7 +37,7 @@ struct ConfigPathResolutionTests {
         return try await CurrentWorkingDirectory.$url.withValue(scenarioPath) {
             let config = Configuration(configurationFiles: [])
             let files = try await config.visitLintableFiles(
-                options: LintOrAnalyzeOptions(paths: paths.map { $0.url() }),
+                options: .lint(paths: paths.map { $0.url() }),
                 storage: RuleStorage(),
                 visitorBlock: { _ in
                     // Only the set of visited files matters, not the violations found in them.
@@ -265,34 +265,34 @@ private extension LintOrAnalyzeOptions {
     static func lint(paths: [URL]) -> Self {
         Self(mode: .lint,
              paths: paths,
-                  useSTDIN: false,
-                  configurationFiles: [],
-                  strict: false,
-                  lenient: false,
-                  forceExclude: false,
-                  useExcludingByPrefix: false,
-                  useScriptInputFiles: false,
-                  useScriptInputFileLists: false,
-                  benchmark: false,
-                  reporter: nil,
-                  baseline: nil,
-                  writeBaseline: nil,
-                  workingDirectory: nil,
-                  // Avoid verbose stderr.
-                  quiet: true,
-                  output: nil,
-                  progress: false,
-                  cachePath: nil,
-                  // The default of visitLintableFiles does not use caches.
-                  ignoreCache: true,
-                  enableAllRules: false,
-                  onlyRule: [],
-                  autocorrect: false,
-                  format: false,
-                  disableSourceKit: false,
-                  compilerLogPath: nil,
-                  compileCommands: nil,
-                  checkForUpdates: false
+             useSTDIN: false,
+             configurationFiles: [],
+             strict: false,
+             lenient: false,
+             forceExclude: false,
+             useExcludingByPrefix: false,
+             useScriptInputFiles: false,
+             useScriptInputFileLists: false,
+             benchmark: false,
+             reporter: nil,
+             baseline: nil,
+             writeBaseline: nil,
+             workingDirectory: nil,
+             // Avoid verbose stderr.
+             quiet: true,
+             output: nil,
+             progress: false,
+             cachePath: nil,
+             // The default of visitLintableFiles does not use caches.
+             ignoreCache: true,
+             enableAllRules: false,
+             onlyRule: [],
+             autocorrect: false,
+             format: false,
+             disableSourceKit: false,
+             compilerLogPath: nil,
+             compileCommands: nil,
+             checkForUpdates: false
         )
     }
 }

--- a/Tests/IntegrationTests/ConfigPathResolutionTests.swift
+++ b/Tests/IntegrationTests/ConfigPathResolutionTests.swift
@@ -32,7 +32,7 @@ struct ConfigPathResolutionTests {
 
     /// Returns the paths of the files that are actually linted when the given paths are passed as command line
     /// arguments, relative to the fixture directory.
-    private func visitedFilePaths(in scenario: String, paths: [String]) async throws -> [String] {
+    private func visitedLintableFilePaths(in scenario: String, paths: [String]) async throws -> [String] {
         let scenarioPath = fixturePath(scenario)
         return try await CurrentWorkingDirectory.$url.withValue(scenarioPath) {
             let config = Configuration(configurationFiles: [])
@@ -95,6 +95,14 @@ struct ConfigPathResolutionTests {
             lintableFilePaths(in: "_4_nested_basic", configFile: ".swiftlint.yml")
                 == ["ModuleA/File.swift", "ModuleA/Generated/File.swift", "ModuleB/File.swift"]
         )
+    }
+    
+    @Test
+    func nestedConfigurationBasicWithCommandLine() async throws {
+        #expect(try await visitedLintableFilePaths(
+            in: "_4_nested_basic",
+            paths: ["ModuleA/File.swift", "ModuleA/Generated/File.swift", "ModuleB/File.swift"]
+        ) == ["ModuleA/File.swift", "ModuleB/File.swift"])
     }
 
     @Test
@@ -179,18 +187,6 @@ struct ConfigPathResolutionTests {
                     .contains("explicit_type_interface")
             )
         }
-    }
-
-    @Test
-    func nestedConfigurationExclusionAppliesToFilePathArguments() async throws {
-        // Passing a file explicitly bypasses the exclusion filter while collecting the files to lint. The
-        // exclusions of the configuration applying to each file must still be honored when grouping them.
-        let visitedPaths = try await visitedFilePaths(
-            in: "_4_nested_basic",
-            paths: ["ModuleA/File.swift", "ModuleA/Generated/File.swift", "ModuleB/File.swift"]
-        )
-
-        #expect(visitedPaths == ["ModuleA/File.swift", "ModuleB/File.swift"])
     }
 
     @Test

--- a/Tests/IntegrationTests/Resources/_10_relative_path_arguments/.swiftlint.yml
+++ b/Tests/IntegrationTests/Resources/_10_relative_path_arguments/.swiftlint.yml
@@ -1,0 +1,3 @@
+# This configuration lives above the working directory and must never be picked up when linting in `project`.
+excluded:
+  - project

--- a/Tests/IntegrationTests/Resources/_10_relative_path_arguments/project/.swiftlint.yml
+++ b/Tests/IntegrationTests/Resources/_10_relative_path_arguments/project/.swiftlint.yml
@@ -1,0 +1,2 @@
+disabled_rules:
+  - line_length

--- a/Tests/IntegrationTests/Resources/_10_relative_path_arguments/project/Sources/File.swift
+++ b/Tests/IntegrationTests/Resources/_10_relative_path_arguments/project/Sources/File.swift
@@ -1,0 +1,4 @@
+// Must be linted when passed as a relative path argument
+struct ProjectFile {
+    let name: String
+}


### PR DESCRIPTION
## Summary

This commit stops resolving a path to an absolute path in `Configuration.groupFiles`. This will resolve the issue mentioned in comments in #6795 that the `excluded` configuration in .swiftlint.yml is ignored when file paths are passed as arguments.

## Context
The `excluded` configuration is sometimes ignored since v0.64.0  (https://github.com/realm/SwiftLint/issues/6795#issuecomment-4953871888). The issue seems to happen when file paths are passed as arguments (for example, running`swiftlint Foo.swift Bar.swift` instead of `swiftlint .` or `swiftlint`).

Using a debugger, I found that `excludedRelativePath` in the diff was actually not a relative path, because it had  already been resolved in [Configuration+Parsing.swift](https://github.com/realm/SwiftLint/blob/e4d82f13dcd25583c33caec013b084376db5125e/Source/SwiftLintFramework/Configuration/Configuration%2BParsing.swift#L104). As a result, `let excludedPath` in the diff was being doubly-resolved to an invalid path like `"file:///Users/username/projects/foo/Users/username/projects/foo/MyPackage/Package.swift"`.

## Test
- [x] With [this reproduction setup](https://github.com/realm/SwiftLint/issues/6795#issuecomment-4953871888) and with `Arguments Passed On Launch` `NoProblem.swift MyPackage/Package.swift`, running the swiftlint scheme:
  - [x] Before this PR: Failed
  - [x] After this PR: Succeeded

## Comment
- I couldn't find an appropriate place to put unit tests. Any suggestions would be appreciated.
- I'm new to this codebase. Sorry if something is wrong.
