### PR TITLE
Reduce per-file filesystem and gating overhead

### DIFF
--- a/Source/SwiftLintFramework/Configuration/Configuration+RulesWrapper.swift
+++ b/Source/SwiftLintFramework/Configuration/Configuration+RulesWrapper.swift
@@ -9,6 +9,8 @@ internal extension Configuration {
         let allRulesWrapped: [ConfigurationRuleWrapper]
         internal let mode: RulesMode
         private let aliasResolver: (String) -> String
+        /// Swift versions are process constants, so compute each rule type's support once per shared configuration.
+        private let swiftVersionSupportByRuleType: [ObjectIdentifier: Bool]
 
         private var invalidRuleIdsWarnedAbout: Set<String> = []
         private var customRulesIdentifiers: Set<String> {
@@ -109,6 +111,10 @@ internal extension Configuration {
         ) {
             self.allRulesWrapped = allRulesWrapped
             self.aliasResolver = aliasResolver
+            swiftVersionSupportByRuleType = Dictionary(uniqueKeysWithValues: allRulesWrapped.map {
+                let ruleType = type(of: $0.rule)
+                return (ObjectIdentifier(ruleType), SwiftVersion.current >= ruleType.description.minSwiftVersion)
+            })
             let mode = mode.applied(aliasResolver: aliasResolver)
 
             // If this instance originates from a merging process, some custom rules may be treated as not activated
@@ -116,6 +122,11 @@ internal extension Configuration {
             self.mode = originatesFromMergingProcess
                 ? mode
                 : mode.activateCustomRuleIdentifiers(allRulesWrapped: allRulesWrapped)
+        }
+
+        func supportsCurrentSwiftVersion(_ ruleType: any Rule.Type) -> Bool {
+            swiftVersionSupportByRuleType[ObjectIdentifier(ruleType)] ??
+                (SwiftVersion.current >= ruleType.description.minSwiftVersion)
         }
 
         // MARK: - Methods: Validation

--- a/Source/SwiftLintFramework/Extensions/FileManager+SwiftLint.swift
+++ b/Source/SwiftLintFramework/Extensions/FileManager+SwiftLint.swift
@@ -133,6 +133,6 @@ extension FileManager: LintableFileManager {
     }
 
     public func modificationDate(forFileAtPath path: URL) -> Date? {
-        (try? attributesOfItem(atPath: path.filepath))?[.modificationDate] as? Date
+        try? path.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate
     }
 }

--- a/Source/SwiftLintFramework/Models/Linter.swift
+++ b/Source/SwiftLintFramework/Models/Linter.swift
@@ -18,6 +18,11 @@ private struct LintResult {
     let deprecatedToValidIDPairs: [(String, String)]
 }
 
+private struct LinterRule: Sendable {
+    let rule: any Rule
+    let supportsCurrentSwiftVersion: Bool
+}
+
 private extension Rule {
     func superfluousDisableCommandViolations(regions: [Region],
                                              superfluousDisableCommandRule: SuperfluousDisableCommandRule?,
@@ -67,14 +72,22 @@ private extension Rule {
         return superfluousDisableCommandViolations
     }
 
-    func shouldRun(onFile file: SwiftLintFile) -> Bool {
+    func shouldRun(onFile file: SwiftLintFile, supportsCurrentSwiftVersion: Bool) -> Bool {
+        shouldRun(onFile: file, supportsCurrentSwiftVersion: supportsCurrentSwiftVersion, fileIsEmpty: file.isEmpty)
+    }
+
+    // The all-rules lint path can pass one precomputed value while autocorrect keeps the read lazy
+    // when a rule can be rejected without reading the file.
+    func shouldRun(onFile file: SwiftLintFile,
+                   supportsCurrentSwiftVersion: Bool,
+                   fileIsEmpty: @autoclosure () -> Bool) -> Bool {
         // We shouldn't lint if the current Swift version is not supported by the rule
-        guard SwiftVersion.current >= Self.description.minSwiftVersion else {
+        guard supportsCurrentSwiftVersion else {
             return false
         }
 
         // Empty files shouldn't trigger violations if `shouldLintEmptyFiles` is `false`
-        if file.isEmpty, !shouldLintEmptyFiles {
+        if !shouldLintEmptyFiles, fileIsEmpty() {
             return false
         }
 
@@ -98,6 +111,8 @@ private extension Rule {
     // As we need the configuration to get custom identifiers.
     // swiftlint:disable:next function_parameter_count
     func lint(file: SwiftLintFile,
+              supportsCurrentSwiftVersion: Bool,
+              fileIsEmpty: Bool,
               regions: [Region],
               benchmark: Bool,
               storage: RuleStorage,
@@ -108,7 +123,9 @@ private extension Rule {
 
         // Wrap entire lint process including shouldRun check in rule context
         return CurrentRule.$identifier.withValue(ruleID) {
-            guard shouldRun(onFile: file) else {
+            guard shouldRun(onFile: file,
+                            supportsCurrentSwiftVersion: supportsCurrentSwiftVersion,
+                            fileIsEmpty: fileIsEmpty) else {
                 return LintResult(violations: [], ruleTime: nil, deprecatedToValidIDPairs: [])
             }
 
@@ -249,7 +266,7 @@ public struct Linter {
     public let file: SwiftLintFile
     /// Whether or not this linter will be used to collect information from several files.
     public var isCollecting: Bool
-    fileprivate let rules: [any Rule]
+    fileprivate let rules: [LinterRule]
     fileprivate let cache: LinterCache?
     fileprivate let configuration: Configuration
     fileprivate let compilerArguments: [String]
@@ -269,14 +286,22 @@ public struct Linter {
         self.configuration = configuration
         self.compilerArguments = compilerArguments
 
-        let rules = configuration.rules.filter { rule in
-            if compilerArguments.isEmpty {
-                return !(rule is any AnalyzerRule)
+        let rules = configuration.rules.compactMap { rule -> LinterRule? in
+            let shouldIncludeRule = if compilerArguments.isEmpty {
+                !(rule is any AnalyzerRule)
+            } else {
+                rule is any AnalyzerRule || rule is SuperfluousDisableCommandRule
             }
-            return rule is any AnalyzerRule || rule is SuperfluousDisableCommandRule
+            guard shouldIncludeRule else {
+                return nil
+            }
+            return LinterRule(
+                rule: rule,
+                supportsCurrentSwiftVersion: configuration.rulesWrapper.supportsCurrentSwiftVersion(type(of: rule))
+            )
         }
         self.rules = rules
-        self.isCollecting = rules.contains(where: { $0 is any AnyCollectingRule })
+        self.isCollecting = rules.contains(where: { $0.rule is any AnyCollectingRule })
     }
 
     /// Returns a linter capable of checking for violations after running each rule's collection step.
@@ -286,7 +311,7 @@ public struct Linter {
     /// - returns: A linter capable of checking for violations after running each rule's collection step.
     public func collect(into storage: RuleStorage) -> CollectedLinter {
         DispatchQueue.concurrentPerform(iterations: rules.count) { idx in
-            let rule = rules[idx]
+            let rule = rules[idx].rule
             let ruleID = type(of: rule).identifier
             CurrentRule.$identifier.withValue(ruleID) {
                 rule.collectInfo(for: file, into: storage, compilerArguments: compilerArguments)
@@ -302,7 +327,7 @@ public struct Linter {
 public struct CollectedLinter {
     /// The file to lint with this linter.
     public let file: SwiftLintFile
-    private let rules: [any Rule]
+    private let rules: [LinterRule]
     private let cache: LinterCache?
     private let configuration: Configuration
     private let compilerArguments: [String]
@@ -346,15 +371,25 @@ public struct CollectedLinter {
         }
 
         let regions = file.regions()
+        let needsEmptyFileCheck = rules.contains {
+            $0.supportsCurrentSwiftVersion && !$0.rule.shouldLintEmptyFiles
+        }
+        let fileIsEmpty = needsEmptyFileCheck && file.isEmpty
         let superfluousDisableCommandRule = rules.first(where: {
-            $0 is SuperfluousDisableCommandRule
-        }) as? SuperfluousDisableCommandRule
-        let validationResults: [LintResult] = rules.parallelMap {
-            $0.lint(file: file, regions: regions, benchmark: benchmark,
-                    storage: storage,
-                    superfluousDisableCommandRule: superfluousDisableCommandRule,
-                    globalConfiguration: configuration.globalConfiguration,
-                    compilerArguments: compilerArguments)
+            $0.rule is SuperfluousDisableCommandRule
+        })?.rule as? SuperfluousDisableCommandRule
+        let validationResults: [LintResult] = rules.parallelMap { linterRule in
+            linterRule.rule.lint(
+                file: file,
+                supportsCurrentSwiftVersion: linterRule.supportsCurrentSwiftVersion,
+                fileIsEmpty: fileIsEmpty,
+                regions: regions,
+                benchmark: benchmark,
+                storage: storage,
+                superfluousDisableCommandRule: superfluousDisableCommandRule,
+                globalConfiguration: configuration.globalConfiguration,
+                compilerArguments: compilerArguments
+            )
         }
         let undefinedSuperfluousCommandViolations = undefinedSuperfluousCommandViolations(
             regions: regions, configuration: configuration,
@@ -393,8 +428,8 @@ public struct CollectedLinter {
             // let's assume that all rules should have the same duration and split the duration among them
             let totalTime = -start.timeIntervalSinceNow
             let fractionedTime = totalTime / TimeInterval(rules.count)
-            ruleTimes = rules.compactMap { rule in
-                let id = type(of: rule).identifier
+            ruleTimes = rules.compactMap { linterRule in
+                let id = type(of: linterRule.rule).identifier
                 return (id, fractionedTime)
             }
         }
@@ -425,10 +460,16 @@ public struct CollectedLinter {
 
         var corrections = [String: Int]()
         let globalConfiguration = configuration.globalConfiguration
-        for rule in rules.compactMap({ $0 as? any CorrectableRule }) {
+        for linterRule in rules {
+            guard let rule = linterRule.rule as? any CorrectableRule else {
+                continue
+            }
             // Set rule context before checking shouldRun to allow file property access
             let ruleCorrections = CurrentRule.$identifier.withValue(type(of: rule).identifier) { () -> Int? in
-                guard rule.shouldRun(onFile: file) else {
+                guard rule.shouldRun(
+                    onFile: file,
+                    supportsCurrentSwiftVersion: linterRule.supportsCurrentSwiftVersion
+                ) else {
                     return nil
                 }
                 return CurrentRule.$configuration.withValue(globalConfiguration) {

--- a/Tests/FrameworkTests/EmptyFileTests.swift
+++ b/Tests/FrameworkTests/EmptyFileTests.swift
@@ -1,4 +1,6 @@
+import Foundation
 import SwiftLintFramework
+import TestHelpers
 import Testing
 
 @Suite
@@ -7,7 +9,11 @@ struct EmptyFileTests {
     var ruleStorage: RuleStorage!  // swiftlint:disable:this implicitly_unwrapped_optional
 
     init() throws {
-        let ruleList = RuleList(rules: RuleMock<DontLintEmptyFiles>.self, RuleMock<LintEmptyFiles>.self)
+        let ruleList = RuleList(
+            rules: RuleMock<DontLintEmptyFiles>.self,
+            RuleMock<LintEmptyFiles>.self,
+            RuleMock<UnsupportedSwiftVersion>.self
+        )
         let configuration = try Configuration(dict: [:], ruleList: ruleList)
         let file = SwiftLintFile(contents: "")
         let linter = Linter(file: file, configuration: configuration)
@@ -27,34 +33,59 @@ struct EmptyFileTests {
         let corrections = collectedLinter.correct(using: ruleStorage)
         #expect(corrections == ["rule_mock<LintEmptyFiles>": 1])
     }
+
+    @Test(.parserDiagnosticsEnabled(false))
+    func unsupportedRuleDoesNotReadFileDuringCorrect() throws {
+        let ruleList = RuleList(rules: RuleMock<UnsupportedSwiftVersion>.self)
+        let configuration = try Configuration(dict: [:], ruleList: ruleList)
+        let missingFile = URL.temporaryDirectory
+            .appending(path: UUID().uuidString)
+            .appendingPathExtension("swift")
+        let file = SwiftLintFile(pathDeferringReading: missingFile)
+        let storage = RuleStorage()
+        let collectedLinter = Linter(file: file, configuration: configuration).collect(into: storage)
+
+        #expect(collectedLinter.correct(using: storage).isEmpty)
+    }
 }
 
-private protocol ShouldLintEmptyFilesProtocol {
+private protocol RuleMockBehavior {
     static var shouldLintEmptyFiles: Bool { get }
+    static var minSwiftVersion: SwiftVersion { get }
 }
 
-private struct LintEmptyFiles: ShouldLintEmptyFilesProtocol {
+private extension RuleMockBehavior {
+    static var minSwiftVersion: SwiftVersion { .five }
+}
+
+private struct LintEmptyFiles: RuleMockBehavior {
     static var shouldLintEmptyFiles: Bool { true }
 }
 
-private struct DontLintEmptyFiles: ShouldLintEmptyFilesProtocol {
+private struct DontLintEmptyFiles: RuleMockBehavior {
     static var shouldLintEmptyFiles: Bool { false }
 }
 
-private struct RuleMock<ShouldLintEmptyFiles: ShouldLintEmptyFilesProtocol>: CorrectableRule, SourceKitFreeRule {
+private struct UnsupportedSwiftVersion: RuleMockBehavior {
+    static var shouldLintEmptyFiles: Bool { false }
+    static var minSwiftVersion: SwiftVersion { SwiftVersion(rawValue: "999.0.0") }
+}
+
+private struct RuleMock<Behavior: RuleMockBehavior>: CorrectableRule, SourceKitFreeRule {
     var configuration = SeverityConfiguration<Self>(.warning)
 
     static var description: RuleDescription {
         RuleDescription(
-            identifier: "rule_mock<\(ShouldLintEmptyFiles.self)>",
+            identifier: "rule_mock<\(Behavior.self)>",
             name: "",
             description: "",
             kind: .style,
+            minSwiftVersion: Behavior.minSwiftVersion,
             deprecatedAliases: ["mock"])
     }
 
     var shouldLintEmptyFiles: Bool {
-        ShouldLintEmptyFiles.shouldLintEmptyFiles
+        Behavior.shouldLintEmptyFiles
     }
 
     func validate(file: SwiftLintFile) -> [StyleViolation] {


### PR DESCRIPTION
Linting each file currently does two avoidable pieces of fixed work:

- cache validation obtains the complete file attribute dictionary, including extended attributes, just to read modification date;
- rule gating repeatedly compares each rule's minimum Swift version and can repeatedly acquire the file-contents synchronization path just to test emptiness.

This asks the URL for only `contentModificationDateKey`. Swift-version eligibility is computed once per shared configuration and carried alongside each selected rule. Before reading `file.isEmpty`, the linter checks whether any version-compatible rule requires empty-file gating, so the value is computed zero or one time per file. Autocorrect keeps the read lazy behind the same version and empty-file gates.

### Verification

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build -c release --product swiftlint`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test`: passed.
- `swift test --filter EmptyFileTests`: 3 tests passed, including a deferred nonexistent-file regression proving an unsupported rule does not read the file during autocorrect.
- `make bazel_test_tsan`: 18/18 targets passed; the affected `//Tests:FrameworkTests` target was rerun after adding the regression test.
- `.build/debug/swiftlint lint --strict --quiet --no-cache` on all four changed files: clean.
- Sorted JSON violation lists matched:
  - DuckDuckGo, default configuration: 84 before, 84 after.
  - realm-swift with `--enable-all-rules`: 64,834 before, 64,834 after.
  - Cache-enabled parity also matched: 84/84 on DuckDuckGo and 64,834/64,834 on realm-swift.
- Comparisons sorted by file, line, character, rule, reason, and severity; raw JSON order is not stable for parallel linting.

### Measurement

`--only-rule trailing_newline` on DuckDuckGo (6,747 linted files), chosen so that fixed per-file
cost dominates rather than rule work. Both binaries interleaved, best of three, on an otherwise
idle machine:

| | baseline | change |
| --- | ---: | ---: |
| warm cache — cache validation runs for every file | 1.01s | 0.92s |
| empty cache on each run | 2.47s | 2.21s |

```bash
swiftlint lint --quiet --only-rule trailing_newline --cache-path <dir>
```

The warm-cache row is the one that exercises the attribute change directly, since validating a
cached entry is what reads the modification date.

A separate seven-run `--no-cache` check of the version-aware gating revision was neutral:
2.125s before versus 2.126s after. For a full `--no-cache` lint the end-to-end difference is
within machine noise and is not presented here as a speedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
