### PR TITLE
Make collection_alignment linear in file size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 ### Enhancements
 
+* Speed up the `collection_alignment` rule, which read the whole file's
+  source lines once per element of a dictionary literal.  
+  [Brett-Best](https://github.com/Brett-Best)
+
 * Add `#examples` and `#corrections` macros that expand lists and
   dictionaries of code strings into `Example`s, reducing boilerplate when
   defining a rule's triggering/non-triggering examples and corrections. Adopt

--- a/Source/SwiftLintBuiltInRules/Rules/Style/CollectionAlignmentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/CollectionAlignmentRule.swift
@@ -17,6 +17,11 @@ struct CollectionAlignmentRule: Rule {
 
 private extension CollectionAlignmentRule {
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
+        // Computed once per file: `SourceLocationConverter.sourceLines` materializes every line of the
+        // file as a new `[String]` on each access, and the dictionary path below reads it once per
+        // element, which is quadratic in files holding large dictionary literals.
+        private lazy var sourceLines = locationConverter.sourceLines
+
         override func visitPost(_ node: ArrayExprSyntax) {
             let locations = node.elements.map { element in
                 locationConverter.location(for: element.positionAfterSkippingLeadingTrivia)
@@ -32,7 +37,7 @@ private extension CollectionAlignmentRule {
 
                 let graphemeColumn: Int
                 let graphemeClusters = String(
-                    locationConverter.sourceLines[location.line - 1].utf8.prefix(location.column - 1)
+                    sourceLines[location.line - 1].utf8.prefix(location.column - 1)
                 )
                 if let graphemeClusters {
                     graphemeColumn = graphemeClusters.count + 1


### PR DESCRIPTION
`collection_alignment`'s visitor reads `locationConverter.sourceLines` once for **every element** of a dictionary literal:

```swift
let graphemeClusters = String(
    locationConverter.sourceLines[location.line - 1].utf8.prefix(location.column - 1)
)
```

`sourceLines` is a computed property in swift-syntax, and it rebuilds the entire file each time it is read:

```swift
public var sourceLines: [String] {
  var result: [String] = []
  self.forEachSourceLine { line in
    result.append(String(syntaxText: line))
  }
  return result
}
```

So a dictionary of _n_ entries in a file of _m_ lines allocates _n_ × _m_ strings in order to look at _n_ lines. Hoisting the property into a `lazy var` on the visitor computes it once per file and makes the rule linear.

### Scaling

One file containing a single dictionary literal with the keys on their own lines, best of three:

| entries | before | after |
| ---: | ---: | ---: |
| 1,000 | 0.09s | 0.06s |
| 2,000 | 0.16s | 0.06s |
| 4,000 | 0.47s | 0.07s |
| 8,000 | 1.71s | 0.07s |

Before, the time roughly quadruples each time the entry count doubles; after, it is flat. The file is correctly aligned, so both builds report no violations on it — every one of those 1.71 seconds is spent to find nothing.

```bash
python3 - <<'EOF' > Table.swift
print("let table: [String: Int] = [")
for i in range(8000):
    print('    "key%d":' % i)
    print("        %d," % i)
print("]")
EOF
swiftlint lint --no-cache --quiet --only-rule collection_alignment Table.swift
```

### No behaviour change

Violation counts are identical before and after on realm-swift (0) and DuckDuckGo (84), each linted with its own configuration, and the test suite passes.

Repositories made up of many small files are unaffected in either direction, which is what a defect quadratic in file size should do: DuckDuckGo (6,824 files averaging 186 lines) measures 1.40s before and 1.41s after — within noise.

### Scope

The same `locationConverter.sourceLines` access pattern appears in two other rules: `vertical_parameter_alignment`, where `graphemeColumn(line:column:)` reads it once per parameter, and `closure_end_indentation`, where `getFirstNonWhitespaceColumn(onLine:)` reads it once per line. Both look like the same defect, but this change is deliberately limited to `collection_alignment` — happy to follow up on the others separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
