### PR TITLE
Add --parent-config option to lint command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@
 
 ### Enhancements
 
+* Add a `--parent-config` option to the `lint` command, allowing a parent
+  configuration to be supplied without modifying the child configuration file.  
+  [LizunovSergey](https://github.com/LizunovSergey)
+  [#5421](https://github.com/realm/SwiftLint/issues/5421)
+
 * Speed up the `collection_alignment` rule, which read the whole file's
   source lines once per element of a dictionary literal.  
   [Brett-Best](https://github.com/Brett-Best)

--- a/Source/SwiftLintFramework/Configuration+CommandLine.swift
+++ b/Source/SwiftLintFramework/Configuration+CommandLine.swift
@@ -288,7 +288,7 @@ extension Configuration {
 
     init(options: LintOrAnalyzeOptions) {
         self.init(
-            configurationFiles: options.configurationFiles,
+            configurationFiles: options.effectiveConfigurationFiles,
             enableAllRules: options.enableAllRules,
             onlyRule: options.onlyRule,
             cachePath: options.cachePath

--- a/Source/SwiftLintFramework/Configuration+CommandLine.swift
+++ b/Source/SwiftLintFramework/Configuration+CommandLine.swift
@@ -293,6 +293,7 @@ extension Configuration {
             onlyRule: options.onlyRule,
             cachePath: options.cachePath
         )
+        basedOnCustomConfigurationFiles = options.configurationFiles.isNotEmpty
     }
 }
 

--- a/Source/SwiftLintFramework/Configuration/Configuration.swift
+++ b/Source/SwiftLintFramework/Configuration/Configuration.swift
@@ -53,7 +53,7 @@ public struct Configuration {
     /// This value is `true` iff the `--config` parameter was used to specify (a) configuration file(s)
     /// In particular, this means that the value is also `true` if the `--config` parameter
     /// was used to explicitly specify the default `.swiftlint.yml` as the configuration file
-    public private(set) var basedOnCustomConfigurationFiles = false
+    public internal(set) var basedOnCustomConfigurationFiles = false
 
     // MARK: Public Computed
     /// All rules enabled in this configuration

--- a/Source/SwiftLintFramework/LintOrAnalyzeCommand.swift
+++ b/Source/SwiftLintFramework/LintOrAnalyzeCommand.swift
@@ -34,6 +34,7 @@ package struct LintOrAnalyzeOptions {
     let paths: [URL]
     let useSTDIN: Bool
     let configurationFiles: [URL]
+    let parentConfigurationFile: URL?
     let strict: Bool
     let lenient: Bool
     let forceExclude: Bool
@@ -63,6 +64,7 @@ package struct LintOrAnalyzeOptions {
                  paths: [URL],
                  useSTDIN: Bool,
                  configurationFiles: [URL],
+                 parentConfigurationFile: URL?,
                  strict: Bool,
                  lenient: Bool,
                  forceExclude: Bool,
@@ -91,6 +93,7 @@ package struct LintOrAnalyzeOptions {
         self.paths = paths
         self.useSTDIN = useSTDIN
         self.configurationFiles = configurationFiles
+        self.parentConfigurationFile = parentConfigurationFile
         self.strict = strict
         self.lenient = lenient
         self.forceExclude = forceExclude
@@ -123,6 +126,17 @@ package struct LintOrAnalyzeOptions {
 
     var capitalizedVerb: String {
         verb.capitalized
+    }
+
+    var effectiveConfigurationFiles: [URL] {
+        guard let parentConfigurationFile else {
+            return configurationFiles
+        }
+
+        let childConfigurationFiles = configurationFiles.isEmpty
+            ? [Configuration.defaultFileName.url()]
+            : configurationFiles
+        return [parentConfigurationFile] + childConfigurationFiles
     }
 }
 

--- a/Source/SwiftLintFramework/LintOrAnalyzeCommand.swift
+++ b/Source/SwiftLintFramework/LintOrAnalyzeCommand.swift
@@ -133,9 +133,14 @@ package struct LintOrAnalyzeOptions {
             return configurationFiles
         }
 
-        let childConfigurationFiles = configurationFiles.isEmpty
-            ? [Configuration.defaultFileName.url()]
-            : configurationFiles
+        let defaultConfigurationFile = Configuration.defaultFileName.url()
+        let childConfigurationFiles: [URL] = if configurationFiles.isNotEmpty {
+            configurationFiles
+        } else if defaultConfigurationFile.exists {
+            [defaultConfigurationFile]
+        } else {
+            []
+        }
         return [parentConfigurationFile] + childConfigurationFiles
     }
 }

--- a/Source/swiftlint/Commands/Analyze.swift
+++ b/Source/swiftlint/Commands/Analyze.swift
@@ -25,6 +25,7 @@ extension SwiftLint {
                 paths: allPaths,
                 useSTDIN: false,
                 configurationFiles: common.config,
+                parentConfigurationFile: nil,
                 strict: common.leniency == .strict,
                 lenient: common.leniency == .lenient,
                 forceExclude: common.forceExclude,

--- a/Source/swiftlint/Commands/Lint.swift
+++ b/Source/swiftlint/Commands/Lint.swift
@@ -8,6 +8,8 @@ extension SwiftLint {
 
         @OptionGroup
         var common: LintOrAnalyzeArguments
+        @Option(help: "The path to a parent SwiftLint configuration file.")
+        var parentConfig: URL?
         @Flag(help: "Lint standard input.")
         var useSTDIN = false
         @Flag(help: quietOptionDescription(for: .lint))
@@ -42,6 +44,7 @@ extension SwiftLint {
                 paths: allPaths,
                 useSTDIN: useSTDIN,
                 configurationFiles: common.config,
+                parentConfigurationFile: parentConfig,
                 strict: common.leniency == .strict,
                 lenient: common.leniency == .lenient,
                 forceExclude: common.forceExclude,

--- a/Tests/FrameworkTests/LintOrAnalyzeOptionsTests.swift
+++ b/Tests/FrameworkTests/LintOrAnalyzeOptionsTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 @testable import SwiftLintFramework
 import Testing
 
@@ -38,14 +39,46 @@ struct LintOrAnalyzeOptionsTests {
             }
         }
     }
+
+    @Test
+    func parentConfigurationFilePrecedesExplicitConfigurationFiles() {
+        let options = LintOrAnalyzeOptions(
+            configurationFiles: ["child-1.yml".url(), "child-2.yml".url()],
+            parentConfigurationFile: "parent.yml".url()
+        )
+
+        #expect(options.effectiveConfigurationFiles == [
+            "parent.yml".url(),
+            "child-1.yml".url(),
+            "child-2.yml".url(),
+        ])
+    }
+
+    @Test
+    func parentConfigurationFilePrecedesDefaultConfigurationFile() {
+        let options = LintOrAnalyzeOptions(
+            configurationFiles: [],
+            parentConfigurationFile: "parent.yml".url()
+        )
+
+        #expect(options.effectiveConfigurationFiles == [
+            "parent.yml".url(),
+            Configuration.defaultFileName.url(),
+        ])
+    }
 }
 
 private extension LintOrAnalyzeOptions {
-    init(leniency: Leniency) {
+    init(
+        leniency: Leniency = (strict: false, lenient: false),
+        configurationFiles: [URL] = [],
+        parentConfigurationFile: URL? = nil
+    ) {
         self.init(mode: .lint,
                   paths: [],
                   useSTDIN: true,
-                  configurationFiles: [],
+                  configurationFiles: configurationFiles,
+                  parentConfigurationFile: parentConfigurationFile,
                   strict: leniency.strict,
                   lenient: leniency.lenient,
                   forceExclude: false,

--- a/Tests/FrameworkTests/LintOrAnalyzeOptionsTests.swift
+++ b/Tests/FrameworkTests/LintOrAnalyzeOptionsTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 @testable import SwiftLintFramework
+import TestHelpers
 import Testing
 
 @Suite
@@ -54,8 +55,13 @@ struct LintOrAnalyzeOptionsTests {
         ])
     }
 
-    @Test
-    func parentConfigurationFilePrecedesDefaultConfigurationFile() {
+    @Test(.temporaryDirectory)
+    func parentConfigurationFilePrecedesDefaultConfigurationFile() throws {
+        try "reporter: csv".write(
+            to: Configuration.defaultFileName.url(),
+            atomically: true,
+            encoding: .utf8
+        )
         let options = LintOrAnalyzeOptions(
             configurationFiles: [],
             parentConfigurationFile: "parent.yml".url()
@@ -65,6 +71,51 @@ struct LintOrAnalyzeOptionsTests {
             "parent.yml".url(),
             Configuration.defaultFileName.url(),
         ])
+    }
+
+    @Test(.temporaryDirectory)
+    func parentConfigurationFileWorksWithoutDefaultConfigurationFile() {
+        let options = LintOrAnalyzeOptions(
+            configurationFiles: [],
+            parentConfigurationFile: "parent.yml".url()
+        )
+
+        #expect(options.effectiveConfigurationFiles == ["parent.yml".url()])
+    }
+
+    @Test(.rulesRegistered, .temporaryDirectory)
+    func parentConfigurationFilePreservesNestedConfigurations() throws {
+        let parentConfigurationFile = "parent.yml".url()
+        try "disabled_rules: []".write(to: parentConfigurationFile, atomically: true, encoding: .utf8)
+        try "disabled_rules: []".write(
+            to: Configuration.defaultFileName.url(),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let nestedDirectory = URL.cwd.appending(path: "Nested", directoryHint: .isDirectory)
+        try FileManager.default.createDirectory(at: nestedDirectory, withIntermediateDirectories: true)
+        try "disabled_rules: [line_length]".write(
+            to: nestedDirectory.appending(path: Configuration.defaultFileName),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let options = LintOrAnalyzeOptions(
+            configurationFiles: [],
+            parentConfigurationFile: parentConfigurationFile
+        )
+        let configuration = Configuration(options: options)
+        let nestedFile = SwiftLintFile(
+            pathDeferringReading: nestedDirectory.appending(path: "Example.swift")
+        )
+
+        #expect(!configuration.basedOnCustomConfigurationFiles)
+        #expect(!configuration.rulesWrapper.disabledRuleIdentifiers.contains("line_length"))
+        #expect(
+            configuration.configuration(for: nestedFile)
+                .rulesWrapper.disabledRuleIdentifiers.contains("line_length")
+        )
     }
 }
 


### PR DESCRIPTION
## Summary

- add a `--parent-config` option to the `lint` command
- prepend the parent configuration to explicitly supplied `--config` files
- use the default `.swiftlint.yml` as the child when it exists
- keep nested configuration discovery enabled when `--parent-config` is used without `--config`
- allow the parent configuration to stand alone when no default `.swiftlint.yml` exists
- add regression coverage for explicit, default, missing-default, and nested configuration paths
- document the enhancement in the changelog

## Why

Some workflows download a shared parent configuration to a temporary location,
so its path cannot be written into the project's configuration file ahead of
time. The new option allows that parent to be supplied at invocation time while
preserving the existing parent-to-child merge order and nested configuration
discovery.

## Testing

- `xcrun swift test --filter LintOrAnalyzeOptionsTests` (5 tests passed)
- verified a nested `.swiftlint.yml` changes the effective rule configuration
- verified `swiftlint lint --help` exposes `--parent-config`
- smoke-tested parent precedence with both an explicit child config and the
  default `.swiftlint.yml`
- linted all changed Swift files with the locally built SwiftLint binary

Closes #5421
