### PR TITLE
Add `#example` macro allowing for compiled example code

### DIFF
--- a/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedParameterRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/UnusedParameterRule.swift
@@ -16,57 +16,58 @@ struct UnusedParameterRule: Rule {
             or replaced/shadowed by a wildcard '_' to indicate that they are being deliberately disregarded.
             """,
         kind: .lint,
-        nonTriggeringExamples: #examples([
-            """
-            func f(a: Int) {
-                _ = a
-            }
-            """,
-            """
-            func f(case: Int) {
-                _ = `case`
-            }
-            """,
-            """
-            func f(a _: Int) {}
-            """,
-            """
-            func f(_: Int) {}
-            """,
-            """
-            func f(a: Int, b c: String) {
-                func g() {
+        // swiftlint:disable all
+        nonTriggeringExamples: [
+            #example {
+                func f(a: Int) {
                     _ = a
-                    _ = c
                 }
-            }
-            """,
-            """
-            func f(a: Int, c: Int) -> Int {
-                struct S {
-                    let b = 1
-                    func f(a: Int, b: Int = 2) -> Int { a + b }
+            },
+            #example {
+                func f(case: Int) {
+                    _ = `case`
                 }
-                return a + c
-            }
-            """,
-            """
-            func f(a: Int?) {
-                if let a {}
-            }
-            """,
-            """
-            func f(a: Int) {
-                let a = a
-                return a
-            }
-            """,
-            """
-            func f(`operator`: Int) -> Int { `operator` }
-            """,
-            """
-            func f(_a: Int) {}
-            """.asExample(configuration: allowUnderscorePrefixedNames),
+            },
+            #example {
+                func f(a _: Int) {}
+            },
+            #example {
+                func f(_: Int) {}
+            },
+            #example {
+                func f(a: Int, b c: String) {
+                    func g() {
+                        _ = a
+                        _ = c
+                    }
+                }
+            },
+            #example {
+                func f(a: Int, c: Int) -> Int {
+                    struct S {
+                        let b = 1
+                        func f(a: Int, b: Int = 2) -> Int { a + b }
+                    }
+                    return a + c
+                }
+            },
+            #example {
+                func f(a: Int?) {
+                    if let a {}
+                }
+            },
+            #example {
+                func f(a: Int) -> Int {
+                    let a = a
+                    return a
+                }
+            },
+            #example {
+                func f(`operator`: Int) -> Int { `operator` }
+            },
+            #example(configuration: allowUnderscorePrefixedNames) {
+                func f(_a: Int) {}
+            },
             """
             List($history) { $_historyItem in
                 Foo()
@@ -76,7 +77,7 @@ struct UnusedParameterRule: Rule {
             List($history) { $historyItem in
                 Foo(url: historyItem.url)
             }
-            """,
+            """.asExample(),
             """
             List($history) { $historyItem in
                 Foo(binding: $historyItem)
@@ -86,90 +87,91 @@ struct UnusedParameterRule: Rule {
             List($history) { $_ in
                 Foo()
             }
-            """.asExample(excludeFromDocumentation: true),
-        ]),
-        triggeringExamples: #examples([
-            """
-            func f(↓a: Int) {}
-            """,
-            """
-            func f(↓_a: Int) {}
-            """,
-            """
-            func f(↓a: Int, b ↓c: String) {}
-            """,
-            """
-            func f(↓a: Int, b ↓c: String) {
-                func g(a: Int, ↓b: Double) {
-                    _ = a
+            """.asExample(excludeFromDocumentation: true)
+        ],
+        triggeringExamples: [
+            #example {
+                func f(/*>*/a: Int) {}
+            },
+            #example {
+                func f(/*>*/_a: Int) {}
+            },
+            #example {
+                func f(/*>*/a: Int, b /*>*/c: String) {}
+            },
+            #example {
+                func f(/*>*/a: Int, b /*>*/c: String) {
+                    func g(a: Int, /*>*/b: Double) {
+                        _ = a
+                    }
                 }
