### PR TITLE
Fix orphaned_doc_comment for current doc comment attachment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@
   [SimplyDanny](https://github.com/SimplyDanny)
   [#5740](https://github.com/realm/SwiftLint/issues/5740)
 
+* Fix `orphaned_doc_comment` to report documentation groups superseded by later
+  docs after a blank line.
+  [Hokila](https://github.com/Hokila)
+  [#6897](https://github.com/realm/SwiftLint/issues/6897)
+
 ## 0.65.1: Fresh Folded Fixtures
 
 ### Breaking

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@
   [#5740](https://github.com/realm/SwiftLint/issues/5740)
 
 * Fix `orphaned_doc_comment` to report documentation groups superseded by later
-  docs after a blank line.
+  docs after a blank line.  
   [Hokila](https://github.com/Hokila)
   [#6897](https://github.com/realm/SwiftLint/issues/6897)
 

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/OrphanedDocCommentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/OrphanedDocCommentRule.swift
@@ -60,11 +60,49 @@ struct OrphanedDocCommentRule: Rule {
             """
             extension Nested {
                 ↓///
-                /// Look here for more info: https://github.com.
+                ↓/// Look here for more info: https://github.com.
 
                 // Not a doc string
                 var myGreatProperty: String!
             }
+            """,
+            """
+            ↓/// My great property
+
+            /// Documentation that is attached to the declaration.
+            var myGreatProperty: String!
+            """,
+            """
+            ↓/// Look here for more info: https://github.com.
+
+            /// Documentation that is attached to the declaration.
+            var myGreatProperty: String!
+            """,
+            """
+            ↓/// Look here for more info: https://github.com.
+
+
+            /// Documentation that is attached to the declaration.
+            var myGreatProperty: String!
+            """,
+            """
+            ↓/// Look here for more info: https://github.com.
+            ↓/// More orphaned documentation.
+
+            /// Documentation that is attached to the declaration.
+            var myGreatProperty: String!
+            """,
+            """
+            extension Nested {
+                ↓///
+                ↓/// Look here for more info: https://github.com.
+
+                /// Documentation that is attached to the declaration.
+                var myGreatProperty: String!
+            }
+            """,
+            """
+            ↓/// Documentation without a declaration.
             """,
         ])
     )
@@ -74,41 +112,86 @@ private extension OrphanedDocCommentRule {
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: TokenSyntax) {
             let pieces = node.leadingTrivia.pieces
-            var iterator = pieces.enumerated().makeIterator()
-            while let (index, piece) = iterator.next() {
-                switch piece {
-                case .docLineComment(let comment), .docBlockComment(let comment):
-                    // These patterns are often used for "file header" style comments
-                    if !comment.hasPrefix("////"), !comment.hasPrefix("/***") {
-                        if isOrphanedDocComment(with: &iterator) {
-                            let utf8Length = pieces[..<index].reduce(0) { $0 + $1.sourceLength.utf8Length }
-                            violations.append(node.position.advanced(by: utf8Length))
-                        }
-                    }
-
-                default:
-                    break
-                }
+            for offset in orphanedDocCommentOffsets(in: pieces, isEndOfFile: node.tokenKind == .endOfFile) {
+                violations.append(node.position.advanced(by: offset))
             }
         }
     }
 }
 
-private func isOrphanedDocComment(
-    with iterator: inout some IteratorProtocol<(offset: Int, element: TriviaPiece)>
-) -> Bool {
-    while let (_, piece) = iterator.next() {
+private func orphanedDocCommentOffsets(in pieces: [TriviaPiece], isEndOfFile: Bool) -> [Int] {
+    var pendingDocCommentOffsets: [Int] = []
+    var orphanedDocCommentOffsets: [Int] = []
+    var utf8Offset = 0
+    var currentLine = 1
+    var previousCommentEndLine: Int?
+
+    for piece in pieces {
+        defer {
+            utf8Offset += piece.sourceLength.utf8Length
+            currentLine += piece.lineBreakCount
+        }
+
         switch piece {
-        case .docLineComment, .docBlockComment,
-             .carriageReturns, .carriageReturnLineFeeds, .newlines, .spaces:
-            break
+        case .docLineComment(let comment), .docBlockComment(let comment):
+            // These patterns are often used for "file header" style comments.
+            guard !comment.hasPrefix("////"), !comment.hasPrefix("/***") else {
+                continue
+            }
 
         case .lineComment, .blockComment:
-            return true
+            orphanedDocCommentOffsets.append(contentsOf: pendingDocCommentOffsets)
+            pendingDocCommentOffsets.removeAll()
+            previousCommentEndLine = currentLine + piece.lineBreakCount
 
+        default:
+            continue
+        }
+
+        guard piece.isDocComment else {
+            continue
+        }
+
+        if let previousCommentEndLine,
+           !pendingDocCommentOffsets.isEmpty,
+           currentLine > previousCommentEndLine + 1 {
+            orphanedDocCommentOffsets.append(contentsOf: pendingDocCommentOffsets)
+            pendingDocCommentOffsets.removeAll()
+        }
+
+        pendingDocCommentOffsets.append(utf8Offset)
+        previousCommentEndLine = currentLine + piece.lineBreakCount
+    }
+
+    if isEndOfFile {
+        orphanedDocCommentOffsets.append(contentsOf: pendingDocCommentOffsets)
+    }
+
+    return orphanedDocCommentOffsets
+}
+
+private extension TriviaPiece {
+    var isDocComment: Bool {
+        switch self {
+        case .docLineComment, .docBlockComment:
+            return true
         default:
             return false
         }
     }
-    return false
+
+    var lineBreakCount: Int {
+        switch self {
+        case .carriageReturnLineFeeds(let count), .carriageReturns(let count), .newlines(let count):
+            count
+        case .blockComment(let comment), .docBlockComment(let comment),
+             .lineComment(let comment), .docLineComment(let comment),
+             .unexpectedText(let comment):
+            comment.reduce(0) { count, character in
+                count + (character.isNewline ? 1 : 0)
+            }
+        default:
+            0
+        }
+    }
 }

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/OrphanedDocCommentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/OrphanedDocCommentRule.swift
@@ -44,6 +44,11 @@ struct OrphanedDocCommentRule: Rule {
             var myGreatProperty: String!
             """,
             """
+            ↓/// The #2989 motivation.
+            // swiftlint:disable:next force_unwrapping
+            public var caseD: String! = nil
+            """,
+            """
             ↓/// Look here for more info: https://github.com.
 
 
@@ -60,7 +65,7 @@ struct OrphanedDocCommentRule: Rule {
             """
             extension Nested {
                 ↓///
-                ↓/// Look here for more info: https://github.com.
+                /// Look here for more info: https://github.com.
 
                 // Not a doc string
                 var myGreatProperty: String!
@@ -75,19 +80,13 @@ struct OrphanedDocCommentRule: Rule {
             """
             ↓/// Look here for more info: https://github.com.
 
-            /// Documentation that is attached to the declaration.
-            var myGreatProperty: String!
-            """,
-            """
-            ↓/// Look here for more info: https://github.com.
-
 
             /// Documentation that is attached to the declaration.
             var myGreatProperty: String!
             """,
             """
             ↓/// Look here for more info: https://github.com.
-            ↓/// More orphaned documentation.
+            /// More orphaned documentation.
 
             /// Documentation that is attached to the declaration.
             var myGreatProperty: String!
@@ -95,7 +94,7 @@ struct OrphanedDocCommentRule: Rule {
             """
             extension Nested {
                 ↓///
-                ↓/// Look here for more info: https://github.com.
+                /// Look here for more info: https://github.com.
 
                 /// Documentation that is attached to the declaration.
                 var myGreatProperty: String!
@@ -140,7 +139,7 @@ private func orphanedDocCommentOffsets(in pieces: [TriviaPiece], isEndOfFile: Bo
             }
 
         case .lineComment, .blockComment:
-            orphanedDocCommentOffsets.append(contentsOf: pendingDocCommentOffsets)
+            orphanedDocCommentOffsets.append(contentsOf: pendingDocCommentOffsets.prefix(1))
             pendingDocCommentOffsets.removeAll()
             previousCommentEndLine = currentLine + piece.lineBreakCount
 
@@ -155,7 +154,7 @@ private func orphanedDocCommentOffsets(in pieces: [TriviaPiece], isEndOfFile: Bo
         if let previousCommentEndLine,
            !pendingDocCommentOffsets.isEmpty,
            currentLine > previousCommentEndLine + 1 {
-            orphanedDocCommentOffsets.append(contentsOf: pendingDocCommentOffsets)
+            orphanedDocCommentOffsets.append(contentsOf: pendingDocCommentOffsets.prefix(1))
             pendingDocCommentOffsets.removeAll()
         }
 
@@ -164,7 +163,7 @@ private func orphanedDocCommentOffsets(in pieces: [TriviaPiece], isEndOfFile: Bo
     }
 
     if isEndOfFile {
-        orphanedDocCommentOffsets.append(contentsOf: pendingDocCommentOffsets)
+        orphanedDocCommentOffsets.append(contentsOf: pendingDocCommentOffsets.prefix(1))
     }
 
     return orphanedDocCommentOffsets

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/OrphanedDocCommentRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/OrphanedDocCommentRule.swift
@@ -119,7 +119,7 @@ private extension OrphanedDocCommentRule {
 }
 
 private func orphanedDocCommentOffsets(in pieces: [TriviaPiece], isEndOfFile: Bool) -> [Int] {
-    var pendingDocCommentOffsets: [Int] = []
+    var pendingDocCommentOffset: Int?
     var orphanedDocCommentOffsets: [Int] = []
     var utf8Offset = 0
     var currentLine = 1
@@ -139,46 +139,38 @@ private func orphanedDocCommentOffsets(in pieces: [TriviaPiece], isEndOfFile: Bo
             }
 
         case .lineComment, .blockComment:
-            orphanedDocCommentOffsets.append(contentsOf: pendingDocCommentOffsets.prefix(1))
-            pendingDocCommentOffsets.removeAll()
+            if let offset = pendingDocCommentOffset {
+                orphanedDocCommentOffsets.append(offset)
+                pendingDocCommentOffset = nil
+            }
             previousCommentEndLine = currentLine + piece.lineBreakCount
+            continue
 
         default:
             continue
         }
 
-        guard piece.isDocComment else {
-            continue
-        }
-
         if let previousCommentEndLine,
-           !pendingDocCommentOffsets.isEmpty,
+           pendingDocCommentOffset != nil,
            currentLine > previousCommentEndLine + 1 {
-            orphanedDocCommentOffsets.append(contentsOf: pendingDocCommentOffsets.prefix(1))
-            pendingDocCommentOffsets.removeAll()
+            if let offset = pendingDocCommentOffset {
+                orphanedDocCommentOffsets.append(offset)
+                pendingDocCommentOffset = nil
+            }
         }
 
-        pendingDocCommentOffsets.append(utf8Offset)
+        pendingDocCommentOffset = pendingDocCommentOffset ?? utf8Offset
         previousCommentEndLine = currentLine + piece.lineBreakCount
     }
 
-    if isEndOfFile {
-        orphanedDocCommentOffsets.append(contentsOf: pendingDocCommentOffsets.prefix(1))
+    if isEndOfFile, let pendingDocCommentOffset {
+        orphanedDocCommentOffsets.append(pendingDocCommentOffset)
     }
 
     return orphanedDocCommentOffsets
 }
 
 private extension TriviaPiece {
-    var isDocComment: Bool {
-        switch self {
-        case .docLineComment, .docBlockComment:
-            return true
-        default:
-            return false
-        }
-    }
-
     var lineBreakCount: Int {
         switch self {
         case .carriageReturnLineFeeds(let count), .carriageReturns(let count), .newlines(let count):


### PR DESCRIPTION
## Summary
- stop treating ordinary comments between documentation and declarations as orphaning doc comments
- flag doc comment groups that are superseded by a later doc comment group after a blank line
- flag doc comments that reach EOF without a following declaration
- update rule examples and changelog for #6897

## Test Plan
- swift test --filter OrphanedDocCommentRuleGeneratedTests
- swift test --filter RulesTests/orphanedDocComment
- swift run swiftlint lint --quiet --no-cache Source/SwiftLintBuiltInRules/Rules/Lint/OrphanedDocCommentRule.swift CHANGELOG.md

Fixes #6897