### PR TITLE
Inherit allow_zero_lintable_files from parent config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@
 
 ### Bug Fixes
 
+* Inherit `allow_zero_lintable_files` from parent configuration when loaded by a
+  child configuration.  
+  [shubhransh-gupta](https://github.com/shubhransh-gupta)
+  [#6240](https://github.com/realm/SwiftLint/issues/6240)
+
 * Keep the formatting of multiline member chains when correcting
   `legacy_swiftui_aspect_ratio`. The trivia between the base expression and
   `.aspectRatio` is no longer collapsed onto a single line.  

--- a/Source/SwiftLintFramework/Configuration/Configuration+Merging.swift
+++ b/Source/SwiftLintFramework/Configuration/Configuration+Merging.swift
@@ -21,7 +21,7 @@ extension Configuration {
             warningThreshold: mergedWarningTreshold(with: childConfiguration),
             reporter: reporter,
             cachePath: cachePath,
-            allowZeroLintableFiles: childConfiguration.allowZeroLintableFiles,
+            allowZeroLintableFiles: childConfiguration.allowZeroLintableFiles || allowZeroLintableFiles,
             strict: childConfiguration.strict,
             lenient: childConfiguration.lenient,
             baseline: childConfiguration.baseline,

--- a/Tests/FileSystemAccessTests/ConfigurationTests.swift
+++ b/Tests/FileSystemAccessTests/ConfigurationTests.swift
@@ -496,6 +496,14 @@ struct ConfigurationTests { // swiftlint:disable:this type_body_length
     }
 
     @Test
+    func allowZeroLintableFilesMerging() throws {
+        let parentConfiguration = try Configuration(dict: ["allow_zero_lintable_files": true])
+        let childConfiguration = try Configuration(dict: [:])
+        let mergedConfiguration = parentConfiguration.merged(withChild: childConfiguration)
+        #expect(mergedConfiguration.allowZeroLintableFiles)
+    }
+
+    @Test
     func strict() throws {
         let configuration = try Configuration(dict: ["strict": true])
         #expect(configuration.strict)


### PR DESCRIPTION
### Summary
Resolves #6240.

When merging a parent configuration with a child configuration via `parent_config`, `Configuration+Merging.swift` was taking `childConfiguration.allowZeroLintableFiles`. Because `allow_zero_lintable_files` defaults to `false` when unspecified in the child config dictionary, the child config was inadvertently overriding and discarding `allow_zero_lintable_files: true` defined in the parent config.

### Changes
- In `Configuration+Merging.swift`, merge `allowZeroLintableFiles` using `childConfiguration.allowZeroLintableFiles || allowZeroLintableFiles`.
- Added unit test `allowZeroLintableFilesMerging` in `Tests/FileSystemAccessTests/ConfigurationTests.swift`.
- Added `CHANGELOG.md` entry under `Bug Fixes` following repository guidelines.