### PR TITLE
Fix analyze handling of Xcode 26 @response files

### DIFF
--- a/Source/SwiftLintFramework/CompilerArgumentsExtractor.swift
+++ b/Source/SwiftLintFramework/CompilerArgumentsExtractor.swift
@@ -22,19 +22,33 @@ private func parseCLIArguments(_ string: String) -> [String] {
     let scanner = Scanner(string: string)
     var str = ""
     var didStart = false
-    while let result = scanner.scanUpToString("\"") {
+    while !scanner.isAtEnd {
+        var result: String? = scanner.scanUpToString("\"")
+        if result == nil {
+            result = ""
+        }
         if didStart {
-            str += result.replacingOccurrences(of: " ", with: escapedSpacePlaceholder)
+            str += result!.replacingOccurrences(of: " ", with: escapedSpacePlaceholder)
             str += " "
         } else {
-            str += result
+            str += result!
         }
-        _ = scanner.scanString("\"")
-        didStart.toggle()
+        if scanner.scanString("\"") != nil {
+            didStart.toggle()
+        } else {
+            let remaining = String(scanner.string[scanner.currentIndex...])
+            if didStart {
+                str += remaining.replacingOccurrences(of: " ", with: escapedSpacePlaceholder)
+            } else {
+                str += remaining
+            }
+            break
+        }
     }
-    return str.trimmingCharacters(in: .whitespaces)
+    return str.trimmingCharacters(in: .whitespacesAndNewlines)
         .replacingOccurrences(of: "\\ ", with: escapedSpacePlaceholder)
-        .components(separatedBy: " ")
+        .components(separatedBy: .whitespacesAndNewlines)
+        .filter { !$0.isEmpty }
         .map { $0.replacingOccurrences(of: escapedSpacePlaceholder, with: " ") }
 }
 
@@ -65,9 +79,12 @@ extension Array where Element == String {
             }
             let responseFile = String(arg.dropFirst())
             return (try? String(contentsOf: URL(filePath: responseFile, directoryHint: .notDirectory))).flatMap {
-                $0.trimmingCharacters(in: .newlines)
-                    .components(separatedBy: "\n")
-                    .expandingResponseFiles
+                // Response files may contain arguments separated by whitespace
+                // (spaces, newlines) with quoting for paths containing spaces.
+                // Reuse the CLI parser so both Xcode 25 (newline-separated) and
+                // Xcode 26 (space-separated via @response files) layouts are
+                // handled, including nested @ files.
+                parseCLIArguments($0).expandingResponseFiles
             } ?? [arg]
         }
     }


### PR DESCRIPTION
Fixes #6877

### Problem

`swiftlint analyze` reported 0 files with exit 0 on Xcode 26 build logs:

```bash
xcodebuild ... clean build > xcodebuild.log
swiftlint analyze --compiler-log-path xcodebuild.log
# Done analyzing! Found 0 violations, 0 serious in 0 files.
```

Xcode 26 passes swiftc arguments via `@response` files (`.../swiftc -module-name Sovran -Onone @/path/to/response`). The log parser's `expandingResponseFiles` only split response files by newlines (`components(separatedBy: "\n")`), so space-separated files (Xcode 26) were treated as a single argument and no source files were discovered.

Quoted paths with spaces and nested `@` files were also at risk, and `parseCLIArguments` mishandled leading quotes.

### Change

- Reuse `parseCLIArguments` for response file contents so both newline-separated (Xcode 25) and space-separated (Xcode 26) layouts are handled, including quoted paths and nested `@` files.
- Fix `parseCLIArguments` to correctly handle leading quotes and to split on `whitespacesAndNewlines` (not just `" "`), filtering empty components. This preserves existing log parsing while fixing response-file parsing.

### Validation

- Manual reproduction with temporary response files:
  - newline-separated (3 files) → 3, space-separated (3 files) → 3, quoted path with space → 2 correctly, mixed flags + files → 5
  - `swiftc -module-name Sovran -Onone @/path` correctly expands
  - `bash -n` equivalent file check passes; `swift build` of `SwiftLintFramework` target compiles (change is isolated to `CompilerArgumentsExtractor.swift`)
