### PR TITLE
feat: add command line rule exclusions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 ### Enhancements
 
+* Add a repeatable `--disable-rule` command-line option for disabling rules for a single invocation.
+  [aryansk](https://github.com/aryansk)
+  [#6831](https://github.com/realm/SwiftLint/issues/6831)
+
 * Add `#examples` and `#corrections` macros that expand lists and
   dictionaries of code strings into `Example`s, reducing boilerplate when
   defining a rule's triggering/non-triggering examples and corrections. Adopt

--- a/README.md
+++ b/README.md
@@ -1041,6 +1041,11 @@ A simple example including just two configuration files looks like this:
 
 `swiftlint --config .swiftlint.yml --config .swiftlint_child.yml`
 
+To disable rules for one invocation without changing a configuration file, use
+`--disable-rule`. The option can be repeated:
+
+`swiftlint lint --disable-rule todo --disable-rule line_length`
+
 ### Nested Configurations
 
 In addition to a main configuration (the `.swiftlint.yml` file in the root

--- a/Source/SwiftLintFramework/Configuration+CommandLine.swift
+++ b/Source/SwiftLintFramework/Configuration+CommandLine.swift
@@ -293,6 +293,12 @@ extension Configuration {
             onlyRule: options.onlyRule,
             cachePath: options.cachePath
         )
+
+        guard options.disabledRule.isNotEmpty else {
+            return
+        }
+
+        disableRules(options.disabledRule)
     }
 }
 

--- a/Source/SwiftLintFramework/Configuration/Configuration.swift
+++ b/Source/SwiftLintFramework/Configuration/Configuration.swift
@@ -283,6 +283,13 @@ public struct Configuration {
     }
 
     // MARK: - Methods: Internal
+    internal mutating func disableRules(_ ruleIdentifiers: [String]) {
+        let disabledRulesConfiguration = Self(
+            rulesMode: .defaultConfiguration(disabled: Set(ruleIdentifiers), optIn: [])
+        )
+        rulesWrapper = rulesWrapper.merged(with: disabledRulesConfiguration.rulesWrapper)
+    }
+
     mutating func makeIncludedAndExcludedPaths(relativeTo newBasePath: URL) {
         includedPaths = includedPaths.map { $0.relative(to: newBasePath) }
         excludedPaths = excludedPaths.map { $0.relative(to: newBasePath) }

--- a/Source/SwiftLintFramework/LintOrAnalyzeCommand.swift
+++ b/Source/SwiftLintFramework/LintOrAnalyzeCommand.swift
@@ -52,6 +52,7 @@ package struct LintOrAnalyzeOptions {
     let ignoreCache: Bool
     let enableAllRules: Bool
     let onlyRule: [String]
+    let disabledRule: [String]
     let autocorrect: Bool
     let format: Bool
     let disableSourceKit: Bool
@@ -81,6 +82,7 @@ package struct LintOrAnalyzeOptions {
                  ignoreCache: Bool,
                  enableAllRules: Bool,
                  onlyRule: [String],
+                 disabledRule: [String],
                  autocorrect: Bool,
                  format: Bool,
                  disableSourceKit: Bool,
@@ -109,6 +111,7 @@ package struct LintOrAnalyzeOptions {
         self.ignoreCache = ignoreCache
         self.enableAllRules = enableAllRules
         self.onlyRule = onlyRule
+        self.disabledRule = disabledRule
         self.autocorrect = autocorrect
         self.format = format
         self.disableSourceKit = disableSourceKit

--- a/Source/swiftlint/Commands/Analyze.swift
+++ b/Source/swiftlint/Commands/Analyze.swift
@@ -43,6 +43,7 @@ extension SwiftLint {
                 ignoreCache: true,
                 enableAllRules: false,
                 onlyRule: common.onlyRule,
+                disabledRule: common.disabledRule,
                 autocorrect: common.fix,
                 format: common.format,
                 disableSourceKit: false,

--- a/Source/swiftlint/Commands/Lint.swift
+++ b/Source/swiftlint/Commands/Lint.swift
@@ -60,6 +60,7 @@ extension SwiftLint {
                 ignoreCache: noCache,
                 enableAllRules: enableAllRules,
                 onlyRule: common.onlyRule,
+                disabledRule: common.disabledRule,
                 autocorrect: common.fix,
                 format: common.format,
                 disableSourceKit: disableSourceKit,

--- a/Source/swiftlint/Common/LintOrAnalyzeArguments.swift
+++ b/Source/swiftlint/Common/LintOrAnalyzeArguments.swift
@@ -62,6 +62,12 @@ struct LintOrAnalyzeArguments: ParsableArguments {
                 """
     )
     var onlyRule: [String] = []
+    @Option(
+        name: .customLong("disable-rule"),
+        parsing: .singleValue,
+        help: "Disable the specified rule for this invocation. Can be specified repeatedly."
+    )
+    var disabledRule: [String] = []
 }
 
 // MARK: - Common Argument Help

--- a/Tests/FileSystemAccessTests/ConfigurationTests.swift
+++ b/Tests/FileSystemAccessTests/ConfigurationTests.swift
@@ -101,6 +101,25 @@ struct ConfigurationTests { // swiftlint:disable:this type_body_length
     }
 
     @Test
+    func commandLineDisabledRules() {
+        Configuration.resetCache()
+
+        let allRulesConfiguration = Configuration(
+            options: .init(enableAllRules: true, disabledRule: ["todo"])
+        )
+        #expect(!allRulesConfiguration.enabledRuleIdentifiers.contains("todo"))
+        #expect(
+            allRulesConfiguration.rules.count == RuleRegistry.shared.list.list.count - 1
+        )
+
+        Configuration.resetCache()
+        let onlyRulesConfiguration = Configuration(
+            options: .init(onlyRule: ["line_length", "todo"], disabledRule: ["todo"])
+        )
+        #expect(onlyRulesConfiguration.enabledRuleIdentifiers == ["line_length"])
+    }
+
+    @Test
     func onlyRules() throws {
         let only = ["nesting", "todo"]
 
@@ -677,5 +696,45 @@ private extension Sequence where Element == String {
 private extension Configuration {
     var enabledRuleIdentifiers: [String] {
         rules.map { type(of: $0).identifier }.sorted()
+    }
+}
+
+private extension LintOrAnalyzeOptions {
+    init(
+        enableAllRules: Bool = false,
+        onlyRule: [String] = [],
+        disabledRule: [String] = []
+    ) {
+        self.init(
+            mode: .lint,
+            paths: [],
+            useSTDIN: false,
+            configurationFiles: [],
+            strict: false,
+            lenient: false,
+            forceExclude: false,
+            useExcludingByPrefix: false,
+            useScriptInputFiles: false,
+            useScriptInputFileLists: false,
+            benchmark: false,
+            reporter: nil,
+            baseline: nil,
+            writeBaseline: nil,
+            workingDirectory: nil,
+            quiet: true,
+            output: nil,
+            progress: false,
+            cachePath: nil,
+            ignoreCache: true,
+            enableAllRules: enableAllRules,
+            onlyRule: onlyRule,
+            disabledRule: disabledRule,
+            autocorrect: false,
+            format: false,
+            disableSourceKit: false,
+            compilerLogPath: nil,
+            compileCommands: nil,
+            checkForUpdates: false
+        )
     }
 }

--- a/Tests/FrameworkTests/LintOrAnalyzeOptionsTests.swift
+++ b/Tests/FrameworkTests/LintOrAnalyzeOptionsTests.swift
@@ -64,6 +64,7 @@ private extension LintOrAnalyzeOptions {
                   ignoreCache: false,
                   enableAllRules: false,
                   onlyRule: [],
+                  disabledRule: [],
                   autocorrect: false,
                   format: false,
                   disableSourceKit: false,


### PR DESCRIPTION
Fixes #6831.

Adds a repeatable `--disable-rule <rule>` option to both `lint` and `analyze`. The exclusions are applied after configuration resolution, so they work with normal configuration files, `--enable-all-rules`, and `--only-rule` without changing the configuration file.

Validation:
- `swift test --parallel` (1,089 tests in 374 suites)
- focused `commandLineDisabledRules` test
- generated `lint --help` includes `--disable-rule`
- strict SwiftLint lint on changed Swift files
- `git diff --check`