### PR TITLE
Compare operands by token stream in identical_operands rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@
   source lines once per element of a dictionary literal.  
   [Brett-Best](https://github.com/Brett-Best)
 
+* Compare the two operands of a comparison by walking their token streams in
+  the `identical_operands` rule instead of rendering both operands to strings,
+  so differing operands stop at the first mismatching token.  
+  [Brett-Best](https://github.com/Brett-Best)
+
 * Add `#examples` and `#corrections` macros that expand lists and
   dictionaries of code strings into `Example`s, reducing boilerplate when
   defining a rule's triggering/non-triggering examples and corrections. Adopt

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/IdenticalOperandsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/IdenticalOperandsRule.swift
@@ -80,7 +80,7 @@ private extension IdenticalOperandsRule {
                 return
             }
 
-            if node.leftOperand.normalizedDescription == node.rightOperand.normalizedDescription {
+            if node.leftOperand.isStructurallyIdentical(to: node.rightOperand) {
                 violations.append(node.leftOperand.positionAfterSkippingLeadingTrivia)
             }
         }
@@ -88,7 +88,18 @@ private extension IdenticalOperandsRule {
 }
 
 private extension ExprSyntax {
-    var normalizedDescription: String {
-        debugDescription(includeTrivia: false)
+    func isStructurallyIdentical(to other: ExprSyntax) -> Bool {
+        var lhsTokens = tokens(viewMode: .sourceAccurate).makeIterator()
+        var rhsTokens = other.tokens(viewMode: .sourceAccurate).makeIterator()
+        while true {
+            switch (lhsTokens.next(), rhsTokens.next()) {
+            case (nil, nil):
+                return true
+            case let (lhsToken?, rhsToken?) where lhsToken.tokenKind == rhsToken.tokenKind:
+                continue
+            default:
+                return false
+            }
+        }
     }
 }


### PR DESCRIPTION
The `identical_operands` rule currently renders both operands with `debugDescription(includeTrivia: false)` and compares the resulting strings. That constructs a complete syntax dump for every infix comparison, even when the operands differ near the beginning.

This changes the comparison to walk both operands' source-accurate token streams and compare their token kinds. The iterators stop at the first mismatch and avoid building operand strings.

### Verification

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build -c release --product swiftlint`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test`: 370 tests in 73 suites passed.
- `.build/release/swiftlint lint --strict --quiet Source/SwiftLintBuiltInRules/Rules/Lint/IdenticalOperandsRule.swift`: clean.
- Sorted JSON violation lists matched:
  - DuckDuckGo, `--only-rule identical_operands`: 2 before, 2 after.
  - realm-swift, `--only-rule identical_operands`: 0 before, 0 after.
  - A synthetic corpus with 200 identical long member-chain comparisons: 200 before, 200 after.
- The parity comparison sorted by file, line, character, rule, reason, and severity because parallel linting does not guarantee raw JSON ordering.

### Measurement

`--only-rule identical_operands`, both binaries interleaved, five runs each, on an otherwise idle
machine:

| corpus | baseline median / best | change median / best |
| --- | ---: | ---: |
| DuckDuckGo (6,747 files) | 2.56s / 2.28s | 1.79s / 1.57s |
| realm-swift | 0.34s / 0.33s | 0.19s / 0.18s |
| synthetic, long operands | 0.49s | 0.07s |

```bash
swiftlint lint --no-cache --quiet --only-rule identical_operands
```

Roughly 30% off the rule's cost on DuckDuckGo. The synthetic case uses 200 comparisons with
12-member chains on both sides, to concentrate the string building that this change avoids; it is
synthetic and is included only to show where the cost goes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
