### PR TITLE
Remove deprecated `allow_multiline_func` option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
   Rules can now read the global `indentation` setting via `CurrentRule.configuration`.  
   [GandaLF2006](https://github.com/GandaLF2006)
 
+* Remove the deprecated `allow_multiline_func` option from the `opening_brace`
+  rule. Use `ignore_multiline_function_signatures` instead.  
+  [Brett-Best](https://github.com/Brett-Best)
+
 ### Experimental
 
 * None.

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OpeningBraceConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/OpeningBraceConfiguration.swift
@@ -10,12 +10,4 @@ struct OpeningBraceConfiguration: SeverityBasedRuleConfiguration {
     private(set) var ignoreMultilineStatementConditions = false
     @ConfigurationElement(key: "ignore_multiline_function_signatures")
     private(set) var ignoreMultilineFunctionSignatures = false
-    // TODO: [08/23/2026] Remove deprecation warning after ~2 years.
-    @ConfigurationElement(key: "allow_multiline_func", deprecationNotice: .suggestAlternative(
-        ruleID: Parent.identifier, name: "ignore_multiline_function_signatures"))
-    private(set) var allowMultilineFunc = false
-
-    var shouldIgnoreMultilineFunctionSignatures: Bool {
-        ignoreMultilineFunctionSignatures || allowMultilineFunc
-    }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Style/OpeningBraceRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/OpeningBraceRule.swift
@@ -116,7 +116,7 @@ private extension OpeningBraceRule {
 
         override func visitPost(_ node: FunctionDeclSyntax) {
             if let body = node.body,
-               configuration.shouldIgnoreMultilineFunctionSignatures,
+               configuration.ignoreMultilineFunctionSignatures,
                hasMultilinePredecessors(body, keyword: node.funcKeyword) {
                 return
             }
@@ -126,7 +126,7 @@ private extension OpeningBraceRule {
 
         override func visitPost(_ node: InitializerDeclSyntax) {
             if let body = node.body,
-               configuration.shouldIgnoreMultilineFunctionSignatures,
+               configuration.ignoreMultilineFunctionSignatures,
                hasMultilinePredecessors(body, keyword: node.initKeyword) {
                 return
             }

--- a/Tests/IntegrationTests/Resources/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/Resources/default_rule_configurations.yml
@@ -848,7 +848,6 @@ opening_brace:
   ignore_multiline_type_headers: false
   ignore_multiline_statement_conditions: false
   ignore_multiline_function_signatures: false
-  allow_multiline_func: false
   meta:
     opt-in: false
     correctable: true


### PR DESCRIPTION
## Summary

- Remove the deprecated `allow_multiline_func` compatibility option from `opening_brace`.
- Use `ignore_multiline_function_signatures` directly in the rule implementation.
- Update the default-configuration fixture and document the breaking change.

## Motivation

`allow_multiline_func` was renamed to `ignore_multiline_function_signatures` in SwiftLint 0.57.0 and has emitted a deprecation warning for about two years. Its expiring TODO has now entered the warning window and causes the integration self-lint to fail.

Removing the deprecated option follows the scheduled cleanup and existing deprecation-removal practice. Configurations still using `allow_multiline_func` must migrate to `ignore_multiline_function_signatures`.

## Validation

- `swift test --filter OpeningBraceRuleTests` (4 tests passed)
- `swift test --filter IntegrationTests` (16 tests passed)
- `make bazel_test_tsan` (18 of 18 targets passed)
