### PR TITLE
Add MegaLinter to the README setup section

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,6 +479,13 @@ Done linting! Found 0 violations, 0 serious in 490 files.
 Here you have more documentation about the usage of
 [Docker Images](https://docs.docker.com/).
 
+### MegaLinter
+
+SwiftLint is also embedded in [MegaLinter](https://megalinter.io), an
+open-source aggregator of linters for CI. See its
+[SwiftLint documentation](https://megalinter.io/latest/descriptors/swift_swiftlint/)
+for setup instructions.
+
 ## Command Line Usage
 
 ```txt


### PR DESCRIPTION
Hi, MegaLinter maintainer here :wave:

SwiftLint has been shipped in [MegaLinter](https://megalinter.io) (an open-source aggregator of linters for CI) for quite a while, so I figured it could be worth a short mention in the README next to the other integrations (VS Code, Fastlane, Docker...).

Docs-only change, feel free to tweak the wording or placement if you prefer it elsewhere!