### PR TITLE
Fix missing_docs false positives for implicit actor requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@
 
 ### Bug Fixes
 
+* Fix `missing_docs` false positives for implicit actor requirements.  
+  [ZHUOLIN0928](https://github.com/ZHUOLIN0928)
+  [#5422](https://github.com/realm/SwiftLint/issues/5422)
+
 * Add an opt-in `allow_explicit_unsafe_unowned` option to let the
   `unowned_variable_capture` rule accept explicit `unowned(unsafe)` captures.  
   [Yurii Bakurov](https://github.com/Yurii201811)

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/MissingDocsRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/MissingDocsRule.swift
@@ -130,6 +130,9 @@ private extension MissingDocsRule {
         }
 
         override func visit(_ node: VariableDeclSyntax) -> SyntaxVisitorContinueKind {
+            if configuration.excludesInheritedTypes, node.isActorRequirement {
+                return .skipChildren
+            }
             collectViolation(from: node, on: node.bindingSpecifier)
             return .skipChildren
         }
@@ -149,6 +152,17 @@ private extension MissingDocsRule {
                 )
             }
         }
+    }
+}
+
+private extension VariableDeclSyntax {
+    var isActorRequirement: Bool {
+        guard bindings.count == 1,
+              let identifier = bindings.first?.pattern.as(IdentifierPatternSyntax.self),
+              identifier.identifier.text == "unownedExecutor" else {
+            return false
+        }
+        return parent?.parent?.parent?.parent?.is(ActorDeclSyntax.self) == true
     }
 }
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/MissingDocsRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/MissingDocsRuleExamples.swift
@@ -54,6 +54,12 @@ struct MissingDocsRuleExamples {
         }
         """,
         """
+        /// Documentation for MyActor.
+        public final actor MyActor {
+            public nonisolated var unownedExecutor: UnownedSerialExecutor { fatalError() }
+        }
+        """,
+        """
         /// my doc
         #if os(macOS)
         public func f() {}


### PR DESCRIPTION
Fixes #5422

## Summary

- Ignore the compiler-provided `unownedExecutor` requirement when checking an actor's documented members.
- Keep the exemption limited to a direct actor member with a single `unownedExecutor` binding.
- Add a non-triggering example for the reported implicit actor conformance case.

## Validation

- `swift build --disable-sandbox --product swiftlint` passed.
- Built SwiftLint with `--disable-sourcekit` reported no `missing_docs` violation for the implicit actor example, while a regular struct's undocumented `unownedExecutor` still produced the expected violations.
- `swift test --disable-sandbox --filter MissingDocsRuleTests` could not run because the installed CommandLineTools environment cannot resolve `XCTest` while building SwiftSyntax test support.
