### PR TITLE
Add `allow_compact_empty_blocks` option to `no_empty_block` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@
   them across the built-in rules.  
   [ZevEisenberg](https://github.com/ZevEisenberg)
 
+* Add `allow_compact_empty_blocks` option to the `no_empty_block` rule to
+  allow empty blocks written compactly as `{}` while still flagging empty
+  blocks with any whitespace or newlines between the braces.  
+  [arimu1](https://github.com/arimu1)
+  [#6839](https://github.com/realm/SwiftLint/issues/6839)
+
 ### Bug Fixes
 
 * Fix baseline writing to store file locations as paths relative to the current working directory,

--- a/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoEmptyBlockRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Idiomatic/NoEmptyBlockRule.swift
@@ -104,6 +104,13 @@ struct NoEmptyBlockRule: Rule {
             f {}
             {}()
             """.asExample(configuration: ["disabled_block_types": ["closure_blocks"]]),
+            """
+            func f() {}
+
+            var flag = true {
+                willSet {}
+            }
+            """.asExample(configuration: ["allow_compact_empty_blocks": true]),
         ]),
         triggeringExamples: #examples([
             """
@@ -148,6 +155,14 @@ struct NoEmptyBlockRule: Rule {
             """
             Button ↓{} label: ↓{}
             """,
+            """
+            func f() ↓{ }
+
+            var flag = true {
+                willSet ↓{
+                }
+            }
+            """.asExample(configuration: ["allow_compact_empty_blocks": true]),
         ])
     )
 }
@@ -171,6 +186,11 @@ private extension NoEmptyBlockRule {
             guard node.statements.isEmpty,
                   !node.leftBrace.trailingTrivia.containsComments,
                   !node.rightBrace.leadingTrivia.containsComments else {
+                return
+            }
+            if configuration.allowCompactEmptyBlocks,
+               node.leftBrace.trailingTrivia.isEmpty,
+               node.rightBrace.leadingTrivia.isEmpty {
                 return
             }
             violations.append(node.leftBrace.positionAfterSkippingLeadingTrivia)

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NoEmptyBlockConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NoEmptyBlockConfiguration.swift
@@ -18,6 +18,9 @@ struct NoEmptyBlockConfiguration: SeverityBasedRuleConfiguration {
     @ConfigurationElement(key: "disabled_block_types")
     private(set) var disabledBlockTypes: [CodeBlockType] = []
 
+    @ConfigurationElement(key: "allow_compact_empty_blocks")
+    private(set) var allowCompactEmptyBlocks = false
+
     var enabledBlockTypes: Set<CodeBlockType> {
         CodeBlockType.all.subtracting(disabledBlockTypes)
     }

--- a/Tests/BuiltInRulesTests/NoEmptyBlockConfigurationTests.swift
+++ b/Tests/BuiltInRulesTests/NoEmptyBlockConfigurationTests.swift
@@ -11,6 +11,7 @@ struct NoEmptyBlockConfigurationTests {
         let config = NoEmptyBlockConfiguration()
         #expect(config.severityConfiguration.severity == .warning)
         #expect(config.enabledBlockTypes == NoEmptyBlockConfiguration.CodeBlockType.all)
+        #expect(!config.allowCompactEmptyBlocks)
     }
 
     @Test
@@ -20,10 +21,12 @@ struct NoEmptyBlockConfigurationTests {
             configuration: [
                 "severity": "error",
                 "disabled_block_types": ["function_bodies"],
+                "allow_compact_empty_blocks": true,
             ]
         )
         #expect(config.severityConfiguration.severity == .error)
         #expect(config.enabledBlockTypes == Set([.initializerBodies, .statementBlocks, .closureBlocks]))
+        #expect(config.allowCompactEmptyBlocks)
     }
 
     @Test
@@ -59,7 +62,8 @@ struct NoEmptyBlockConfigurationTests {
         try config.apply(configuration: ["disabled_block_types": ["initializer_bodies", "statement_blocks"]])
         #expect(
             RuleConfigurationDescription.from(configuration: config).oneLiner()
-                == "severity: warning; disabled_block_types: [initializer_bodies, statement_blocks]"
+                == "severity: warning; disabled_block_types: [initializer_bodies, statement_blocks]; "
+                + "allow_compact_empty_blocks: false"
         )
     }
 }

--- a/Tests/IntegrationTests/Resources/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/Resources/default_rule_configurations.yml
@@ -751,6 +751,7 @@ nimble_operator:
 no_empty_block:
   severity: warning
   disabled_block_types: []
+  allow_compact_empty_blocks: false
   meta:
     opt-in: true
     correctable: false


### PR DESCRIPTION
## Summary

- Add `allow_compact_empty_blocks` boolean configuration option to `no_empty_block` (defaults to `false`).
- When enabled, compact empty blocks written as `{}` are allowed, while empty blocks with whitespace or newlines between the braces are still flagged.
- Update rule examples, configuration tests, default rule configurations, and CHANGELOG.

Fixes #6839

## Test plan

- [x] `swift build --target SwiftLintBuiltInRules` passes locally
- [ ] `swift test --filter NoEmptyBlock` — blocked locally (no full Xcode; `swift test` fails on missing XCTest module)
- [ ] `xcodebuild -scheme swiftlint test -destination 'platform=macOS'` — blocked locally (only Command Line Tools installed)
- [ ] CI