### PR TITLE
Remove archived VS Code extension recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,12 +418,6 @@ If you've installed SwiftLint via CocoaPods the script should look like this:
 "${PODS_ROOT}/SwiftLint/swiftlint"
 ```
 
-### Visual Studio Code
-
-To integrate SwiftLint with [Visual Studio Code](https://code.visualstudio.com), install the
-[`vscode-swiftlint`](https://marketplace.visualstudio.com/items?itemName=vknabel.vscode-swiftlint)
-extension from the marketplace.
-
 ### Fastlane
 
 You can use the official

--- a/README_CN.md
+++ b/README_CN.md
@@ -246,11 +246,6 @@ _注意：这将隐含地信任所有的Xcode软件包插件，并绕过Xcode的
 ),
 ```
 
-### Visual Studio Code
-
-如果要在[vscode](https://code.visualstudio.com)上使用 SwiftLint，在应用市场上安装
-[`vscode-swiftlint`](https://marketplace.visualstudio.com/items?itemName=vknabel.vscode-swiftlint)扩展。
-
 ### fastlane
 
 你可以用[fastlane官方的SwiftLint功能](https://docs.fastlane.tools/actions/swiftlint)来运行 SwiftLint 作为你的 Fastlane 程序的一部分。


### PR DESCRIPTION
## Summary
- remove the Visual Studio Code integration section from README.md
- remove the matching Visual Studio Code integration section from README_CN.md
- confirm README_KR.md has no Visual Studio Code recommendation to remove

Closes #6541

## Test Plan
- docs-only change
- verified README.md, README_CN.md, and README_KR.md no longer contain Visual Studio Code, vscode-swiftlint, or vknabel.vscode-swiftlint references