### PR TITLE
Avoid recomputing the rule identifier in `performLint`

### DIFF
--- a/Source/SwiftLintFramework/Models/Linter.swift
+++ b/Source/SwiftLintFramework/Models/Linter.swift
@@ -115,6 +115,7 @@ private extension Rule {
             return CurrentRule.$configuration.withValue(globalConfiguration) {
                 performLint(
                     file: file,
+                    ruleID: ruleID,
                     regions: regions,
                     benchmark: benchmark,
                     storage: storage,
@@ -127,13 +128,12 @@ private extension Rule {
 
     // swiftlint:disable:next function_parameter_count
     private func performLint(file: SwiftLintFile,
+                             ruleID: String,
                              regions: [Region],
                              benchmark: Bool,
                              storage: RuleStorage,
                              superfluousDisableCommandRule: SuperfluousDisableCommandRule?,
                              compilerArguments: [String]) -> LintResult {
-        let ruleID = Self.identifier
-
         let violations: [StyleViolation]
         let ruleTime: (String, Double)?
         if benchmark {


### PR DESCRIPTION
`lint(file:regions:…)` already resolves `Self.identifier` and passes it into the rule context, then calls `performLint`, which resolved it a second time. This passes the resolved value down instead. Both sites resolve it on the same opened existential within the same dynamic dispatch, so the value is identical by construction. `Self.description.allIdentifiers` is untouched.

### What is removed

`Rule.identifier` is `static var identifier: String { description.identifier }`, so each read goes through the static `description` witness and copies `RuleDescription` — eight ref-counted fields. This removes one copy per rule and file.

Isolated through the same protocol-witness dispatch: 91.0 ns to resolve twice, 48.0 ns once — **43 ns per (rule, file)**. At ~200 rules that is **~8.6 µs of CPU per file**, or ~58 ms of CPU across DuckDuckGo's 6,747 files.

Time Profiler confirms it, on a 20,000-file corpus with `--enable-all-rules`, 111,969 samples per side:

| Symbol | `main` | this PR |
| --- | ---: | ---: |
| `protocol witness for static Rule.description.getter` | 1.02% | **0.81%** |
| `RuleDescription.allIdentifiers.getter` *(control — untouched)* | 1.19% | 1.18% |

The flat control is what separates the delta from trace drift.

### No end-to-end speedup is claimed

Same corpus, ~4M rule-and-file pairs (~3x DuckDuckGo's), the most favourable case for this change. Six interleaved pairs: 13.84 s vs 13.86 s median. hyperfine, 6 runs each: `1.00 ± 0.02`. Eight pairs with all 12 cores saturated: 20.75 s vs 20.67 s. No paired t exceeded 1.03 either way.

Run order was alternated throughout — an earlier unbalanced version, always running `main` first, showed ~2.8% faster purely from the second binary meeting a warm page cache.

### Why land it anyway

~0.2% of CPU sits permanently below a 2–4% noise floor, so this will never measure on its own. The case is that lint time has no single dominant hot spot: it is the sum of many small costs, and this is strictly less work for byte-identical output. Ten changes this size land around 2%, which is measurable; none of them are individually.

The counter-argument is real and the measurement doesn't settle it — a threaded parameter is a permanent readability cost for an invisible gain. That trade is the maintainers' call.

### Verification

`swift build -c release`, `swift test` (all suites), `lint --strict --quiet --no-cache` clean. Sorted violation lists identical to `main`: DuckDuckGo 84/84, realm-swift 64,834/64,834 (`--enable-all-rules`). No CHANGELOG entry — no user-observable change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
