### PR TITLE
Cache source lines in `vertical_parameter_alignment`

### DIFF
--- a/Source/SwiftLintBuiltInRules/Rules/Style/VerticalParameterAlignmentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Style/VerticalParameterAlignmentRule.swift
@@ -16,6 +16,11 @@ struct VerticalParameterAlignmentRule: Rule {
 
 private extension VerticalParameterAlignmentRule {
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
+        // Computed once per file: `SourceLocationConverter.sourceLines` materializes every line of the
+        // file as a new `[String]` on each access, and `graphemeColumn(line:column:)` below reads it
+        // once per parameter, which is quadratic in the size of the file.
+        private lazy var sourceLines = locationConverter.sourceLines
+
         override func visitPost(_ node: FunctionDeclSyntax) {
             violations.append(contentsOf: violations(for: node.signature.parameterClause.parameters))
         }
@@ -52,7 +57,7 @@ private extension VerticalParameterAlignmentRule {
         /// by multi-byte characters (e.g. a non-ASCII function name) are compared by their visible alignment
         /// rather than by their byte offset.
         private func graphemeColumn(line: Int, column: Int) -> Int {
-            guard let graphemeClusters = String(locationConverter.sourceLines[line - 1].utf8.prefix(column - 1)) else {
+            guard let graphemeClusters = String(sourceLines[line - 1].utf8.prefix(column - 1)) else {
                 return column
             }
             return graphemeClusters.count + 1


### PR DESCRIPTION
`vertical_parameter_alignment` converts a parameter's UTF-8 column into a grapheme-cluster column, so that declarations preceded by multi-byte characters are compared by visible alignment. It reads the file's source lines to do that:

```swift
private func graphemeColumn(line: Int, column: Int) -> Int {
    guard let graphemeClusters = String(locationConverter.sourceLines[line - 1].utf8.prefix(column - 1)) else {
```

`sourceLines` is a computed property in swift-syntax, and it rebuilds the entire file on each access:

```swift
public var sourceLines: [String] {
  var result: [String] = []
  self.forEachSourceLine { line in
    result.append(String(syntaxText: line))
  }
  return result
}
```

`graphemeColumn` is called once per parameter, for every declaration that has more than one parameter:

```swift
let paramLocations = params.compactMap { param -> (position: AbsolutePosition, line: Int, column: Int)? in
    let position = param.positionAfterSkippingLeadingTrivia
    let location = locationConverter.location(for: position)
    return (position, location.line, graphemeColumn(line: location.line, column: location.column))
}
```

So a file of _m_ lines whose multi-parameter declarations hold _p_ parameters in total allocates _m_ × _p_ strings in order to look at _p_ lines. Hoisting the property into a `lazy var` on the visitor computes it once per file.

`collection_alignment` already carries this same hoist, for the same reason.

### Scaling

One file of _n_ two-parameter functions, `--only-rule vertical_parameter_alignment`, best of three:

| functions | before | after |
| ---: | ---: | ---: |
| 500 | 0.14s | 0.06s |
| 1,000 | 0.33s | 0.07s |
| 2,000 | 1.17s | 0.08s |
| 4,000 | 4.47s | 0.10s |

Before, the time roughly quadruples each time the count doubles; after, it is flat. The declarations are correctly aligned, so both builds report no violations on that file — all 4.47 seconds go to finding nothing.

```bash
python3 -c "
for i in range(4000):
    print('func compute%d(first: Int, second: Int) -> Int {' % i)
    print('    first + second')
    print('}')" > Decls.swift
swiftlint lint --no-cache --quiet --only-rule vertical_parameter_alignment Decls.swift
```

### Real projects

Unlike a defect that only shows up in unusually large files, this one is visible on ordinary code, because the rule touches the source lines for every parameter of every multi-parameter declaration. Both binaries run interleaved, five runs each, on an idle machine:

| corpus | before (median / best) | after (median / best) |
| --- | ---: | ---: |
| DuckDuckGo, 6,747 files | 1.93s / 1.82s | 1.52s / 1.40s |
| realm-swift, 152 files | 0.31s / 0.30s | 0.19s / 0.18s |

### No behaviour change

With `--enable-all-rules`, the violations are identical before and after — 590,289 on DuckDuckGo and 64,834 on realm-swift, 655,123 in total, matching once sorted. (The raw JSON order is not stable between runs of the same binary, since linting is parallel.) The test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
