### PR TITLE
Fix line_length URL detection for property accesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@
   [Yurii Bakurov](https://github.com/Yurii201811)
   [#6817](https://github.com/realm/SwiftLint/issues/6817)
 
+* Fix `line_length` with `ignores_urls` enabled incorrectly ignoring property
+  accesses whose member names are valid top-level domains.  
+  [Arthur Liu](https://github.com/thliu21)
+  [#6811](https://github.com/realm/SwiftLint/issues/6811)
+
 * Fix baseline writing to store file locations as paths relative to the current working directory,
   restoring baseline portability and avoiding absolute `file://` paths in generated baseline files.  
   [SimplyDanny](https://github.com/SimplyDanny)

--- a/Source/SwiftLintBuiltInRules/Rules/Metrics/LineLengthRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Metrics/LineLengthRule.swift
@@ -252,7 +252,22 @@ private extension String {
             guard let urlDetector = try? NSDataDetector(types: types) else {
                 return self
             }
-            return urlDetector.stringByReplacingMatches(in: self, options: [], range: range, withTemplate: "")
+            var result = self
+            for match in urlDetector.matches(in: self, options: [], range: range).reversed() {
+                guard let matchedRange = Range(match.range, in: self),
+                      String(self[matchedRange]).hasExplicitURLSyntax,
+                      let replacementRange = Range(match.range, in: result) else {
+                    continue
+                }
+                result.removeSubrange(replacementRange)
+            }
+            return result
         #endif
+    }
+
+    private var hasExplicitURLSyntax: Bool {
+        let pattern =
+            "(?i)^(?:[a-z][\\w-]+:(?:/{1,3}|[a-z0-9%])|www\\d{0,3}[.]|[a-z0-9.\\-]+[.][a-z]{2,4}/)"
+        return regex(pattern).firstMatch(in: self, range: fullNSRange) != nil
     }
 }

--- a/Tests/BuiltInRulesTests/LineLengthRuleTests.swift
+++ b/Tests/BuiltInRulesTests/LineLengthRuleTests.swift
@@ -184,9 +184,16 @@ struct LineLengthRuleTests {
     @Test
     func lineLengthWithIgnoreURLsEnabled() {
         let url = "https://github.com/realm/SwiftLint"
-        let triggeringLines = #examples([(String(repeating: "/", count: 121) + "\(url)\n").asExample()])
+        let triggeringLines = #examples([
+            (String(repeating: "/", count: 121) + "\(url)\n").asExample(),
+            ("let value = " + String(repeating: "a", count: 99) + " + post.id\n").asExample(),
+            ("let value = " + String(repeating: "a", count: 97) + " + user.name\n").asExample(),
+            ("let value = " + String(repeating: "a", count: 96) + " + offer.info\n").asExample(),
+        ])
         let nonTriggeringLines = #examples([
             ("\(url) " + String(repeating: "/", count: 118) + " \(url)\n").asExample(),
+            ("www.example.com " + String(repeating: "/", count: 118) + " www.example.com\n").asExample(),
+            ("example.com/path " + String(repeating: "/", count: 118) + " example.com/path\n").asExample(),
             ("\(url)/" + String(repeating: "a", count: 120)).asExample(),
         ])
 


### PR DESCRIPTION
## Summary

- only strip `NSDataDetector` matches that have explicit URL syntax
- keep scheme, `www.`, and domain-with-path URLs aligned with the Linux/Windows behavior
- add regressions for property accesses whose member names are valid top-level domains

Fixes #6811

## Testing

- `swift test --filter LineLengthRuleTests.lineLengthWithIgnoreURLsEnabled`
- `swift test --filter LineLength`
- `swift test --quiet`
- strict SwiftLint on the two changed Swift files
