### PR TITLE
Cache allowedSymbolsAndAlphanumerics in NameConfiguration

### DIFF
--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NameConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NameConfiguration.swift
@@ -6,6 +6,8 @@ struct NameConfiguration<Parent: Rule>: RuleConfiguration, InlinableOptionType {
     typealias SeverityLevels = SeverityLevelsConfiguration<Parent>
     typealias StartWithLowercaseConfiguration = ChildOptionSeverityConfiguration<Parent>
 
+    private(set) var allowedSymbolsAndAlphanumerics = CharacterSet.alphanumerics
+
     @ConfigurationElement(key: "min_length")
     private(set) var minLength = SeverityLevels(warning: 0, error: 0)
     @ConfigurationElement(key: "max_length")
@@ -13,7 +15,12 @@ struct NameConfiguration<Parent: Rule>: RuleConfiguration, InlinableOptionType {
     @ConfigurationElement(key: "excluded")
     private(set) var excludedRegularExpressions = Set<RegularExpression>()
     @ConfigurationElement(key: "allowed_symbols")
-    private(set) var allowedSymbols = Set<String>()
+    private(set) var allowedSymbols = Set<String>() {
+        didSet {
+            allowedSymbolsAndAlphanumerics = CharacterSet(charactersIn: allowedSymbols.joined())
+            allowedSymbolsAndAlphanumerics.formUnion(.alphanumerics)
+        }
+    }
     @ConfigurationElement(key: "unallowed_symbols_severity")
     private(set) var unallowedSymbolsSeverity = Severity.error
     @ConfigurationElement(key: "validates_start_with_lowercase")
@@ -25,10 +32,6 @@ struct NameConfiguration<Parent: Rule>: RuleConfiguration, InlinableOptionType {
 
     var maxLengthThreshold: Int {
         min(maxLength.warning, maxLength.error ?? maxLength.warning)
-    }
-
-    var allowedSymbolsAndAlphanumerics: CharacterSet {
-        CharacterSet(charactersIn: allowedSymbols.joined()).union(.alphanumerics)
     }
 
     init(minLengthWarning: Int,

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NameConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NameConfiguration.swift
@@ -17,8 +17,10 @@ struct NameConfiguration<Parent: Rule>: RuleConfiguration, InlinableOptionType {
     @ConfigurationElement(key: "allowed_symbols")
     private(set) var allowedSymbols = Set<String>() {
         didSet {
-            allowedSymbolsAndAlphanumerics = CharacterSet(charactersIn: allowedSymbols.joined())
-            allowedSymbolsAndAlphanumerics.formUnion(.alphanumerics)
+            if allowedSymbols != oldValue {
+                allowedSymbolsAndAlphanumerics = CharacterSet(charactersIn: allowedSymbols.joined())
+                allowedSymbolsAndAlphanumerics.formUnion(.alphanumerics)
+            }
         }
     }
     @ConfigurationElement(key: "unallowed_symbols_severity")


### PR DESCRIPTION
`NameConfiguration.allowedSymbolsAndAlphanumerics` currently rebuilds a `CharacterSet` union every time a checked name reaches `containsOnlyAllowedCharacters`. The allowed-symbol configuration is stable for the lifetime of a configuration, so repeating that CoreFoundation work is unnecessary.

This caches the union and refreshes it in the initializer and when `allowedSymbols` is applied from configuration. Reads now return the cached set while preserving configuration behavior.

### Verification

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build -c release --product swiftlint`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test`: 370 tests in 73 suites passed.
- `.build/release/swiftlint lint --strict --quiet Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/NameConfiguration.swift`: clean.
- Sorted JSON violation lists matched:
  - DuckDuckGo, default configuration: 84 before, 84 after.
  - realm-swift, default configuration: 0 before, 0 after.
- The comparisons sorted by file, line, character, rule, reason, and severity; raw JSON order is not stable for parallel linting.

### Measurement

The two binaries were run interleaved for five iterations with the relevant rule commands:

```bash
/usr/bin/time -p <baseline> lint --no-cache --quiet --only-rule identifier_name >/dev/null
/usr/bin/time -p <change> lint --no-cache --quiet --only-rule identifier_name >/dev/null
/usr/bin/time -p <baseline> lint --no-cache --quiet --only-rule type_name >/dev/null
/usr/bin/time -p <change> lint --no-cache --quiet --only-rule type_name >/dev/null
```

| Corpus / rule | Baseline median | Change median |
| --- | ---: | ---: |
| DuckDuckGo / `identifier_name` | 2.65s | 2.72s |
| DuckDuckGo / `type_name` | 1.93s | 1.94s |
| realm-swift / `type_name` | 0.18s | 0.18s |
| Synthetic names / both rules | 0.62s | 0.63s |

The measured corpora did not show a reproducible end-to-end speedup; these runs were within noise. The change nevertheless removes repeated character-set construction from the per-name path, and the parity checks confirm that configured allowed symbols retain their behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
