### PR TITLE
Fix baseline duplicate replacements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,10 @@
 
 ### Bug Fixes
 
+* Fix baseline duplicate replacements.  
+  [LizunovSergey](https://github.com/LizunovSergey)
+  [#6871](https://github.com/realm/SwiftLint/issues/6871)
+
 * Add an opt-in `allow_explicit_unsafe_unowned` option to let the
   `unowned_variable_capture` rule accept explicit `unowned(unsafe)` captures.  
   [Yurii Bakurov](https://github.com/Yurii201811)

--- a/Source/SwiftLintCore/Models/Baseline.swift
+++ b/Source/SwiftLintCore/Models/Baseline.swift
@@ -156,6 +156,8 @@ public struct Baseline: Equatable {
             return []
         }
 
+        let exactViolations = Set(relativePathViolations).intersection(baselineViolations)
+
         let violationsByRuleIdentifier = relativePathViolations.groupedByRuleIdentifier(
             filteredBy: baselineViolations
         )
@@ -181,6 +183,11 @@ public struct Baseline: Equatable {
                     continue
                 }
                 if ruleViolations.count > baselineViolations.count {
+                    filteredViolations.formUnion(ruleViolations)
+                } else if ruleViolations.count == baselineViolations.count,
+                          exactViolations.contains(where: {
+                              $0.violation.ruleIdentifier == ruleIdentifier && $0.key == key
+                          }) {
                     filteredViolations.formUnion(ruleViolations)
                 }
             }

--- a/Tests/FileSystemAccessTests/BaselineTests.swift
+++ b/Tests/FileSystemAccessTests/BaselineTests.swift
@@ -50,6 +50,21 @@ struct BaselineTests {
         Baseline(violations: ruleDescriptions.violations(for: filePath))
     }
 
+    private static func lines(withDuplicatesAt duplicateLines: Set<Int>) -> [String] {
+        (1...30).map { line in
+            duplicateLines.contains(line) ? "// TODO: remove this" : ""
+        }
+    }
+
+    private static func duplicateViolations(at lines: [Int], in filePath: URL) -> [StyleViolation] {
+        lines.map { line in
+            StyleViolation(
+                ruleDescription: ArrayInitRule.description,
+                location: Location(file: filePath, line: line, character: 1)
+            )
+        }
+    }
+
     @Test(.temporaryDirectory)
     func writingAndReading() throws {
         try withExampleFileCreated { sourceFilePath in
@@ -101,6 +116,42 @@ struct BaselineTests {
             let violations = try Self.violations(for: sourceFilePath).lineShifted(by: 2, path: sourceFilePath)
             #expect(baseline.filter(violations).isEmpty)
         }
+    }
+
+    @Test(.temporaryDirectory)
+    func reportsSameCountReplacementOfDuplicateViolations() throws {
+        let sourceFilePath = URL.cwd.appending(path: "Example.swift", directoryHint: .notDirectory)
+        try Self.lines(withDuplicatesAt: [10, 20]).joined(separator: "\n").write(
+            to: sourceFilePath,
+            atomically: true,
+            encoding: .utf8
+        )
+        let baseline = Baseline(violations: Self.duplicateViolations(at: [10, 20], in: sourceFilePath))
+
+        try Self.lines(withDuplicatesAt: [20, 30]).joined(separator: "\n").write(
+            to: sourceFilePath,
+            atomically: true,
+            encoding: .utf8
+        )
+        let currentViolations = Self.duplicateViolations(at: [20, 30], in: sourceFilePath)
+
+        #expect(baseline.filter(currentViolations) == [currentViolations[1]])
+    }
+
+    @Test(.temporaryDirectory)
+    func ignoresUniformlyShiftedDuplicateViolations() throws {
+        let sourceFilePath = URL.cwd.appending(path: "Example.swift", directoryHint: .notDirectory)
+        try Self.lines(withDuplicatesAt: [10, 20]).joined(separator: "\n").write(
+            to: sourceFilePath,
+            atomically: true,
+            encoding: .utf8
+        )
+        let baselineViolations = Self.duplicateViolations(at: [10, 20], in: sourceFilePath)
+        let baseline = Baseline(violations: baselineViolations)
+
+        let currentViolations = try baselineViolations.lineShifted(by: 2, path: sourceFilePath)
+
+        #expect(baseline.filter(currentViolations).isEmpty)
     }
 
     @Test(.temporaryDirectory)


### PR DESCRIPTION
Fixes #6871

## Summary
- report a same-count replacement of identical baseline violations when another duplicate still matches exactly
- preserve the existing behavior for uniformly shifted duplicate violations

## Root cause
After exact matches are removed, the fallback comparison used only the number of remaining violations with the same text and reason. A replacement could therefore be hidden by an unmatched baseline duplicate with the same key.

An unchanged duplicate now acts as an anchor: if the remaining counts are equal within that group, the unmatched current violations are reported. A group with no exact match still follows the existing shift-tolerant behavior.

## Tests
- `swift test --filter BaselineTests`