-            }
-            """,
-            """
-            struct S {
-                let a: Int
-
-                init(a: Int, ↓b: Int) {
-                    func f(↓a: Int, b: Int) -> Int { b }
-                    self.a = f(a: a, b: 0)
-                }
-            }
-            """,
-            """
-            struct S {
-                subscript(a: Int, ↓b: Int) {
-                    func f(↓a: Int, b: Int) -> Int { b }
-                    return f(a: a, b: 0)
-                }
-            }
-            """,
-            """
-            func f(↓a: Int, ↓b: Int, c: Int) -> Int {
+            },
+            #example {
                 struct S {
-                    let b = 1
-                    func f(a: Int, ↓c: Int = 2) -> Int { a + b }
+                    let a: Int
+
+                    init(a: Int, /*>*/b: Int) {
+                        func f(/*>*/a: Int, b: Int) -> Int { b }
+                        self.a = f(a: a, b: 0)
+                    }
                 }
-                return S().f(a: c)
-            }
-            """,
-            """
-            func f(↓a: Int, c: String) {
-                let a = 1
-                return a + c
-            }
-            """,
+            },
+            #example {
+                struct S {
+                    subscript(a: Int, /*>*/b: Int) -> Int {
+                        func f(/*>*/a: Int, b: Int) -> Int { b }
+                        return f(a: a, b: 0)
+                    }
+                }
+            },
+            #example {
+                func f(/*>*/a: Int, /*>*/b: Int, c: Int) -> Int {
+                    struct S {
+                        let b = 1
+                        func f(a: Int, /*>*/c: Int = 2) -> Int { a + b }
+                    }
+                    return S().f(a: c)
+                }
+            },
+            #example {
+                func f(/*>*/a: Int, c: String) -> Int {
+                    let a = 1
+                    return a + Int(c)!
+                }
+            },
             """
             List($history) { ↓$historyItem in
                 Foo()
             }
