### PR TITLE
Serialize analyzer rule scheduling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Serialize analyzer rule collection and validation to prevent overlapping
   SourceKit requests for the same compiler context.  
   [Derek Pearson](https://github.com/dpearson2699)
+  [#3020](https://github.com/realm/SwiftLint/issues/3020)
 
 ## 0.65.1: Fresh Folded Fixtures
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,10 @@
 
 ### Bug Fixes
 
-* None.
+* Serialize analyzer rule collection and validation to prevent overlapping
+  SourceKit requests for the same compiler context.  
+  [Derek Pearson](https://github.com/dpearson2699)
+  [#553](https://github.com/dpearson2699/ios-options-wheel-tracker/issues/553)
 
 ## 0.65.1: Fresh Folded Fixtures
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@
 * Serialize analyzer rule collection and validation to prevent overlapping
   SourceKit requests for the same compiler context.  
   [Derek Pearson](https://github.com/dpearson2699)
-  [#553](https://github.com/dpearson2699/ios-options-wheel-tracker/issues/553)
 
 ## 0.65.1: Fresh Folded Fixtures
 

--- a/Source/SwiftLintFramework/Models/Linter.swift
+++ b/Source/SwiftLintFramework/Models/Linter.swift
@@ -285,12 +285,18 @@ public struct Linter {
     ///
     /// - returns: A linter capable of checking for violations after running each rule's collection step.
     public func collect(into storage: RuleStorage) -> CollectedLinter {
-        DispatchQueue.concurrentPerform(iterations: rules.count) { idx in
-            let rule = rules[idx]
+        let collectRule = { (rule: any Rule) in
             let ruleID = type(of: rule).identifier
             CurrentRule.$identifier.withValue(ruleID) {
                 rule.collectInfo(for: file, into: storage, compilerArguments: compilerArguments)
             }
+        }
+        if compilerArguments.isEmpty {
+            DispatchQueue.concurrentPerform(iterations: rules.count) { idx in
+                collectRule(rules[idx])
+            }
+        } else {
+            rules.forEach(collectRule)
         }
         return CollectedLinter(from: self)
     }
@@ -349,13 +355,16 @@ public struct CollectedLinter {
         let superfluousDisableCommandRule = rules.first(where: {
             $0 is SuperfluousDisableCommandRule
         }) as? SuperfluousDisableCommandRule
-        let validationResults: [LintResult] = rules.parallelMap {
-            $0.lint(file: file, regions: regions, benchmark: benchmark,
-                    storage: storage,
-                    superfluousDisableCommandRule: superfluousDisableCommandRule,
-                    globalConfiguration: configuration.globalConfiguration,
-                    compilerArguments: compilerArguments)
+        let validateRule: @Sendable (any Rule) -> LintResult = { rule in
+            rule.lint(file: file, regions: regions, benchmark: benchmark,
+                      storage: storage,
+                      superfluousDisableCommandRule: superfluousDisableCommandRule,
+                      globalConfiguration: configuration.globalConfiguration,
+                      compilerArguments: compilerArguments)
         }
+        let validationResults: [LintResult] = compilerArguments.isEmpty
+            ? rules.parallelMap(transform: validateRule)
+            : rules.map(validateRule)
         let undefinedSuperfluousCommandViolations = undefinedSuperfluousCommandViolations(
             regions: regions, configuration: configuration,
             superfluousDisableCommandRule: superfluousDisableCommandRule)

--- a/Source/SwiftLintFramework/Models/Linter.swift
+++ b/Source/SwiftLintFramework/Models/Linter.swift
@@ -253,6 +253,7 @@ public struct Linter {
     fileprivate let cache: LinterCache?
     fileprivate let configuration: Configuration
     fileprivate let compilerArguments: [String]
+    var usesParallelRuleScheduling: Bool { compilerArguments.isEmpty }
 
     /// Creates a `Linter` by specifying its properties directly.
     ///
@@ -291,7 +292,7 @@ public struct Linter {
                 rule.collectInfo(for: file, into: storage, compilerArguments: compilerArguments)
             }
         }
-        if compilerArguments.isEmpty {
+        if usesParallelRuleScheduling {
             DispatchQueue.concurrentPerform(iterations: rules.count) { idx in
                 collectRule(rules[idx])
             }
@@ -312,6 +313,7 @@ public struct CollectedLinter {
     private let cache: LinterCache?
     private let configuration: Configuration
     private let compilerArguments: [String]
+    var usesParallelRuleScheduling: Bool { compilerArguments.isEmpty }
 
     fileprivate init(from linter: Linter) {
         file = linter.file
@@ -362,7 +364,7 @@ public struct CollectedLinter {
                       globalConfiguration: configuration.globalConfiguration,
                       compilerArguments: compilerArguments)
         }
-        let validationResults: [LintResult] = compilerArguments.isEmpty
+        let validationResults: [LintResult] = usesParallelRuleScheduling
             ? rules.parallelMap(transform: validateRule)
             : rules.map(validateRule)
         let undefinedSuperfluousCommandViolations = undefinedSuperfluousCommandViolations(

--- a/Tests/FrameworkTests/CollectingRuleTests.swift
+++ b/Tests/FrameworkTests/CollectingRuleTests.swift
@@ -97,8 +97,10 @@ struct CollectingRuleTests {
             compilerArguments: ["-module-name", "SchedulingTest"]
         )
 
+        #expect(!linter.usesParallelRuleScheduling)
         _ = linter.collect(into: RuleStorage())
 
+        #expect(probe.invocationCount == 2)
         #expect(!probe.didOverlap)
     }
 
@@ -117,14 +119,16 @@ struct CollectingRuleTests {
         )
 
         let collectedLinter = linter.collect(into: storage)
+        #expect(!collectedLinter.usesParallelRuleScheduling)
         _ = collectedLinter.styleViolations(using: storage)
 
+        #expect(probe.invocationCount == 2)
         #expect(!probe.didOverlap)
     }
 
     @Test
     func lintRuleCollectionRemainsParallel() {
-        let probe = SchedulingProbe(waitTimeout: .seconds(10))
+        let probe = SchedulingProbe(waitsForOverlap: false)
         let rules: [any Rule] = [
             LintSchedulingRule<FirstSchedulingRule>(collectionProbe: probe),
             LintSchedulingRule<SecondSchedulingRule>(collectionProbe: probe),
@@ -134,14 +138,14 @@ struct CollectingRuleTests {
             configuration: schedulingConfiguration(rules)
         )
 
+        #expect(linter.usesParallelRuleScheduling)
         _ = linter.collect(into: RuleStorage())
-
-        #expect(probe.didOverlap)
+        #expect(probe.invocationCount == 2)
     }
 
     @Test
     func lintRuleValidationRemainsParallel() {
-        let probe = SchedulingProbe(waitTimeout: .seconds(10))
+        let probe = SchedulingProbe(waitsForOverlap: false)
         let rules: [any Rule] = [
             LintSchedulingRule<FirstSchedulingRule>(validationProbe: probe),
             LintSchedulingRule<SecondSchedulingRule>(validationProbe: probe),
@@ -153,9 +157,9 @@ struct CollectingRuleTests {
         )
 
         let collectedLinter = linter.collect(into: storage)
+        #expect(collectedLinter.usesParallelRuleScheduling)
         _ = collectedLinter.styleViolations(using: storage)
-
-        #expect(probe.didOverlap)
+        #expect(probe.invocationCount == 2)
     }
 
     @Test
@@ -318,13 +322,17 @@ private struct LintSchedulingRule<Marker: SchedulingRuleMarker>: MockCollectingR
 private final class SchedulingProbe: @unchecked Sendable {
     private let lock = NSLock()
     private let overlapSignal = DispatchSemaphore(value: 0)
-    private let waitTimeout: DispatchTimeInterval
+    private let waitsForOverlap: Bool
     private var activeInvocations = 0
-    private var invocationCount = 0
+    private var invocations = 0
     private var overlapDetected = false
 
-    init(waitTimeout: DispatchTimeInterval = .seconds(1)) {
-        self.waitTimeout = waitTimeout
+    init(waitsForOverlap: Bool = true) {
+        self.waitsForOverlap = waitsForOverlap
+    }
+
+    var invocationCount: Int {
+        lock.withLock { invocations }
     }
 
     var didOverlap: Bool {
@@ -333,17 +341,17 @@ private final class SchedulingProbe: @unchecked Sendable {
 
     func recordInvocation() {
         let invocation = lock.withLock { () -> Int in
-            invocationCount += 1
+            invocations += 1
             activeInvocations += 1
             if activeInvocations > 1 {
                 overlapDetected = true
                 overlapSignal.signal()
             }
-            return invocationCount
+            return invocations
         }
 
-        if invocation == 1 {
-            _ = overlapSignal.wait(timeout: .now() + waitTimeout)
+        if invocation == 1, waitsForOverlap {
+            _ = overlapSignal.wait(timeout: .now() + .seconds(1))
         }
 
         lock.withLock {

--- a/Tests/FrameworkTests/CollectingRuleTests.swift
+++ b/Tests/FrameworkTests/CollectingRuleTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import SourceKittenFramework
 import TestHelpers
 import Testing
@@ -84,6 +85,80 @@ struct CollectingRuleTests {
     }
 
     @Test
+    func analyzerRuleCollectionIsSerialized() {
+        let probe = SchedulingProbe()
+        let rules: [any Rule] = [
+            AnalyzerSchedulingRule<FirstSchedulingRule>(collectionProbe: probe),
+            AnalyzerSchedulingRule<SecondSchedulingRule>(collectionProbe: probe),
+        ]
+        let linter = Linter(
+            file: SwiftLintFile(contents: "let value = 1"),
+            configuration: schedulingConfiguration(rules),
+            compilerArguments: ["-module-name", "SchedulingTest"]
+        )
+
+        _ = linter.collect(into: RuleStorage())
+
+        #expect(!probe.didOverlap)
+    }
+
+    @Test
+    func analyzerRuleValidationIsSerialized() {
+        let probe = SchedulingProbe()
+        let rules: [any Rule] = [
+            AnalyzerSchedulingRule<FirstSchedulingRule>(validationProbe: probe),
+            AnalyzerSchedulingRule<SecondSchedulingRule>(validationProbe: probe),
+        ]
+        let storage = RuleStorage()
+        let linter = Linter(
+            file: SwiftLintFile(contents: "let value = 1"),
+            configuration: schedulingConfiguration(rules),
+            compilerArguments: ["-module-name", "SchedulingTest"]
+        )
+
+        let collectedLinter = linter.collect(into: storage)
+        _ = collectedLinter.styleViolations(using: storage)
+
+        #expect(!probe.didOverlap)
+    }
+
+    @Test
+    func lintRuleCollectionRemainsParallel() {
+        let probe = SchedulingProbe()
+        let rules: [any Rule] = [
+            LintSchedulingRule<FirstSchedulingRule>(collectionProbe: probe),
+            LintSchedulingRule<SecondSchedulingRule>(collectionProbe: probe),
+        ]
+        let linter = Linter(
+            file: SwiftLintFile(contents: "let value = 1"),
+            configuration: schedulingConfiguration(rules)
+        )
+
+        _ = linter.collect(into: RuleStorage())
+
+        #expect(probe.didOverlap)
+    }
+
+    @Test
+    func lintRuleValidationRemainsParallel() {
+        let probe = SchedulingProbe()
+        let rules: [any Rule] = [
+            LintSchedulingRule<FirstSchedulingRule>(validationProbe: probe),
+            LintSchedulingRule<SecondSchedulingRule>(validationProbe: probe),
+        ]
+        let storage = RuleStorage()
+        let linter = Linter(
+            file: SwiftLintFile(contents: "let value = 1"),
+            configuration: schedulingConfiguration(rules)
+        )
+
+        let collectedLinter = linter.collect(into: storage)
+        _ = collectedLinter.styleViolations(using: storage)
+
+        #expect(probe.didOverlap)
+    }
+
+    @Test
     func corrects() {
         struct Spec: MockCollectingRule, CorrectableRule {
             var configuration = SeverityConfiguration<Self>(.warning)
@@ -151,6 +226,124 @@ struct CollectingRuleTests {
         let inputs = ["foo", "baz"]
         #expect(inputs.corrections(config: Spec.configuration!).count == 1)
         #expect(inputs.corrections(config: AnalyzerSpec.configuration!, requiresFileOnDisk: true).count == 1)
+    }
+}
+
+private func schedulingConfiguration(_ rules: [any Rule]) -> Configuration {
+    Configuration(
+        rulesMode: .onlyConfiguration(Set(rules.map { type(of: $0).identifier })),
+        allRulesWrapped: rules.map { ($0, false) },
+        ruleList: RuleList(rules: rules.map { type(of: $0) })
+    )
+}
+
+private protocol SchedulingRuleMarker: Sendable {
+    static var identifier: String { get }
+}
+
+private enum FirstSchedulingRule: SchedulingRuleMarker {
+    static let identifier = "first_scheduling_rule"
+}
+
+private enum SecondSchedulingRule: SchedulingRuleMarker {
+    static let identifier = "second_scheduling_rule"
+}
+
+private struct AnalyzerSchedulingRule<Marker: SchedulingRuleMarker>:
+    MockCollectingRule, AnalyzerRule, SourceKitFreeRule {
+    var configuration = SeverityConfiguration<Self>(.warning)
+    private let collectionProbe: SchedulingProbe?
+    private let validationProbe: SchedulingProbe?
+
+    init() {
+        collectionProbe = nil
+        validationProbe = nil
+    }
+
+    init(collectionProbe: SchedulingProbe? = nil, validationProbe: SchedulingProbe? = nil) {
+        self.collectionProbe = collectionProbe
+        self.validationProbe = validationProbe
+    }
+
+    static var description: RuleDescription {
+        RuleDescription(identifier: Marker.identifier, name: "", description: "", kind: .lint)
+    }
+
+    func collectInfo(for _: SwiftLintFile, compilerArguments _: [String]) -> Bool {
+        collectionProbe?.recordInvocation()
+        return true
+    }
+
+    func validate(
+        file _: SwiftLintFile,
+        collectedInfo _: [SwiftLintFile: Bool],
+        compilerArguments _: [String]
+    ) -> [StyleViolation] {
+        validationProbe?.recordInvocation()
+        return []
+    }
+}
+
+private struct LintSchedulingRule<Marker: SchedulingRuleMarker>: MockCollectingRule, SourceKitFreeRule {
+    var configuration = SeverityConfiguration<Self>(.warning)
+    private let collectionProbe: SchedulingProbe?
+    private let validationProbe: SchedulingProbe?
+
+    init() {
+        collectionProbe = nil
+        validationProbe = nil
+    }
+
+    init(collectionProbe: SchedulingProbe? = nil, validationProbe: SchedulingProbe? = nil) {
+        self.collectionProbe = collectionProbe
+        self.validationProbe = validationProbe
+    }
+
+    static var description: RuleDescription {
+        RuleDescription(identifier: Marker.identifier, name: "", description: "", kind: .lint)
+    }
+
+    func collectInfo(for _: SwiftLintFile) -> Bool {
+        collectionProbe?.recordInvocation()
+        return true
+    }
+
+    func validate(file _: SwiftLintFile, collectedInfo _: [SwiftLintFile: Bool]) -> [StyleViolation] {
+        validationProbe?.recordInvocation()
+        return []
+    }
+}
+
+// All mutable state is private, protected by `lock`, and no mutable reference escapes.
+private final class SchedulingProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private let overlapSignal = DispatchSemaphore(value: 0)
+    private var activeInvocations = 0
+    private var invocationCount = 0
+    private var overlapDetected = false
+
+    var didOverlap: Bool {
+        lock.withLock { overlapDetected }
+    }
+
+    func recordInvocation() {
+        let invocation = lock.withLock { () -> Int in
+            invocationCount += 1
+            activeInvocations += 1
+            if activeInvocations > 1 {
+                overlapDetected = true
+                overlapSignal.signal()
+            }
+            return invocationCount
+        }
+
+        if invocation == 1 {
+            _ = overlapSignal.wait(timeout: .now() + .seconds(1))
+        }
+
+        lock.withLock {
+            activeInvocations -= 1
+        }
     }
 }
 

--- a/Tests/FrameworkTests/CollectingRuleTests.swift
+++ b/Tests/FrameworkTests/CollectingRuleTests.swift
@@ -124,7 +124,7 @@ struct CollectingRuleTests {
 
     @Test
     func lintRuleCollectionRemainsParallel() {
-        let probe = SchedulingProbe()
+        let probe = SchedulingProbe(waitTimeout: .seconds(10))
         let rules: [any Rule] = [
             LintSchedulingRule<FirstSchedulingRule>(collectionProbe: probe),
             LintSchedulingRule<SecondSchedulingRule>(collectionProbe: probe),
@@ -141,7 +141,7 @@ struct CollectingRuleTests {
 
     @Test
     func lintRuleValidationRemainsParallel() {
-        let probe = SchedulingProbe()
+        let probe = SchedulingProbe(waitTimeout: .seconds(10))
         let rules: [any Rule] = [
             LintSchedulingRule<FirstSchedulingRule>(validationProbe: probe),
             LintSchedulingRule<SecondSchedulingRule>(validationProbe: probe),
@@ -318,9 +318,14 @@ private struct LintSchedulingRule<Marker: SchedulingRuleMarker>: MockCollectingR
 private final class SchedulingProbe: @unchecked Sendable {
     private let lock = NSLock()
     private let overlapSignal = DispatchSemaphore(value: 0)
+    private let waitTimeout: DispatchTimeInterval
     private var activeInvocations = 0
     private var invocationCount = 0
     private var overlapDetected = false
+
+    init(waitTimeout: DispatchTimeInterval = .seconds(1)) {
+        self.waitTimeout = waitTimeout
+    }
 
     var didOverlap: Bool {
         lock.withLock { overlapDetected }
@@ -338,7 +343,7 @@ private final class SchedulingProbe: @unchecked Sendable {
         }
 
         if invocation == 1 {
-            _ = overlapSignal.wait(timeout: .now() + .seconds(1))
+            _ = overlapSignal.wait(timeout: .now() + waitTimeout)
         }
 
         lock.withLock {


### PR DESCRIPTION
## Summary

Fixes #3020.

`swiftlint analyze` can schedule multiple collecting analyzer rules at the same
time for one file and compiler context. Those rules may send overlapping
SourceKit requests, causing nondeterministic `Could not get cursor info` errors,
missing violations, or an analyzer crash.

This pull request gives analyzer mode a serial rule-scheduling path while
preserving the existing parallel path for regular linting.

## Root cause

`Linter.collect(into:)` used `DispatchQueue.concurrentPerform` for every rule,
and `CollectedLinter.getStyleViolations(using:benchmark:)` used `parallelMap`.
That scheduling works for ordinary lint rules, but analyzer rules share compiler
arguments and SourceKit state for the same file. Nothing prevented their
collection and validation requests from overlapping.

## Changes

- Use serial rule collection and validation when compiler arguments are present.
- Keep parallel rule collection and validation when compiler arguments are empty.
- Add deterministic scheduling tests for analyzer collection, analyzer
  validation, lint collection, and lint validation.
- Add a changelog entry linked to #3020.

## Why this fixes #3020

Analyzer runs carry compiler arguments, so their collecting and validation
stages now finish one rule before starting the next. Multiple analyzer rules can
therefore run in one invocation without competing for the same SourceKit
context. Regular `swiftlint lint` runs still use parallel rule scheduling.

## Validation

- [x] `swift test --filter CollectingRuleTests` (8 tests passed)
- [x] `swift test --no-parallel` (1,092 tests in 374 suites passed)
- [x] `swift run swiftlint lint --strict` (0 violations)
- [x] `make portable_zip`
- [x] CI on the current head

