### PR TITLE
Fix orphaned_doc_comment for current doc comment attachment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@
   [SimplyDanny](https://github.com/SimplyDanny)
   [#5740](https://github.com/realm/SwiftLint/issues/5740)
 
+* Fix `orphaned_doc_comment` to match Swift's current doc comment attachment
+  behavior by allowing ordinary comments between documentation and declarations
+  while flagging documentation groups superseded by later docs.
+  [Hokila](https://github.com/Hokila)
+  [#6897](https://github.com/realm/SwiftLint/issues/6897)
+
 ## 0.65.1: Fresh Folded Fixtures
 
 ### Breaking

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/OrphanedDocCommentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/OrphanedDocCommentRule.swift
@@ -31,40 +31,78 @@ struct OrphanedDocCommentRule: Rule {
             /// https://github.com.
             var myGreatProperty: String!
             """,
-        ]),
-        triggeringExamples: #examples([
             """
-            ↓/// My great property
+            /// My great property
             // Not a doc string
             var myGreatProperty: String!
             """,
             """
-            ↓/// Look here for more info: https://github.com.
+            /// Look here for more info: https://github.com.
             // Not a doc string
             var myGreatProperty: String!
             """,
             """
-            ↓/// Look here for more info: https://github.com.
+            /// Look here for more info: https://github.com.
 
 
             // Not a doc string
             var myGreatProperty: String!
             """,
             """
-            ↓/// Look here for more info: https://github.com.
+            /// Look here for more info: https://github.com.
             // Not a doc string
-            ↓/// My great property
+            /// My great property
             // Not a doc string
             var myGreatProperty: String!
             """,
             """
             extension Nested {
-                ↓///
+                ///
                 /// Look here for more info: https://github.com.
 
                 // Not a doc string
                 var myGreatProperty: String!
             }
+            """,
+        ]),
+        triggeringExamples: #examples([
+            """
+            ↓/// My great property
+
+            /// Documentation that is attached to the declaration.
+            var myGreatProperty: String!
+            """,
+            """
+            ↓/// Look here for more info: https://github.com.
+
+            /// Documentation that is attached to the declaration.
+            var myGreatProperty: String!
+            """,
+            """
+            ↓/// Look here for more info: https://github.com.
+
+
+            /// Documentation that is attached to the declaration.
+            var myGreatProperty: String!
+            """,
+            """
+            ↓/// Look here for more info: https://github.com.
+            ↓/// More orphaned documentation.
+
+            /// Documentation that is attached to the declaration.
+            var myGreatProperty: String!
+            """,
+            """
+            extension Nested {
+                ↓///
+                ↓/// Look here for more info: https://github.com.
+
+                /// Documentation that is attached to the declaration.
+                var myGreatProperty: String!
+            }
+            """,
+            """
+            ↓/// Documentation without a declaration.
             """,
         ])
     )
@@ -74,41 +112,84 @@ private extension OrphanedDocCommentRule {
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: TokenSyntax) {
             let pieces = node.leadingTrivia.pieces
-            var iterator = pieces.enumerated().makeIterator()
-            while let (index, piece) = iterator.next() {
-                switch piece {
-                case .docLineComment(let comment), .docBlockComment(let comment):
-                    // These patterns are often used for "file header" style comments
-                    if !comment.hasPrefix("////"), !comment.hasPrefix("/***") {
-                        if isOrphanedDocComment(with: &iterator) {
-                            let utf8Length = pieces[..<index].reduce(0) { $0 + $1.sourceLength.utf8Length }
-                            violations.append(node.position.advanced(by: utf8Length))
-                        }
-                    }
-
-                default:
-                    break
-                }
+            for offset in orphanedDocCommentOffsets(in: pieces, isEndOfFile: node.tokenKind == .endOfFile) {
+                violations.append(node.position.advanced(by: offset))
             }
         }
     }
 }
 
-private func isOrphanedDocComment(
-    with iterator: inout some IteratorProtocol<(offset: Int, element: TriviaPiece)>
-) -> Bool {
-    while let (_, piece) = iterator.next() {
+private func orphanedDocCommentOffsets(in pieces: [TriviaPiece], isEndOfFile: Bool) -> [Int] {
+    var pendingDocCommentOffsets: [Int] = []
+    var orphanedDocCommentOffsets: [Int] = []
+    var utf8Offset = 0
+    var currentLine = 1
+    var previousCommentEndLine: Int?
+
+    for piece in pieces {
+        defer {
+            utf8Offset += piece.sourceLength.utf8Length
+            currentLine += piece.lineBreakCount
+        }
+
         switch piece {
-        case .docLineComment, .docBlockComment,
-             .carriageReturns, .carriageReturnLineFeeds, .newlines, .spaces:
-            break
+        case .docLineComment(let comment), .docBlockComment(let comment):
+            // These patterns are often used for "file header" style comments.
+            guard !comment.hasPrefix("////"), !comment.hasPrefix("/***") else {
+                continue
+            }
 
         case .lineComment, .blockComment:
-            return true
+            previousCommentEndLine = currentLine + piece.lineBreakCount
 
+        default:
+            continue
+        }
+
+        guard piece.isDocComment else {
+            continue
+        }
+
+        if let previousCommentEndLine,
+           !pendingDocCommentOffsets.isEmpty,
+           currentLine > previousCommentEndLine + 1 {
+            orphanedDocCommentOffsets.append(contentsOf: pendingDocCommentOffsets)
+            pendingDocCommentOffsets.removeAll()
+        }
+
+        pendingDocCommentOffsets.append(utf8Offset)
+        previousCommentEndLine = currentLine + piece.lineBreakCount
+    }
+
+    if isEndOfFile {
+        orphanedDocCommentOffsets.append(contentsOf: pendingDocCommentOffsets)
+    }
+
+    return orphanedDocCommentOffsets
+}
+
+private extension TriviaPiece {
+    var isDocComment: Bool {
+        switch self {
+        case .docLineComment, .docBlockComment:
+            return true
         default:
             return false
         }
     }
-    return false
+
+    var lineBreakCount: Int {
+        switch self {
+        case .carriageReturnLineFeeds(let count), .carriageReturns(let count), .newlines(let count):
+            count
+        case .blockComment(let comment), .docBlockComment(let comment),
+             .lineComment(let comment), .docLineComment(let comment),
+             .unexpectedText(let comment):
+            comment.reduce(0) { count, character in
+                count + (character.isNewline ? 1 : 0)
+            }
+        default:
+            0
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- stop treating ordinary comments between documentation and declarations as orphaning doc comments
- flag doc comment groups that are superseded by a later doc comment group after a blank line
- flag doc comments that reach EOF without a following declaration
- update rule examples and changelog for #6897

## Test Plan
- swift test --filter OrphanedDocCommentRuleGeneratedTests
- swift test --filter RulesTests/orphanedDocComment
- swift run swiftlint lint --quiet --no-cache Source/SwiftLintBuiltInRules/Rules/Lint/OrphanedDocCommentRule.swift CHANGELOG.md

Fixes #6897