### PR TITLE
Add Brigade to the oss-check repositories

### DIFF
--- a/tools/oss-check
+++ b/tools/oss-check
@@ -436,6 +436,10 @@ $working_dir = 'osscheck'
   Repo.new('Aerial', 'JohnCoates/Aerial'),
   Repo.new('Alamofire', 'Alamofire/Alamofire'),
   Repo.new('Brave', 'brave/brave-core', false, 'included: ios/brave-ios'),
+  # Purpose-built to stress the linter rather than to be an app: few very large files
+  # alongside many small ones, which is the shape rules scaling with file size react to.
+  # Its own config is kept because the custom rules and the exclusions are load-bearing.
+  Repo.new('Brigade', 'Brett-Best/Brigade', true),
   Repo.new('DuckDuckGo', 'duckduckgo/apple-browsers'),
   Repo.new('Firefox', 'mozilla-mobile/firefox-ios'),
   Repo.new('Kickstarter', 'kickstarter/ios-oss'),


### PR DESCRIPTION
Adds one repository to the oss-check set.

Disclosure: I wrote this repository. It is public, and it exists to stress the linter rather than to be an app, so it is a benchmark input rather than a real-world sample. Happy to drop it if you would rather the set stay entirely third-party applications.

### Why this shape

The current set is made of real applications, which are overwhelmingly composed of small-to-medium files. A rule whose cost grows with the size of a *single file* is close to invisible in that set — it shows up as a fraction of a percent spread across thousands of files, which is within run-to-run noise.

Brigade has the opposite shape. Of the 17 files it lints, two dominate:

| file | lines |
| --- | ---: |
| `Sources/CellarKit/Vintages.swift` | 34,571 |
| `Sources/CellarKit/Appellations.swift` | 28,174 |

Those are generated catalogue data — large dictionary and array literals, long parameter lists — which is exactly the shape that makes a per-file quadratic cost measurable instead of theoretical.

### Cost

Linting it with a `main` build takes about 21s. oss-check defaults to 5 iterations per branch across 2 branches, so this adds roughly 3.5 minutes to a full run. It is 6.4MB cloned at depth 1.

### `keep_config: true` is load-bearing

The repository contains a `Reproducers/` directory holding inputs that currently crash SwiftLint, and its own `.swiftlint.yml` excludes that directory. With the config removed, `swiftlint lint --no-cache --enable-all-rules` on current `main` terminates with SIGILL (exit 132); with the config kept, it exits 0. Hence the third argument.

That is worth knowing rather than hiding: if the config were ever dropped for this entry, oss-check would crash rather than report a diff.

### Verified

Against `main` at 8fef7728c, cloning fresh from GitHub and running the exact command oss-check issues:

```bash
git clone --depth 1 https://github.com/Brett-Best/Brigade
cd Brigade
swiftlint lint --no-cache --enable-all-rules --reporter json
```

Exit 0, 11,116 violations, stable across repeated runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
