### PR TITLE
Update SourceKitten to 0.38.0

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,7 +14,7 @@ bazel_dep(name = "rules_cc", version = "0.2.22")
 bazel_dep(name = "rules_shell", version = "0.8.0", repo_name = "build_bazel_rules_shell")
 bazel_dep(name = "rules_swift", version = "3.6.1", max_compatibility_level = 3, repo_name = "build_bazel_rules_swift")
 
-bazel_dep(name = "sourcekitten", version = "0.37.3", repo_name = "SourceKittenFramework")
+bazel_dep(name = "sourcekitten", version = "0.38.0", repo_name = "SourceKittenFramework")
 bazel_dep(name = "swift_argument_parser", version = "1.7.1", repo_name = "SwiftArgumentParser")
 bazel_dep(name = "swift-filename-matcher", version = "2.0.1", repo_name = "FilenameMatcher")
 bazel_dep(name = "yams", version = "6.2.2", repo_name = "Yams")

--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/jpsim/SourceKitten.git",
       "state" : {
-        "revision" : "6529c17fe80dd94843a3df7ed3e6a239790d5c91",
-        "version" : "0.37.3"
+        "revision" : "821fc0eaa7c07fc98df1e9d3d43371cace697644",
+        "version" : "0.38.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMajor(from: "1.6.1")),
         .package(url: "https://github.com/swiftlang/swift-syntax.git", exact: "605.0.0-prerelease-2026-06-26"),
-        .package(url: "https://github.com/jpsim/SourceKitten.git", .upToNextMajor(from: "0.37.2")),
+        .package(url: "https://github.com/jpsim/SourceKitten.git", .upToNextMajor(from: "0.38.0")),
         .package(url: "https://github.com/jpsim/Yams.git", .upToNextMajor(from: "6.0.2")),
         .package(url: "https://github.com/scottrhoyt/SwiftyTextTable.git", .upToNextMajor(from: "0.9.0")),
         .package(url: "https://github.com/JohnSundell/CollectionConcurrencyKit.git", .upToNextMajor(from: "0.2.0")),

--- a/bazel/repos.bzl
+++ b/bazel/repos.bzl
@@ -5,9 +5,9 @@ def swiftlint_repos(bzlmod = False):
     if not bzlmod:
         http_archive(
             name = "SourceKittenFramework",
-            sha256 = "604d2e5e547ef4280c959760cba0c9bd9be759c9555796cf7a73d9e1c9bcfc90",
-            strip_prefix = "SourceKitten-0.37.2",
-            url = "https://github.com/jpsim/SourceKitten/releases/download/0.37.2/SourceKitten-0.37.2.tar.gz",
+            sha256 = "7eaf0b7acaa2ae4bebf49c686641f9e50b0044c1a91d3c75121ecf698d7fbb91",
+            strip_prefix = "SourceKitten-0.38.0",
+            url = "https://github.com/jpsim/SourceKitten/releases/download/0.38.0/SourceKitten-0.38.0.tar.gz",
         )
 
         http_archive(


### PR DESCRIPTION
[SourceKitten 0.38.0](https://github.com/jpsim/SourceKitten/releases/tag/0.38.0) adds the syntax, attribute and declaration kinds introduced in Swift 6.1 through 6.3, reports a clearer error when `sourcekitdInProc` fails to load, and stops `absolutePathRepresentation()` reaching for the working directory when the path is already absolute.

The new declaration kinds are the main reason to take it.

The working-directory change is small but real, and it is visible in SourceKitten's diff. In 0.37.3 the default argument is evaluated at every call site, so the `getcwd` happens even when the early return is taken:

```swift
public func absolutePathRepresentation(rootDirectory: String = FileManager.default.currentDirectoryPath) -> String {
    if isAbsolutePath { return expandingTildeInPath }
```

In 0.38.0 it is resolved only when it is actually needed:

```swift
public func absolutePathRepresentation(rootDirectory: String? = nil) -> String {
    if isAbsolutePath { return expandingTildeInPath }
    let rootDirectory = rootDirectory ?? FileManager.default.currentDirectoryPath
```

`File.init(path:)` calls it, so linting a code base of several thousand files makes that many syscalls it no longer needs.

### Measured

DuckDuckGo, 6,747 linted files, the two builds run interleaved on an otherwise idle machine:

| | 0.37.3 | 0.38.0 |
| --- | --- | --- |
| one cheap rule, so per-file overhead is what is being measured — best / median of 7 | 1.08s / 1.16s | 1.05s / 1.09s |
| `--enable-all-rules` — best / median of 5 | 17.05s / 17.71s | 16.67s / 17.09s |

The first row is the one attributable to this change: 4–10µs per file, the right order for a syscall that no longer happens. The second row is small enough that I would not lean on it.

### Verification

- Builds with SwiftPM and with Bazel. `bazel build --config release :swiftlint` completes, and `bazel mod graph` shows `sourcekitten@0.38.0`, so the version is in the Bazel Central Registry and bzlmod resolves it.
- Same violations before and after, with `--enable-all-rules`: 590,289 on DuckDuckGo, 64,834 on realm-swift and 26,077 on SwiftLint's own source — 681,200 in total, identical once sorted. The raw JSON ordering is not stable, but that is equally true of two runs of the same binary, since linting is parallel.
- The tarball in `bazel/repos.bzl` checksums to the declared `7eaf0b7a…`.
- Test suite passes. `ConfigPathResolutionTests.symlinkedFileAndFolderAreFollowed()` fails on this machine, but it fails identically on `main` without this change, so it is unrelated.

All four pins move together — `Package.swift`, `Package.resolved`, `MODULE.bazel` and `bazel/repos.bzl` — so SwiftPM and Bazel stay on the same version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