-            """,
-        ]),
-        corrections: #corrections([
-            """
-            func f(a: Int) {}
-            """: """
-            func f(a _: Int) {}
-            """,
-            """
-            func f(a b: Int) {}
-            """: """
-            func f(a _: Int) {}
-            """,
-            """
-            func f(_ a: Int) {}
-            """: """
-            func f(_: Int) {}
-            """,
+            """.asExample(),
+        ],
+        corrections: [
+            #example {
+                func f(/*>*/a: Int) {}
+            }: #example {
+                func f(a _: Int) {}
+            },
+            #example {
+                func f(a /*>*/b: Int) {}
+            }: #example {
+                func f(a _: Int) {}
+            },
+            #example {
+                func f(_ /*>*/a: Int) {}
+            }: #example {
+                func f(_: Int) {}
+            },
             """
             List($history) { $historyItem in
                 Foo()
             }
-            """: """
+            """.asExample(): """
             List($history) { $_ in
                 Foo()
             }
-            """,
-        ])
+            """.asExample()
+        ]
+        //swiftlint:enable all
     )
 }
 

--- a/Source/SwiftLintCore/Helpers/Macros.swift
+++ b/Source/SwiftLintCore/Helpers/Macros.swift
@@ -99,3 +99,31 @@ public macro corrections(_ examples: [Example: Example]) -> [Example: Example] =
     module: "SwiftLintCoreMacros",
     type: "Corrections"
 )
+
+/// Macro that allows to define an example for a rule. It generates an ``Example`` instance with the provided code,
+/// configuration and other options. Valuable is that the code passed as the example's body is compiled, thus making
+/// sure that the example is valid Swift code.
+///
+/// - Parameters:
+///   - configuration: The untyped configuration to apply to the rule, if deviating from the default configuration.
+///   - testMultiByteOffsets: Whether the example should be tested by prepending multi-byte grapheme clusters.
+///   - testWrappingInComment: Whether test shall verify that the example wrapped in a comment doesn't trigger.
+///   - testWrappingInString: Whether tests shall verify that the example wrapped into a string doesn't trigger.
+///   - testDisableCommand: Whether tests shall verify that the disabled rule (comment in the example) doesn't trigger.
+///   - testOnLinux: Whether the example should be tested on Linux.
+///   - testOnWindows: Whether the example should be tested on Windows.
+///   - excludeFromDocumentation: Whether the example should be excluded from the rule's documentation.
+///   - body: The body of the example, which is compiled to ensure that it is valid Swift code.
+@freestanding(expression)
+public macro example(configuration: [String: any Sendable]? = nil,
+                     testMultiByteOffsets: Bool = true,
+                     testWrappingInComment: Bool = true,
+                     testWrappingInString: Bool = true,
+                     testDisableCommand: Bool = true,
+                     testOnLinux: Bool = true,
+                     testOnWindows: Bool = true,
+                     excludeFromDocumentation: Bool = false,
+                     body: () -> Void) -> Example = #externalMacro(
+    module: "SwiftLintCoreMacros",
+    type: "Example"
+)

--- a/Source/SwiftLintCore/Models/Example.swift
+++ b/Source/SwiftLintCore/Models/Example.swift
@@ -74,10 +74,10 @@ public extension Example {
          testDisableCommand: Bool = true,
          testOnLinux: Bool = true,
          testOnWindows: Bool = true,
+         excludeFromDocumentation: Bool = false,
          fileID: String = #fileID,
          file: StaticString = #filePath,
-         line: UInt = #line,
-         excludeFromDocumentation: Bool = false) {
+         line: UInt = #line) {
         self.code = code
         self.configuration = configuration
         self.testMultiByteOffsets = testMultiByteOffsets
@@ -164,13 +164,13 @@ public extension String {
     /// Wraps this code in an `Example`, applying the specified properties.
     func asExample(
         configuration: [String: any Sendable]? = nil,
-        excludeFromDocumentation: Bool = false,
-        testWrappingInComment: Bool = true,
         testMultiByteOffsets: Bool = true,
+        testWrappingInComment: Bool = true,
         testWrappingInString: Bool = true,
         testDisableCommand: Bool = true,
         testOnLinux: Bool = true,
         testOnWindows: Bool = true,
+        excludeFromDocumentation: Bool = false,
         fileID: String = #fileID,
         file: StaticString = #filePath,
         line: UInt = #line
@@ -184,10 +184,10 @@ public extension String {
             testDisableCommand: testDisableCommand,
             testOnLinux: testOnLinux,
             testOnWindows: testOnWindows,
+            excludeFromDocumentation: excludeFromDocumentation,
             fileID: fileID,
             file: file,
-            line: line,
-            excludeFromDocumentation: excludeFromDocumentation
+            line: line
         )
     }
 

--- a/Source/SwiftLintCoreMacros/Example.swift
+++ b/Source/SwiftLintCoreMacros/Example.swift
@@ -1,0 +1,78 @@
+import SwiftBasicFormat
+import SwiftLintBase
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+// swiftlint:disable:next blanket_disable_command
+// swiftlint:disable fatal_error
+
+struct Example: ExpressionMacro {
+    static func expansion(
+        of node: some FreestandingMacroExpansionSyntax,
+        in context: some MacroExpansionContext
+    ) -> ExprSyntax {
+        guard let fileID = context.location(of: node, at: .afterLeadingTrivia, filePathMode: .fileID),
+              let filePath = context.location(of: node, at: .afterLeadingTrivia, filePathMode: .filePath) else {
+            context.diagnose(SwiftLintCoreMacroError.invalidSourceLocation.diagnose(at: node))
+            fatalError(SwiftLintCoreMacroError.invalidSourceLocation.message)
+        }
+
+        guard let trailingClosure = node.trailingClosure else {
+            context.diagnose(SwiftLintCoreMacroError.missingExampleBody.diagnose(at: node))
+            fatalError(SwiftLintCoreMacroError.missingExampleBody.message)
+        }
+
+        let spacesCount = trailingClosure.rightBrace.leadingTrivia.countSpaces
+        let example = """
+            Example(
+                code: \"\"\"\(trailingClosure.statements.asExampleBody(unindentedBy: spacesCount))
+                \"\"\",
+                \(node.exampleArguments),
+                fileID: \(fileID.file),
+                file: \(filePath.file),
+                line: \(filePath.line)
+            )
+            """.indent(by: spacesCount)
+        return ExprSyntax(stringLiteral: example)
+    }
+}
+
+private extension FreestandingMacroExpansionSyntax {
+    func argumentValue(named name: String) -> String? {
+        arguments.first { $0.label?.text == name }?.expression.description
+    }
+
+    var exampleArguments: String {
+        """
+        configuration: \(argumentValue(named: "configuration") ?? "[:]"),
+        testMultiByteOffsets: \(argumentValue(named: "testMultiByteOffsets") ?? "true"),
+        testWrappingInComment: \(argumentValue(named: "testWrappingInComment") ?? "true"),
+        testWrappingInString: \(argumentValue(named: "testWrappingInString") ?? "true"),
+        testDisableCommand: \(argumentValue(named: "testDisableCommand") ?? "true"),
+        testOnLinux: \(argumentValue(named: "testOnLinux") ?? "true"),
+        testOnWindows: \(argumentValue(named: "testOnWindows") ?? "true"),
+        excludeFromDocumentation: \(argumentValue(named: "excludeFromDocumentation") ?? "false")
+        """.indent(by: 4, skipFirst: true)
+    }
+}
+
+private extension CodeBlockItemListSyntax {
+    func asExampleBody(unindentedBy spaces: Int) -> String {
+        CodeIndentingRewriter(style: .unindentSpaces(spaces))
+            .visit(self)
+            .description
+            .replacing("/*>*/", with: "↓")
+    }
+}
+
+private extension Trivia {
+    var countSpaces: Int {
+        pieces.compactMap { piece in
+            switch piece {
+            case let .spaces(number): number
+            default: nil
+            }
+        }.reduce(0, +)
+    }
+}

--- a/Source/SwiftLintCoreMacros/Example.swift
+++ b/Source/SwiftLintCoreMacros/Example.swift
@@ -1,11 +1,7 @@
-import SwiftBasicFormat
 import SwiftLintBase
 import SwiftSyntax
 import SwiftSyntaxBuilder
 import SwiftSyntaxMacros
-
-// swiftlint:disable:next blanket_disable_command
-// swiftlint:disable fatal_error
 
 struct Example: ExpressionMacro {
     static func expansion(
@@ -15,45 +11,61 @@ struct Example: ExpressionMacro {
         guard let fileID = context.location(of: node, at: .afterLeadingTrivia, filePathMode: .fileID),
               let filePath = context.location(of: node, at: .afterLeadingTrivia, filePathMode: .filePath) else {
             context.diagnose(SwiftLintCoreMacroError.invalidSourceLocation.diagnose(at: node))
-            fatalError(SwiftLintCoreMacroError.invalidSourceLocation.message)
+            return ""
         }
 
         guard let trailingClosure = node.trailingClosure else {
             context.diagnose(SwiftLintCoreMacroError.missingExampleBody.diagnose(at: node))
-            fatalError(SwiftLintCoreMacroError.missingExampleBody.message)
+            return ""
         }
 
         let spacesCount = trailingClosure.rightBrace.leadingTrivia.countSpaces
-        let example = """
+        let example: ExprSyntax = """
             Example(
-                code: \"\"\"\(trailingClosure.statements.asExampleBody(unindentedBy: spacesCount))
-                \"\"\",
-                \(node.exampleArguments),
+                code: \"\"\"\(raw: trailingClosure.statements.asExampleBody(unindentedBy: spacesCount))
+                \"\"\",\(raw: node.exampleArguments)
                 fileID: \(fileID.file),
                 file: \(filePath.file),
                 line: \(filePath.line)
             )
-            """.indent(by: spacesCount)
-        return ExprSyntax(stringLiteral: example)
+            """
+        return CodeIndentingRewriter(style: .indentSpaces(spacesCount)).visit(example)
     }
 }
 
 private extension FreestandingMacroExpansionSyntax {
-    func argumentValue(named name: String) -> String? {
-        arguments.first { $0.label?.text == name }?.expression.description
-    }
-
     var exampleArguments: String {
-        """
-        configuration: \(argumentValue(named: "configuration") ?? "[:]"),
-        testMultiByteOffsets: \(argumentValue(named: "testMultiByteOffsets") ?? "true"),
-        testWrappingInComment: \(argumentValue(named: "testWrappingInComment") ?? "true"),
-        testWrappingInString: \(argumentValue(named: "testWrappingInString") ?? "true"),
-        testDisableCommand: \(argumentValue(named: "testDisableCommand") ?? "true"),
-        testOnLinux: \(argumentValue(named: "testOnLinux") ?? "true"),
-        testOnWindows: \(argumentValue(named: "testOnWindows") ?? "true"),
-        excludeFromDocumentation: \(argumentValue(named: "excludeFromDocumentation") ?? "false")
-        """.indent(by: 4, skipFirst: true)
+        var arguments = [String]()
+        if let configuration = argumentValue(named: "configuration") {
+            arguments.append("configuration: \(configuration)")
+        }
+        if let testMultiByteOffsets = argumentValue(named: "testMultiByteOffsets") {
+            arguments.append("testMultiByteOffsets: \(testMultiByteOffsets)")
+        }
+        if let testWrappingInComment = argumentValue(named: "testWrappingInComment") {
+            arguments.append("testWrappingInComment: \(testWrappingInComment)")
+        }
+        if let testWrappingInString = argumentValue(named: "testWrappingInString") {
+            arguments.append("testWrappingInString: \(testWrappingInString)")
+        }
+        if let testDisableCommand = argumentValue(named: "testDisableCommand") {
+            arguments.append("testDisableCommand: \(testDisableCommand)")
+        }
+        if let testOnLinux = argumentValue(named: "testOnLinux") {
+            arguments.append("testOnLinux: \(testOnLinux)")
+        }
+        if let testOnWindows = argumentValue(named: "testOnWindows") {
+            arguments.append("testOnWindows: \(testOnWindows)")
+        }
+        if let excludeFromDocumentation = argumentValue(named: "excludeFromDocumentation") {
+            arguments.append("excludeFromDocumentation: \(excludeFromDocumentation)")
+        }
+        if arguments.isEmpty {
+            return ""
+        }
+        return "\n" + arguments
+            .map { "    " + $0 }
+            .joined(separator: ",\n") + ","
     }
 }
 

--- a/Source/SwiftLintCoreMacros/SwiftLintCoreMacroError.swift
+++ b/Source/SwiftLintCoreMacros/SwiftLintCoreMacroError.swift
@@ -15,6 +15,8 @@ enum SwiftLintCoreMacroError: String, DiagnosticMessage {
     case examplesNotArrayLiteral = "Macro argument must be an array literal"
     case correctionsNotDictionaryLiteral = "Macro argument must be a dictionary literal"
     case missingSourceLocation = "Macro could not determine the source location of an example"
+    case invalidSourceLocation = "Invalid source location"
+    case missingExampleBody = "Missing trailing closure (example body)"
 
     var message: String {
         rawValue

--- a/Source/SwiftLintCoreMacros/SwiftLintCoreMacros.swift
+++ b/Source/SwiftLintCoreMacros/SwiftLintCoreMacros.swift
@@ -8,9 +8,10 @@ struct SwiftLintCoreMacros: CompilerPlugin {
     let providingMacros: [any Macro.Type] = [
         AutoConfigParser.self,
         AcceptableByConfigurationElement.self,
-        DisabledWithoutSourceKit.self,
-        Examples.self,
         Corrections.self,
+        DisabledWithoutSourceKit.self,
+        Example.self,
+        Examples.self,
         SwiftSyntaxRule.self,
     ]
 }

--- a/Source/SwiftLintCoreMacros/SwiftSyntax+SwiftLint.swift
+++ b/Source/SwiftLintCoreMacros/SwiftSyntax+SwiftLint.swift
@@ -30,3 +30,9 @@ extension ExprSyntax {
         `as`(BooleanLiteralExprSyntax.self)?.literal.text == "true"
     }
 }
+
+extension FreestandingMacroExpansionSyntax {
+    func argumentValue(named name: String) -> String? {
+        arguments.first { $0.label?.text == name }?.expression.description
+    }
+}

--- a/Tests/MacroTests/ExampleTests.swift
+++ b/Tests/MacroTests/ExampleTests.swift
@@ -1,0 +1,110 @@
+import SwiftLintCore
+import SwiftSyntaxMacroExpansion
+import SwiftSyntaxMacrosGenericTestSupport
+import Testing
+
+@testable import SwiftLintCoreMacros
+
+private let macros = [
+    "example": MacroSpec(type: Example.self)
+]
+
+@freestanding(expression)
+private macro example(body: () -> Void) -> SwiftLintCore.Example = #externalMacro(
+    module: "SwiftLintCoreMacros",
+    type: "Example"
+)
+
+@Suite
+struct ExampleTests {
+    @Test
+    func exampleMacro() {
+        assertMacroExpansion(
+            """
+            #example {
+                func f() {
+                    print("Hello, world!")
+                }
+            }
+            """,
+            expandedSource: """
+            Example(
+                code: \"\"\"
+                func f() {
+                    print("Hello, world!")
+                }
+                \"\"\",
+                configuration: [:],
+                testMultiByteOffsets: true,
+                testWrappingInComment: true,
+                testWrappingInString: true,
+                testDisableCommand: true,
+                testOnLinux: true,
+                testOnWindows: true,
+                excludeFromDocumentation: false,
+                fileID: "TestModule/test.swift",
+                file: "test.swift",
+                line: 1
+            )
+            """,
+            macroSpecs: macros,
+            failureHandler: FailureHandler.instance
+        )
+    }
+
+    @Test
+    func exampleMacroWithConfiguration() {
+        assertMacroExpansion(
+            """
+            #example(
+                configuration: ["severity": "warning"],
+                testMultiByteOffsets: false,
+                testWrappingInComment: false,
+                testWrappingInString: false,
+                testDisableCommand: false,
+                testOnLinux: false,
+                testOnWindows: false,
+                excludeFromDocumentation: true
+            ) {
+                print("Hello, world!")
+            }
+            """,
+            expandedSource: """
+            Example(
+                code: \"\"\"
+                print("Hello, world!")
+                \"\"\",
+                configuration: ["severity": "warning"],
+                testMultiByteOffsets: false,
+                testWrappingInComment: false,
+                testWrappingInString: false,
+                testDisableCommand: false,
+                testOnLinux: false,
+                testOnWindows: false,
+                excludeFromDocumentation: true,
+                fileID: "TestModule/test.swift",
+                file: "test.swift",
+                line: 1
+            )
+            """,
+            macroSpecs: macros,
+            failureHandler: FailureHandler.instance
+        )
+    }
+
+    @Test
+    func exampleCodeIndentation() {
+        let example = #example {
+            func f() {
+                print("Hello, world!")
+            }
+        }
+        let expectedCode = """
+        func f() {
+            print("Hello, world!")
+        }
+        """
+
+        #expect(example.code == expectedCode)
+    }
+}

--- a/Tests/MacroTests/ExampleTests.swift
+++ b/Tests/MacroTests/ExampleTests.swift
@@ -34,14 +34,6 @@ struct ExampleTests {
                     print("Hello, world!")
                 }
                 \"\"\",
-                configuration: [:],
-                testMultiByteOffsets: true,
-                testWrappingInComment: true,
-                testWrappingInString: true,
-                testDisableCommand: true,
-                testOnLinux: true,
-                testOnWindows: true,
-                excludeFromDocumentation: false,
                 fileID: "TestModule/test.swift",
                 file: "test.swift",
                 line: 1


### PR DESCRIPTION
This adds an `#example` (singular) macro that accepts a single trailing closure body which describes the example to test. `/*>*/` marks the position where a violation is expected to trigger.

By having the example code compiled, we can make sure that they describe valid Swift code avoiding examples only passing tests because of a parsing issue.