### PR TITLE
Fix closure_end_indentation corrupting CRLF files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@
   [#6798](https://github.com/realm/SwiftLint/issues/6798)
   [#6799](https://github.com/realm/SwiftLint/issues/6799)
 
+* Fix `closure_end_indentation` moving closing braces to column 1 in files
+  with CRLF line endings when running `swiftlint --fix`.  
+  [sjh9714](https://github.com/sjh9714)
+  [#6598](https://github.com/realm/SwiftLint/issues/6598)
+
 ## 0.65.0: Fresh Folded Fixtures
 
 ### Breaking

--- a/Source/SwiftLintBuiltInRules/Rules/Style/ClosureEndIndentationRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/ClosureEndIndentationRule.swift
@@ -195,10 +195,13 @@ private extension ClosureEndIndentationRule {
 
         /// Calculates the column of the first non-whitespace character on a given line.
         private func getFirstNonWhitespaceColumn(onLine lineNumber: Int) -> Int {
-            guard lineNumber > 0, lineNumber <= file.lines.count else {
+            // Use the lines seen by `locationConverter`, which produced `lineNumber`.
+            // `file.lines` counts CRLF line endings differently, corrupting files.
+            let sourceLines = locationConverter.sourceLines
+            guard lineNumber > 0, lineNumber <= sourceLines.count else {
                 return 1 // Should not happen
             }
-            let lineContent = file.lines[lineNumber - 1].content
+            let lineContent = sourceLines[lineNumber - 1]
 
             if let firstCharIndex = lineContent.firstIndex(where: { !$0.isWhitespace }) {
                 return lineContent.distance(from: lineContent.startIndex, to: firstCharIndex) + 1

--- a/Tests/BuiltInRulesTests/ClosureEndIndentationRuleTests.swift
+++ b/Tests/BuiltInRulesTests/ClosureEndIndentationRuleTests.swift
@@ -1,0 +1,53 @@
+import TestHelpers
+import Testing
+
+@testable import SwiftLintBuiltInRules
+
+@Suite(.rulesRegistered)
+struct ClosureEndIndentationRuleTests {
+    @Test
+    func crlfLineEndings() {
+        let correctlyIndented = [
+            "struct TestView: View {",
+            "    var body: some View {",
+            "        HStack {",
+            "            VStack {",
+            "                Text(\"Hello\")",
+            "                Spacer()",
+            "            }",
+            "        }",
+            "    }",
+            "}",
+            "",
+        ].joined(separator: "\r\n")
+        let misindented = [
+            "struct S {",
+            "    func f() {",
+            "        run {",
+            "            print(\"hi\")",
+            "            ↓}",
+            "    }",
+            "}",
+            "",
+        ].joined(separator: "\r\n")
+        let corrected = [
+            "struct S {",
+            "    func f() {",
+            "        run {",
+            "            print(\"hi\")",
+            "        }",
+            "    }",
+            "}",
+            "",
+        ].joined(separator: "\r\n")
+
+        // testWrappingInString is disabled because the test helper's string
+        // wrapping escapes only "\n", leaving bare "\r" bytes in the literal.
+        let description = ClosureEndIndentationRule.description
+            .with(nonTriggeringExamples: [Example(code: correctlyIndented)])
+            .with(triggeringExamples: [Example(code: misindented, testWrappingInString: false)])
+            .with(corrections: [Example(code: misindented): Example(code: corrected)])
+
+        verifyRule(description)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #6598.

Running `swiftlint --fix` with `closure_end_indentation` on a file with CRLF
(`\r\n`) line endings moved the closing braces of multi-line closures to
column 1, corrupting the file. LF files were unaffected.

The rule computed the expected indentation by indexing SourceKitten's
`file.lines` with a line number produced by SwiftSyntax's
`locationConverter`. The two disagree on CRLF: SwiftSyntax counts `\r\n` as
one newline, while `StringView` splits it into `\n` and `\r` separately,
inserting a phantom empty line after every real line. On CRLF files the
anchor-line lookup therefore hit the wrong (often empty) line, making the
expected indentation column 0.

## Changes

- `ClosureEndIndentationRule.Visitor.getFirstNonWhitespaceColumn(onLine:)`
  now reads the anchor line from `locationConverter.sourceLines`, the same
  line-numbering domain that produced the line number. No behavior change for
  LF files.
- Regression test with CRLF examples: a correctly indented closure no longer
  triggers, and a genuinely misindented closing brace is corrected to the
  right column while CRLF endings are preserved. (`testWrappingInString` is
  disabled for the triggering example because the test helper's string
  wrapping escapes only `\n`, leaving bare `\r` bytes in the literal.)
- CHANGELOG entry.

## Testing

- `swift test --filter ClosureEndIndentationRule` — new CRLF test fails
  before the fix (closing braces pulled to column 1) and passes after;
  the generated default-examples suite also passes.
- `swift test` — full suite locally (1063 tests), except `MacroTests`, which
  cannot run in this environment (no XCTest under Command Line Tools). One
  unrelated suite (`UnusedDeclarationRuleGeneratedTests`) fails identically
  with and without this change in my environment.
- Manual check of the reproduction from #6598: on the corrupted file the fix
  restores the correct indentation; on the correctly indented CRLF file
  `swiftlint --fix` makes no changes and `swiftlint` reports 0 violations,
  with CRLF endings preserved throughout.