### PR TITLE
Lint inline documentation

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -22,6 +22,7 @@ disabled_rules:
   - contrasted_opening_brace
   - convenience_type
   - discouraged_default_parameter
+  - doc_comment_parameter
   - discouraged_optional_collection
   - explicit_acl
   - explicit_enum_raw_value

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,13 @@
 ### Enhancements
 
 * None.
+* Add `doc_comment_parameter` opt-in rule that validates documentation
+  comments on functions, initializers, and subscripts match their actual
+  signatures. Reports extra or missing `- Parameter` entries. Optionally
+  validates `- Returns:` and `- Throws:` sections (`validate_returns`,
+  `validate_throws`) and enforces consistent parameter documentation
+  syntax (`enforce_parameter_syntax`).  
+  [Yury Lapitsky](https://github.com/YuryLapitsky-TomTom)
 
 ### Bug Fixes
 

--- a/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
+++ b/Source/SwiftLintBuiltInRules/Models/BuiltInRules.swift
@@ -45,6 +45,7 @@ public let builtInRules: [any Rule.Type] = [
     DiscouragedObjectLiteralRule.self,
     DiscouragedOptionalBooleanRule.self,
     DiscouragedOptionalCollectionRule.self,
+    DocCommentParameterRule.self,
     DuplicateConditionsRule.self,
     DuplicateEnumCasesRule.self,
     DuplicateImportsRule.self,

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/DocCommentParameterRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/DocCommentParameterRule.swift
@@ -1,0 +1,518 @@
+import Foundation
+import SwiftLintCore
+import SwiftSyntax
+
+@SwiftSyntaxRule(optIn: true)
+struct DocCommentParameterRule: Rule {
+    var configuration = DocCommentParameterConfiguration()
+
+    static let description = RuleDescription(
+        identifier: "doc_comment_parameter",
+        name: "Doc Comment Parameter",
+        description:
+            "Parameters in documentation comments should match the actual function parameters",
+        kind: .lint,
+        nonTriggeringExamples: DocCommentParameterRuleExamples.nonTriggeringExamples,
+        triggeringExamples: DocCommentParameterRuleExamples.triggeringExamples
+    )
+}
+
+extension DocCommentParameterRule {
+    fileprivate final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
+        // swiftlint:disable force_try
+        private static let singleParamRegex = try! NSRegularExpression(
+            pattern: #"^-\s*[Pp]arameter\s+(\w+)\s*:"#)
+        private static let blockParamRegex = try! NSRegularExpression(
+            pattern: #"^-\s*(\w+)\s*:"#)
+        private static let throwsDocRegex = try! NSRegularExpression(
+            pattern: #"^-\s*[Tt]hrows\s*:"#, options: .anchorsMatchLines)
+        private static let returnsDocRegex = try! NSRegularExpression(
+            pattern: #"^-\s*[Rr]eturns\s*:"#, options: .anchorsMatchLines)
+        private static let singularParamLineRegex = try! NSRegularExpression(
+            pattern: #"- [Pp]arameter\s+\w"#)
+        // swiftlint:enable force_try
+
+        override func visitPost(_ node: FunctionDeclSyntax) {
+            let parameters = node.signature.parameterClause.parameters.compactMap {
+                extractParameterName($0)
+            }
+            validateDocComment(
+                on: node,
+                declKeyword: node.funcKeyword,
+                parameters: parameters,
+                returnClause: node.signature.returnClause,
+                throwsKeyword: node.signature.effectSpecifiers?.throwsClause?.throwsSpecifier,
+                isDiscardableResult: hasDiscardableResult(in: node.attributes)
+            )
+        }
+
+        override func visitPost(_ node: InitializerDeclSyntax) {
+            let parameters = node.signature.parameterClause.parameters.compactMap {
+                extractParameterName($0)
+            }
+            validateDocComment(
+                on: node,
+                declKeyword: node.initKeyword,
+                parameters: parameters,
+                throwsKeyword: node.signature.effectSpecifiers?.throwsClause?.throwsSpecifier
+            )
+        }
+
+        override func visitPost(_ node: SubscriptDeclSyntax) {
+            let parameters = node.parameterClause.parameters.compactMap { extractParameterName($0) }
+            validateDocComment(
+                on: node,
+                declKeyword: node.subscriptKeyword,
+                parameters: parameters,
+                returnClause: node.returnClause
+            )
+        }
+
+        /// Extracts the parameter name for documentation purposes.
+        /// Uses the external name (firstName) if it's not an underscore, otherwise uses the internal name.
+        /// Returns nil for truly unnamed parameters (both names are `_`) which have no documentable name.
+        private func extractParameterName(_ param: FunctionParameterSyntax) -> String? {
+            let firstName = param.firstName.text
+            if firstName == "_" {
+                if let secondName = param.secondName, secondName.text != "_" {
+                    return secondName.text
+                }
+                return nil  // truly unnamed — no documentable name
+            }
+            return firstName
+        }
+
+        private func hasDiscardableResult(in attributes: AttributeListSyntax) -> Bool {
+            attributes.contains {
+                $0.as(AttributeSyntax.self)?.attributeName.trimmedDescription == "discardableResult"
+            }
+        }
+
+        private func validateDocComment(
+            on node: some SyntaxProtocol,
+            declKeyword: TokenSyntax,
+            parameters: [String],
+            returnClause: ReturnClauseSyntax? = nil,
+            throwsKeyword: TokenSyntax? = nil,
+            isDiscardableResult: Bool = false
+        ) {
+            guard let docComment = extractDocComment(from: node) else {
+                return
+            }
+
+            let (documentedParams, paramStyle) = parseDocumentedParameters(from: docComment, node: node)
+
+            // Check for missing parameters (parameters in function but not in docs)
+            let documentedParamNames = Set(documentedParams.map(\.name))
+            let actualParamNames = Set(parameters)
+
+            let missingParams = actualParamNames.subtracting(documentedParamNames)
+            let extraParams = documentedParams.filter { !actualParamNames.contains($0.name) }
+
+            // If there are documented parameters but some actual parameters are missing
+            if documentedParamNames.isNotEmpty, missingParams.isNotEmpty {
+                violations.append(
+                    ReasonedRuleViolation(
+                        position: declKeyword.positionAfterSkippingLeadingTrivia,
+                        reason: "Missing documentation for parameter(s): "
+                            + missingParams.sorted().joined(separator: ", ")
+                    )
+                )
+            }
+
+            // Check for extra/incorrect parameters in documentation
+            for extraParam in extraParams {
+                violations.append(
+                    ReasonedRuleViolation(
+                        position: extraParam.position,
+                        reason: "Documented parameter '\(extraParam.name)' not found in declaration"
+                    )
+                )
+            }
+
+            if configuration.validateReturns {
+                validateReturnDocumentation(
+                    on: node, declKeyword: declKeyword, returnClause: returnClause,
+                    docComment: docComment, isDiscardableResult: isDiscardableResult)
+            }
+            if configuration.validateThrows {
+                validateThrowsDocumentation(
+                    on: node, declKeyword: declKeyword, throwsKeyword: throwsKeyword,
+                    docComment: docComment)
+            }
+            if configuration.enforceParameterSyntax {
+                validateParameterSyntax(paramCount: parameters.count, documentedStyle: paramStyle, on: node)
+            }
+        }
+
+        private func validateParameterSyntax(
+            paramCount: Int,
+            documentedStyle: DocParameterStyle?,
+            on node: some SyntaxProtocol
+        ) {
+            guard let style = documentedStyle, paramCount > 0 else { return }
+            switch style {
+            case .plural where paramCount == 1:
+                let position = findParametersBlockPosition(in: node)
+                violations.append(
+                    ReasonedRuleViolation(
+                        position: position,
+                        reason: "Use '- Parameter name:' syntax for a single parameter"
+                    )
+                )
+            case .singular where paramCount > 1:
+                let position = findSecondSingularParameterPosition(in: node)
+                violations.append(
+                    ReasonedRuleViolation(
+                        position: position,
+                        reason: "Use '- Parameters:' block syntax for multiple parameters"
+                    )
+                )
+            default:
+                break
+            }
+        }
+
+        private func findParametersBlockPosition(in node: some SyntaxProtocol) -> AbsolutePosition {
+            var currentPosition = node.position
+            for piece in node.leadingTrivia.pieces {
+                switch piece {
+                case .docLineComment(let text), .docBlockComment(let text):
+                    for pattern in ["- Parameters:", "- parameters:"] {
+                        if let range = text.range(of: pattern) {
+                            let offset = text.distance(from: text.startIndex, to: range.lowerBound)
+                            return currentPosition.advanced(by: offset + 2)  // point at 'P'
+                        }
+                    }
+                default:
+                    break
+                }
+                currentPosition = currentPosition.advanced(by: piece.sourceLength.utf8Length)
+            }
+            return node.positionAfterSkippingLeadingTrivia
+        }
+
+        private func findSecondSingularParameterPosition(in node: some SyntaxProtocol)
+            -> AbsolutePosition
+        {
+            var currentPosition = node.position
+            var matchCount = 0
+            let regex = Self.singularParamLineRegex
+            for piece in node.leadingTrivia.pieces {
+                switch piece {
+                case .docLineComment(let text), .docBlockComment(let text):
+                    let matches = regex.matches(
+                        in: text, range: NSRange(text.startIndex..., in: text))
+                    for match in matches {
+                        matchCount += 1
+                        if matchCount == 2, let range = Range(match.range, in: text) {
+                            let offset =
+                                text.distance(from: text.startIndex, to: range.lowerBound) + 2  // skip "- "
+                            return currentPosition.advanced(by: offset)
+                        }
+                    }
+                default:
+                    break
+                }
+                currentPosition = currentPosition.advanced(by: piece.sourceLength.utf8Length)
+            }
+            return node.positionAfterSkippingLeadingTrivia
+        }
+
+        private func validateThrowsDocumentation(
+            on node: some SyntaxProtocol,
+            declKeyword: TokenSyntax,
+            throwsKeyword: TokenSyntax?,
+            docComment: String
+        ) {
+            let hasThrowsDoc = docHasThrowsSection(docComment)
+            let isThrows = throwsKeyword?.tokenKind == .keyword(.throws)
+            let isRethrows = throwsKeyword?.tokenKind == .keyword(.rethrows)
+
+            if isThrows, !hasThrowsDoc {
+                violations.append(
+                    ReasonedRuleViolation(
+                        position: declKeyword.positionAfterSkippingLeadingTrivia,
+                        reason: "Missing '- Throws:' documentation for throwing function"
+                    )
+                )
+            } else if !isThrows, !isRethrows, hasThrowsDoc {
+                let position = findThrowsSectionPosition(in: node)
+                violations.append(
+                    ReasonedRuleViolation(
+                        position: position,
+                        reason: "Unexpected '- Throws:' documentation for non-throwing function"
+                    )
+                )
+            }
+            // rethrows: Throws doc is allowed but not required — no violation either way
+        }
+
+        private func docHasThrowsSection(_ docComment: String) -> Bool {
+            Self.throwsDocRegex.firstMatch(
+                in: docComment, range: NSRange(docComment.startIndex..., in: docComment)) != nil
+        }
+
+        private func findThrowsSectionPosition(in node: some SyntaxProtocol) -> AbsolutePosition {
+            let trivia = node.leadingTrivia
+            var currentPosition = node.position
+            for piece in trivia.pieces {
+                switch piece {
+                case .docLineComment(let text), .docBlockComment(let text):
+                    for pattern in ["- Throws:", "- throws:"] {
+                        if let range = text.range(of: pattern) {
+                            let offset = text.distance(from: text.startIndex, to: range.lowerBound)
+                            return currentPosition.advanced(by: offset + 2)  // point at 'T'
+                        }
+                    }
+                default:
+                    break
+                }
+                currentPosition = currentPosition.advanced(by: piece.sourceLength.utf8Length)
+            }
+            return node.positionAfterSkippingLeadingTrivia
+        }
+
+        private func validateReturnDocumentation(
+            on node: some SyntaxProtocol,
+            declKeyword: TokenSyntax,
+            returnClause: ReturnClauseSyntax?,
+            docComment: String,
+            isDiscardableResult: Bool = false
+        ) {
+            let hasReturnsDoc = docHasReturnsSection(docComment)
+
+            // Ignore Never return type — it never actually returns
+            if let returnClause,
+                let identifier = returnClause.type.as(IdentifierTypeSyntax.self),
+                identifier.name.text == "Never"
+            {
+                return
+            }
+
+            // Ignore Void / () return types — no doc needed
+            let hasNonVoidReturn: Bool
+            if let returnClause {
+                let returnType = returnClause.type
+                if let identifier = returnType.as(IdentifierTypeSyntax.self),
+                    identifier.name.text == "Void"
+                {
+                    hasNonVoidReturn = false
+                } else if returnType.is(TupleTypeSyntax.self),
+                    let tuple = returnType.as(TupleTypeSyntax.self),
+                    tuple.elements.isEmpty
+                {
+                    hasNonVoidReturn = false
+                } else {
+                    hasNonVoidReturn = true
+                }
+            } else {
+                hasNonVoidReturn = false
+            }
+
+            if hasNonVoidReturn, !hasReturnsDoc, !isDiscardableResult {
+                violations.append(
+                    ReasonedRuleViolation(
+                        position: declKeyword.positionAfterSkippingLeadingTrivia,
+                        reason:
+                            "Missing '- Returns:' documentation for function that returns a value"
+                    )
+                )
+            } else if !hasNonVoidReturn, hasReturnsDoc {
+                let position = findReturnsSectionPosition(in: node)
+                violations.append(
+                    ReasonedRuleViolation(
+                        position: position,
+                        reason:
+                            "Unexpected '- Returns:' documentation for function that does not return a value"
+                    )
+                )
+            }
+        }
+
+        private func docHasReturnsSection(_ docComment: String) -> Bool {
+            Self.returnsDocRegex.firstMatch(
+                in: docComment, range: NSRange(docComment.startIndex..., in: docComment)) != nil
+        }
+
+        private func findReturnsSectionPosition(in node: some SyntaxProtocol) -> AbsolutePosition {
+            let trivia = node.leadingTrivia
+            var currentPosition = node.position
+            for piece in trivia.pieces {
+                switch piece {
+                case .docLineComment(let text), .docBlockComment(let text):
+                    let patterns = ["- Returns:", "- returns:"]
+                    for pattern in patterns {
+                        if let range = text.range(of: pattern) {
+                            let offset = text.distance(from: text.startIndex, to: range.lowerBound)
+                            return currentPosition.advanced(by: offset + 2)  // point at 'R'
+                        }
+                    }
+                default:
+                    break
+                }
+                currentPosition = currentPosition.advanced(by: piece.sourceLength.utf8Length)
+            }
+            return node.positionAfterSkippingLeadingTrivia
+        }
+
+        private func extractDocComment(from node: some SyntaxProtocol) -> String? {
+            let trivia = node.leadingTrivia
+            var docLines: [String] = []
+
+            outer: for piece in trivia.pieces.reversed() {
+                switch piece {
+                case .docLineComment(let text):
+                    let content = text.hasPrefix("///") ? String(text.dropFirst(3)) : text
+                    docLines.insert(content.trimmingCharacters(in: .whitespaces), at: 0)
+                case .docBlockComment(let text):
+                    let content = parseBlockComment(text)
+                    docLines.insert(contentsOf: content, at: 0)
+                case .newlines, .carriageReturns, .carriageReturnLineFeeds, .spaces, .tabs:
+                    continue
+                default:
+                    if docLines.isNotEmpty {
+                        break outer
+                    }
+                }
+            }
+
+            return docLines.isEmpty ? nil : docLines.joined(separator: "\n")
+        }
+
+        private func parseBlockComment(_ text: String) -> [String] {
+            text
+                .replacingOccurrences(of: "/**", with: "")
+                .replacingOccurrences(of: "*/", with: "")
+                .split(separator: "\n", omittingEmptySubsequences: false)
+                .map { line -> String in
+                    var trimmed = line.trimmingCharacters(in: .whitespaces)
+                    // Remove leading asterisks common in block comments
+                    if trimmed.hasPrefix("*") {
+                        trimmed = String(trimmed.dropFirst()).trimmingCharacters(in: .whitespaces)
+                    }
+                    return trimmed
+                }
+        }
+
+        private func parseDocumentedParameters(
+            from docComment: String,
+            node: some SyntaxProtocol
+        ) -> (params: [DocumentedParameter], style: DocParameterStyle?) {
+            var parameters: [DocumentedParameter] = []
+            let lines = docComment.split(separator: "\n", omittingEmptySubsequences: false)
+
+            var inParametersBlock = false
+            var foundPluralBlock = false
+            var foundSingular = false
+
+            for line in lines {
+                let trimmedLine = line.trimmingCharacters(in: .whitespaces)
+
+                // Check for "- Parameters:" block
+                if trimmedLine.lowercased().hasPrefix("- parameters:") {
+                    inParametersBlock = true
+                    foundPluralBlock = true
+                    continue
+                }
+
+                // Check for "- Parameter name:" syntax
+                if let paramName = extractSingleParameter(from: trimmedLine) {
+                    let position = findParameterPosition(paramName: paramName, in: node)
+                    parameters.append(DocumentedParameter(name: paramName, position: position))
+                    inParametersBlock = false
+                    foundSingular = true
+                    continue
+                }
+
+                // Check for parameters within a Parameters block (- name: description)
+                if inParametersBlock {
+                    if let paramName = extractParameterFromBlock(from: trimmedLine) {
+                        let position = findParameterPosition(paramName: paramName, in: node)
+                        parameters.append(DocumentedParameter(name: paramName, position: position))
+                    } else if trimmedLine.hasPrefix("- ") {
+                        // This is a different list item, exit parameters block
+                        inParametersBlock = false
+                    }
+                }
+            }
+
+            let style: DocParameterStyle?
+            if foundPluralBlock {
+                style = .plural
+            } else if foundSingular {
+                style = .singular
+            } else {
+                style = nil
+            }
+            return (params: parameters, style: style)
+        }
+
+        /// Extracts parameter name from "- Parameter name:" syntax
+        private func extractSingleParameter(from line: String) -> String? {
+            guard let match = Self.singleParamRegex.firstMatch(
+                    in: line, range: NSRange(line.startIndex..., in: line)),
+                  let range = Range(match.range(at: 1), in: line)
+            else { return nil }
+            return String(line[range])
+        }
+
+        /// Extracts parameter name from "- name: description" syntax within Parameters block
+        private func extractParameterFromBlock(from line: String) -> String? {
+            guard let match = Self.blockParamRegex.firstMatch(
+                    in: line, range: NSRange(line.startIndex..., in: line)),
+                  let range = Range(match.range(at: 1), in: line)
+            else { return nil }
+            let name = String(line[range])
+            let excluded = [
+                "returns", "throws", "note", "warning", "important", "see",
+                "precondition", "postcondition", "requires", "invariant",
+                "complexity", "author", "version",
+            ]
+            return excluded.contains(name.lowercased()) ? nil : name
+        }
+
+        /// Finds the position of a documented parameter in the source
+        private func findParameterPosition(paramName: String, in node: some SyntaxProtocol)
+            -> AbsolutePosition
+        {
+            // Search through the trivia to find the exact position of the parameter name
+            let trivia = node.leadingTrivia
+            var currentPosition = node.position
+
+            for piece in trivia.pieces {
+                switch piece {
+                case .docLineComment(let text), .docBlockComment(let text):
+                    if let range = text.range(of: "- Parameter \(paramName):") ?? text.range(
+                        of: "- parameter \(paramName):") ?? text.range(of: "- \(paramName):")
+                    {
+                        let offset = text.distance(from: text.startIndex, to: range.lowerBound)
+                        // Find the parameter name within the match
+                        let matchText = String(text[range])
+                        if let paramRange = matchText.range(of: paramName) {
+                            let paramOffset = matchText.distance(
+                                from: matchText.startIndex, to: paramRange.lowerBound)
+                            return currentPosition.advanced(by: offset + paramOffset)
+                        }
+                    }
+                default:
+                    break
+                }
+                currentPosition = currentPosition.advanced(by: piece.sourceLength.utf8Length)
+            }
+
+            // Fallback to the node position if we can't find the exact location
+            return node.positionAfterSkippingLeadingTrivia
+        }
+    }
+}
+
+private struct DocumentedParameter {
+    let name: String
+    let position: AbsolutePosition
+}
+
+private enum DocParameterStyle {
+    case singular
+    case plural
+}

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/DocCommentParameterRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/DocCommentParameterRule.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import Foundation
 import SwiftLintCore
 import SwiftSyntax
@@ -10,7 +11,7 @@ struct DocCommentParameterRule: Rule {
         identifier: "doc_comment_parameter",
         name: "Doc Comment Parameter",
         description:
-            "Parameters in documentation comments should match the actual function parameters",
+            "Documentation comments should match the actual function signature",
         kind: .lint,
         nonTriggeringExamples: DocCommentParameterRuleExamples.nonTriggeringExamples,
         triggeringExamples: DocCommentParameterRuleExamples.triggeringExamples
@@ -68,18 +69,12 @@ extension DocCommentParameterRule {
             )
         }
 
-        /// Extracts the parameter name for documentation purposes.
-        /// Uses the external name (firstName) if it's not an underscore, otherwise uses the internal name.
-        /// Returns nil for truly unnamed parameters (both names are `_`) which have no documentable name.
         private func extractParameterName(_ param: FunctionParameterSyntax) -> String? {
-            let firstName = param.firstName.text
-            if firstName == "_" {
-                if let secondName = param.secondName, secondName.text != "_" {
-                    return secondName.text
-                }
-                return nil  // truly unnamed — no documentable name
+            if let secondName = param.secondName {
+                return secondName.text == "_" ? nil : secondName.text
             }
-            return firstName
+            let firstName = param.firstName.text
+            return firstName == "_" ? nil : firstName
         }
 
         private func hasDiscardableResult(in attributes: AttributeListSyntax) -> Bool {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/DocCommentParameterRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/DocCommentParameterRule.swift
@@ -18,8 +18,9 @@ struct DocCommentParameterRule: Rule {
     )
 }
 
-extension DocCommentParameterRule {
-    fileprivate final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
+private extension DocCommentParameterRule {
+    // swiftlint:disable:next type_body_length
+    final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         // swiftlint:disable force_try
         private static let singleParamRegex = try! NSRegularExpression(
             pattern: #"^-\s*[Pp]arameter\s+(\w+)\s*:"#)
@@ -188,8 +189,7 @@ extension DocCommentParameterRule {
         }
 
         private func findSecondSingularParameterPosition(in node: some SyntaxProtocol)
-            -> AbsolutePosition
-        {
+            -> AbsolutePosition {
             var currentPosition = node.position
             var matchCount = 0
             let regex = Self.singularParamLineRegex
@@ -280,8 +280,7 @@ extension DocCommentParameterRule {
             // Ignore Never return type — it never actually returns
             if let returnClause,
                 let identifier = returnClause.type.as(IdentifierTypeSyntax.self),
-                identifier.name.text == "Never"
-            {
+                identifier.name.text == "Never" {
                 return
             }
 
@@ -290,13 +289,11 @@ extension DocCommentParameterRule {
             if let returnClause {
                 let returnType = returnClause.type
                 if let identifier = returnType.as(IdentifierTypeSyntax.self),
-                    identifier.name.text == "Void"
-                {
+                    identifier.name.text == "Void" {
                     hasNonVoidReturn = false
                 } else if returnType.is(TupleTypeSyntax.self),
                     let tuple = returnType.as(TupleTypeSyntax.self),
-                    tuple.elements.isEmpty
-                {
+                    tuple.elements.isEmpty {
                     hasNonVoidReturn = false
                 } else {
                     hasNonVoidReturn = true
@@ -469,8 +466,7 @@ extension DocCommentParameterRule {
 
         /// Finds the position of a documented parameter in the source
         private func findParameterPosition(paramName: String, in node: some SyntaxProtocol)
-            -> AbsolutePosition
-        {
+            -> AbsolutePosition {
             // Search through the trivia to find the exact position of the parameter name
             let trivia = node.leadingTrivia
             var currentPosition = node.position
@@ -479,8 +475,7 @@ extension DocCommentParameterRule {
                 switch piece {
                 case .docLineComment(let text), .docBlockComment(let text):
                     if let range = text.range(of: "- Parameter \(paramName):") ?? text.range(
-                        of: "- parameter \(paramName):") ?? text.range(of: "- \(paramName):")
-                    {
+                        of: "- parameter \(paramName):") ?? text.range(of: "- \(paramName):") {
                         let offset = text.distance(from: text.startIndex, to: range.lowerBound)
                         // Find the parameter name within the match
                         let matchText = String(text[range])

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/DocCommentParameterRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/DocCommentParameterRule.swift
@@ -19,7 +19,6 @@ struct DocCommentParameterRule: Rule {
 }
 
 private extension DocCommentParameterRule {
-    // swiftlint:disable:next type_body_length
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
         override func visitPost(_ node: FunctionDeclSyntax) {
             let parameters = node.signature.parameterClause.parameters.compactMap {

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/DocCommentParameterRule.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/DocCommentParameterRule.swift
@@ -21,19 +21,6 @@ struct DocCommentParameterRule: Rule {
 private extension DocCommentParameterRule {
     // swiftlint:disable:next type_body_length
     final class Visitor: ViolationsSyntaxVisitor<ConfigurationType> {
-        // swiftlint:disable force_try
-        private static let singleParamRegex = try! NSRegularExpression(
-            pattern: #"^-\s*[Pp]arameter\s+(\w+)\s*:"#)
-        private static let blockParamRegex = try! NSRegularExpression(
-            pattern: #"^-\s*(\w+)\s*:"#)
-        private static let throwsDocRegex = try! NSRegularExpression(
-            pattern: #"^-\s*[Tt]hrows\s*:"#, options: .anchorsMatchLines)
-        private static let returnsDocRegex = try! NSRegularExpression(
-            pattern: #"^-\s*[Rr]eturns\s*:"#, options: .anchorsMatchLines)
-        private static let singularParamLineRegex = try! NSRegularExpression(
-            pattern: #"- [Pp]arameter\s+\w"#)
-        // swiftlint:enable force_try
-
         override func visitPost(_ node: FunctionDeclSyntax) {
             let parameters = node.signature.parameterClause.parameters.compactMap {
                 extractParameterName($0)
@@ -192,17 +179,14 @@ private extension DocCommentParameterRule {
             -> AbsolutePosition {
             var currentPosition = node.position
             var matchCount = 0
-            let regex = Self.singularParamLineRegex
             for piece in node.leadingTrivia.pieces {
                 switch piece {
                 case .docLineComment(let text), .docBlockComment(let text):
-                    let matches = regex.matches(
-                        in: text, range: NSRange(text.startIndex..., in: text))
-                    for match in matches {
+                    for match in text.matches(of: #/- [Pp]arameter\s+\w/#) {
                         matchCount += 1
-                        if matchCount == 2, let range = Range(match.range, in: text) {
+                        if matchCount == 2 {
                             let offset =
-                                text.distance(from: text.startIndex, to: range.lowerBound) + 2  // skip "- "
+                                text.distance(from: text.startIndex, to: match.range.lowerBound) + 2
                             return currentPosition.advanced(by: offset)
                         }
                     }
@@ -244,8 +228,7 @@ private extension DocCommentParameterRule {
         }
 
         private func docHasThrowsSection(_ docComment: String) -> Bool {
-            Self.throwsDocRegex.firstMatch(
-                in: docComment, range: NSRange(docComment.startIndex..., in: docComment)) != nil
+            docComment.contains(#/(?m)^-\s*[Tt]hrows\s*:/#)
         }
 
         private func findThrowsSectionPosition(in node: some SyntaxProtocol) -> AbsolutePosition {
@@ -323,8 +306,7 @@ private extension DocCommentParameterRule {
         }
 
         private func docHasReturnsSection(_ docComment: String) -> Bool {
-            Self.returnsDocRegex.firstMatch(
-                in: docComment, range: NSRange(docComment.startIndex..., in: docComment)) != nil
+            docComment.contains(#/(?m)^-\s*[Rr]eturns\s*:/#)
         }
 
         private func findReturnsSectionPosition(in node: some SyntaxProtocol) -> AbsolutePosition {
@@ -442,20 +424,16 @@ private extension DocCommentParameterRule {
 
         /// Extracts parameter name from "- Parameter name:" syntax
         private func extractSingleParameter(from line: String) -> String? {
-            guard let match = Self.singleParamRegex.firstMatch(
-                    in: line, range: NSRange(line.startIndex..., in: line)),
-                  let range = Range(match.range(at: 1), in: line)
-            else { return nil }
-            return String(line[range])
+            guard let match = line.firstMatch(of: #/^-\s*[Pp]arameter\s+(\w+)\s*:/#) else {
+                return nil
+            }
+            return String(match.output.1)
         }
 
         /// Extracts parameter name from "- name: description" syntax within Parameters block
         private func extractParameterFromBlock(from line: String) -> String? {
-            guard let match = Self.blockParamRegex.firstMatch(
-                    in: line, range: NSRange(line.startIndex..., in: line)),
-                  let range = Range(match.range(at: 1), in: line)
-            else { return nil }
-            let name = String(line[range])
+            guard let match = line.firstMatch(of: #/^-\s*(\w+)\s*:/#) else { return nil }
+            let name = String(match.output.1)
             let excluded = [
                 "returns", "throws", "note", "warning", "important", "see",
                 "precondition", "postcondition", "requires", "invariant",

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/DocCommentParameterRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/DocCommentParameterRuleExamples.swift
@@ -32,7 +32,7 @@ struct DocCommentParameterRuleExamples {
         Example(code:
             """
             /// Updates the label.
-            /// - Parameter with: The new text for the label.
+            /// - Parameter text: The new text for the label.
             func updateLabel(with text: String) {}
             """),
         // Initializer with correctly documented parameters
@@ -238,6 +238,15 @@ struct DocCommentParameterRuleExamples {
             /// - Note: Uses a stable sort algorithm.
             func sort(collection: [Int]) {}
             """),
+        // Complexity callout inside Parameters block must not be mistaken for a parameter
+        Example(
+            """
+            /// Sorts the collection.
+            /// - Parameters:
+            ///   - collection: The collection to sort.
+            /// - Complexity: O(n log n).
+            func sortInPlace(collection: [Int]) {}
+            """),
         // Block comment with Parameters: block
         Example(code:
             """
@@ -291,11 +300,11 @@ struct DocCommentParameterRuleExamples {
             ///   - ↓extra: This doesn't exist.
             func doSomething(value: Int) {}
             """),
-        // Internal name used instead of external name
+        // External label used instead of internal name
         Example(code:
             """
             /// Updates the label.
-            /// - Parameter ↓text: The new text.
+            /// - Parameter ↓with: The new text.
             ↓func updateLabel(with text: String) {}
             """),
         // validate_returns: missing returns doc

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/DocCommentParameterRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/DocCommentParameterRuleExamples.swift
@@ -1,0 +1,344 @@
+struct DocCommentParameterRuleExamples {
+    static let nonTriggeringExamples = [
+        // Correctly documented function
+        Example(code:
+            """
+            /// A function that does something.
+            /// - Parameter value: The value to process.
+            func process(value: Int) {}
+            """),
+        // Multiple parameters correctly documented
+        Example(code:
+            """
+            /// Adds two numbers together.
+            /// - Parameters:
+            ///   - lhs: Left-hand side value.
+            ///   - rhs: Right-hand side value.
+            /// - Returns: The sum of `lhs` and `rhs`.
+            func add(lhs: Int, rhs: Int) -> Int { lhs + rhs }
+            """),
+        // Function without parameters doesn't need parameter documentation
+        Example(code:
+            """
+            /// Returns a greeting.
+            func greet() -> String { "Hello" }
+            """),
+        // Function without doc comment is not validated
+        Example(code:
+            """
+            func process(value: Int) {}
+            """),
+        // Correctly documented method with external and internal parameter names
+        Example(code:
+            """
+            /// Updates the label.
+            /// - Parameter with: The new text for the label.
+            func updateLabel(with text: String) {}
+            """),
+        // Initializer with correctly documented parameters
+        Example(code:
+            """
+            /// Creates a new instance.
+            /// - Parameter value: The initial value.
+            init(value: Int) {}
+            """),
+        // Subscript with correctly documented parameters
+        Example(code:
+            """
+            /// Accesses the element at the specified index.
+            /// - Parameter index: The index of the element.
+            subscript(index: Int) -> Int { 0 }
+            """),
+        // Closure parameter documented
+        Example(code:
+            """
+            /// Performs an operation.
+            /// - Parameter completion: A closure called when complete.
+            func perform(completion: () -> Void) {}
+            """),
+        // Underscore parameter name uses internal name
+        Example(code:
+            """
+            /// Logs a message.
+            /// - Parameter message: The message to log.
+            func log(_ message: String) {}
+            """),
+        // Block doc comment
+        Example(code:
+            """
+            /**
+             * Processes the value.
+             * - Parameter value: The value.
+             */
+            func process(value: Int) {}
+            """),
+        // Doc comment with only description (no parameter docs) for function without params
+        Example(code:
+            """
+            /// This function does nothing.
+            func doNothing() {}
+            """),
+        // validate_returns: returns doc present and function returns a value
+        Example(code:
+            """
+            /// Computes a value.
+            /// - Returns: The computed value.
+            func compute() -> Int { 0 }
+            """, configuration: ["validate_returns": true]),
+        // validate_returns: no returns doc and function does not return a value
+        Example(code:
+            """
+            /// Does something.
+            func doSomething() {}
+            """, configuration: ["validate_returns": true]),
+        // validate_returns: returns doc present, Void return type — no violation
+        Example(code:
+            """
+            /// Does something.
+            func doSomethingVoid() -> Void {}
+            """, configuration: ["validate_returns": true]),
+        // validate_returns: returns doc present, Never return type — no violation
+        Example(code:
+            """
+            /// Always fails.
+            func fail() -> Never { fatalError() }
+            """, configuration: ["validate_returns": true]),
+        // validate_returns disabled (default) — missing returns doc is not flagged
+        Example(code:
+            """
+            /// Computes a value.
+            func computeNoDoc() -> Int { 0 }
+            """),
+        // validate_throws: throws doc present and function throws
+        Example(code:
+            """
+            /// Parses the input.
+            /// - Throws: `ParseError` if the input is invalid.
+            func parse() throws {}
+            """, configuration: ["validate_throws": true]),
+        // validate_throws: no throws doc and function does not throw
+        Example(code:
+            """
+            /// Does something safe.
+            func safe() {}
+            """, configuration: ["validate_throws": true]),
+        // validate_throws: rethrows — throws doc is optional, both forms are fine
+        Example(code:
+            """
+            /// Maps elements.
+            /// - Parameter transform: A closure.
+            /// - Throws: Rethrows errors from the closure.
+            func map(transform: () throws -> Int) rethrows -> Int { try transform() }
+            """, configuration: ["validate_throws": true]),
+        Example(code:
+            """
+            /// Maps elements.
+            /// - Parameter transform: A closure.
+            func mapNoDoc(transform: () throws -> Int) rethrows -> Int { try transform() }
+            """, configuration: ["validate_throws": true]),
+        // validate_throws disabled (default) — missing throws doc is not flagged
+        Example(code:
+            """
+            /// Parses the input.
+            func parseNoDoc() throws {}
+            """),
+        // enforce_parameter_syntax: singular with 1 param — correct
+        Example(code:
+            """
+            /// Does something.
+            /// - Parameter value: The value.
+            func single(value: Int) {}
+            """, configuration: ["enforce_parameter_syntax": true]),
+        // enforce_parameter_syntax: plural block with 2+ params — correct
+        Example(code:
+            """
+            /// Does something.
+            /// - Parameters:
+            ///   - a: First.
+            ///   - b: Second.
+            func multi(a: Int, b: Int) {}
+            """, configuration: ["enforce_parameter_syntax": true]),
+        // enforce_parameter_syntax: no parameters — no violation
+        Example(code:
+            """
+            /// Does something.
+            func noParams() {}
+            """, configuration: ["enforce_parameter_syntax": true]),
+        // enforce_parameter_syntax disabled (default) — plural block with 1 param is fine
+        Example(code:
+            """
+            /// Does something.
+            /// - Parameters:
+            ///   - value: The value.
+            func singleDefault(value: Int) {}
+            """),
+        // Preceding doc comment must not bleed into the next declaration
+        Example(code:
+            """
+            /// Logs a message.
+            /// - Parameter message: The message.
+            func log(_ message: String) {}
+
+            // This is a plain (non-doc) comment.
+            func unrelated(value: Int) {}
+            """),
+        // Parameters block followed by Returns section — Returns must not be parsed as a parameter
+        Example(code:
+            """
+            /// Does something.
+            /// - Parameters:
+            ///   - value: The value.
+            /// - Returns: The result.
+            func process(value: Int) -> Int { value }
+            """),
+        // Parameters block followed by Throws section — Throws must exit the block correctly
+        Example(code:
+            """
+            /// Parses input.
+            /// - Parameters:
+            ///   - input: The raw input.
+            /// - Throws: `ParseError` on bad input.
+            func parse(input: String) throws {}
+            """),
+        // Doubly-unnamed parameter (_ _:) has no documentable name — no violation
+        Example(code:
+            """
+            /// Performs an action.
+            func perform(_ _: Int) {}
+            """),
+        // Mix of normal and doubly-unnamed — only named params need docs
+        Example(code:
+            """
+            /// Processes a value.
+            /// - Parameter value: The value.
+            func process(value: Int, _ _: String) {}
+            """),
+        // @discardableResult: missing Returns doc is not flagged even with validate_returns
+        Example(code:
+            """
+            /// Computes a value whose result may be ignored.
+            @discardableResult
+            func compute() -> Int { 0 }
+            """, configuration: ["validate_returns": true]),
+        // Multi-line parameter description (continuation lines must not confuse the parser)
+        Example(code:
+            """
+            /// Processes the input.
+            /// - Parameters:
+            ///   - value: A value that can be very long
+            ///     and spans multiple lines of description.
+            ///   - flag: A boolean flag.
+            func process(value: Int, flag: Bool) {}
+            """),
+        // Note inside doc comment must not be mistaken for a parameter
+        Example(code:
+            """
+            /// Sorts the collection.
+            /// - Parameter collection: The collection to sort.
+            /// - Note: Uses a stable sort algorithm.
+            func sort(collection: [Int]) {}
+            """),
+        // Block comment with Parameters: block
+        Example(code:
+            """
+            /**
+             * Adds two numbers.
+             * - Parameters:
+             *   - lhs: Left operand.
+             *   - rhs: Right operand.
+             * - Returns: Their sum.
+             */
+            func add(lhs: Int, rhs: Int) -> Int { lhs + rhs }
+            """),
+    ]
+
+    static let triggeringExamples = [
+        // Documented parameter doesn't exist
+        Example(code:
+            """
+            /// Greets someone.
+            /// - Parameter ↓name: The name to greet.
+            func greet() {}
+            """),
+        // One parameter missing from documentation
+        Example(code:
+            """
+            /// Adds two numbers.
+            /// - Parameter lhs: Left-hand side.
+            ↓func add(lhs: Int, rhs: Int) -> Int { lhs + rhs }
+            """),
+        // Documented parameter name doesn't match
+        Example(code:
+            """
+            /// Processes a value.
+            /// - Parameter ↓val: The value.
+            ↓func process(value: Int) {}
+            """),
+        // Missing one of multiple parameters
+        Example(code:
+            """
+            /// Processes values.
+            /// - Parameters:
+            ///   - first: The first value.
+            ↓func process(first: Int, second: Int) {}
+            """),
+        // Extra documented parameter that doesn't exist
+        Example(code:
+            """
+            /// Does something.
+            /// - Parameters:
+            ///   - value: A value.
+            ///   - ↓extra: This doesn't exist.
+            func doSomething(value: Int) {}
+            """),
+        // Internal name used instead of external name
+        Example(code:
+            """
+            /// Updates the label.
+            /// - Parameter ↓text: The new text.
+            ↓func updateLabel(with text: String) {}
+            """),
+        // validate_returns: missing returns doc
+        Example(code:
+            """
+            /// Computes a value.
+            ↓func compute() -> Int { 0 }
+            """, configuration: ["validate_returns": true]),
+        // validate_returns: unexpected returns doc on void function
+        Example(code:
+            """
+            /// Does something.
+            /// - ↓Returns: Some value.
+            func doSomething() {}
+            """, configuration: ["validate_returns": true]),
+        // validate_throws: missing throws doc
+        Example(code:
+            """
+            /// Parses the input.
+            ↓func parse() throws {}
+            """, configuration: ["validate_throws": true]),
+        // validate_throws: unexpected throws doc on non-throwing function
+        Example(code:
+            """
+            /// Does something safe.
+            /// - ↓Throws: Some error.
+            func safe() {}
+            """, configuration: ["validate_throws": true]),
+        // enforce_parameter_syntax: plural block with 1 param — should use singular
+        Example(code:
+            """
+            /// Does something.
+            /// - ↓Parameters:
+            ///   - value: The value.
+            func single(value: Int) {}
+            """, configuration: ["enforce_parameter_syntax": true]),
+        // enforce_parameter_syntax: multiple singular lines with 2+ params — should use plural
+        Example(code:
+            """
+            /// Does something.
+            /// - Parameter a: First.
+            /// - ↓Parameter b: Second.
+            func multi(a: Int, b: Int) {}
+            """, configuration: ["enforce_parameter_syntax": true]),
+    ]
+}

--- a/Source/SwiftLintBuiltInRules/Rules/Lint/DocCommentParameterRuleExamples.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/Lint/DocCommentParameterRuleExamples.swift
@@ -239,7 +239,7 @@ struct DocCommentParameterRuleExamples {
             func sort(collection: [Int]) {}
             """),
         // Complexity callout inside Parameters block must not be mistaken for a parameter
-        Example(
+        Example(code:
             """
             /// Sorts the collection.
             /// - Parameters:

--- a/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/DocCommentParameterConfiguration.swift
+++ b/Source/SwiftLintBuiltInRules/Rules/RuleConfigurations/DocCommentParameterConfiguration.swift
@@ -1,0 +1,13 @@
+import SwiftLintCore
+
+@AutoConfigParser
+struct DocCommentParameterConfiguration: SeverityBasedRuleConfiguration {
+    @ConfigurationElement(key: "severity")
+    private(set) var severityConfiguration = SeverityConfiguration<Parent>(.warning)
+    @ConfigurationElement(key: "validate_returns")
+    private(set) var validateReturns = false
+    @ConfigurationElement(key: "validate_throws")
+    private(set) var validateThrows = false
+    @ConfigurationElement(key: "enforce_parameter_syntax")
+    private(set) var enforceParameterSyntax = false
+}

--- a/Tests/GeneratedTests/GeneratedTests_02.swift
+++ b/Tests/GeneratedTests/GeneratedTests_02.swift
@@ -154,6 +154,14 @@ struct DiscouragedOptionalCollectionRuleGeneratedTests {
 }
 
 @Suite(.rulesRegistered)
+struct DocCommentParameterRuleGeneratedTests {
+    @Test
+    func withDefaultConfiguration() {
+        verifyRule(DocCommentParameterRule.description)
+    }
+}
+
+@Suite(.rulesRegistered)
 struct DuplicateConditionsRuleGeneratedTests {
     @Test
     func withDefaultConfiguration() {
@@ -198,13 +206,5 @@ struct EmptyCollectionLiteralRuleGeneratedTests {
     @Test
     func withDefaultConfiguration() {
         verifyRule(EmptyCollectionLiteralRule.description)
-    }
-}
-
-@Suite(.rulesRegistered)
-struct EmptyCountRuleGeneratedTests {
-    @Test
-    func withDefaultConfiguration() {
-        verifyRule(EmptyCountRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_03.swift
+++ b/Tests/GeneratedTests/GeneratedTests_03.swift
@@ -10,6 +10,14 @@ import Testing
 @testable import SwiftLintCore
 
 @Suite(.rulesRegistered)
+struct EmptyCountRuleGeneratedTests {
+    @Test
+    func withDefaultConfiguration() {
+        verifyRule(EmptyCountRule.description)
+    }
+}
+
+@Suite(.rulesRegistered)
 struct EmptyEnumArgumentsRuleGeneratedTests {
     @Test
     func withDefaultConfiguration() {
@@ -198,13 +206,5 @@ struct FlatMapOverMapReduceRuleGeneratedTests {
     @Test
     func withDefaultConfiguration() {
         verifyRule(FlatMapOverMapReduceRule.description)
-    }
-}
-
-@Suite(.rulesRegistered)
-struct ForWhereRuleGeneratedTests {
-    @Test
-    func withDefaultConfiguration() {
-        verifyRule(ForWhereRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_04.swift
+++ b/Tests/GeneratedTests/GeneratedTests_04.swift
@@ -10,6 +10,14 @@ import Testing
 @testable import SwiftLintCore
 
 @Suite(.rulesRegistered)
+struct ForWhereRuleGeneratedTests {
+    @Test
+    func withDefaultConfiguration() {
+        verifyRule(ForWhereRule.description)
+    }
+}
+
+@Suite(.rulesRegistered)
 struct ForceCastRuleGeneratedTests {
     @Test
     func withDefaultConfiguration() {
@@ -198,13 +206,5 @@ struct LastWhereRuleGeneratedTests {
     @Test
     func withDefaultConfiguration() {
         verifyRule(LastWhereRule.description)
-    }
-}
-
-@Suite(.rulesRegistered)
-struct LeadingWhitespaceRuleGeneratedTests {
-    @Test
-    func withDefaultConfiguration() {
-        verifyRule(LeadingWhitespaceRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_05.swift
+++ b/Tests/GeneratedTests/GeneratedTests_05.swift
@@ -10,6 +10,14 @@ import Testing
 @testable import SwiftLintCore
 
 @Suite(.rulesRegistered)
+struct LeadingWhitespaceRuleGeneratedTests {
+    @Test
+    func withDefaultConfiguration() {
+        verifyRule(LeadingWhitespaceRule.description)
+    }
+}
+
+@Suite(.rulesRegistered)
 struct LegacyCGGeometryFunctionsRuleGeneratedTests {
     @Test
     func withDefaultConfiguration() {
@@ -198,13 +206,5 @@ struct MultilineParametersBracketsRuleGeneratedTests {
     @Test
     func withDefaultConfiguration() {
         verifyRule(MultilineParametersBracketsRule.description)
-    }
-}
-
-@Suite(.rulesRegistered)
-struct MultilineParametersRuleGeneratedTests {
-    @Test
-    func withDefaultConfiguration() {
-        verifyRule(MultilineParametersRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_06.swift
+++ b/Tests/GeneratedTests/GeneratedTests_06.swift
@@ -10,6 +10,14 @@ import Testing
 @testable import SwiftLintCore
 
 @Suite(.rulesRegistered)
+struct MultilineParametersRuleGeneratedTests {
+    @Test
+    func withDefaultConfiguration() {
+        verifyRule(MultilineParametersRule.description)
+    }
+}
+
+@Suite(.rulesRegistered)
 struct MultipleClosuresWithTrailingClosureRuleGeneratedTests {
     @Test
     func withDefaultConfiguration() {
@@ -198,13 +206,5 @@ struct OrphanedDocCommentRuleGeneratedTests {
     @Test
     func withDefaultConfiguration() {
         verifyRule(OrphanedDocCommentRule.description)
-    }
-}
-
-@Suite(.rulesRegistered)
-struct OverriddenSuperCallRuleGeneratedTests {
-    @Test
-    func withDefaultConfiguration() {
-        verifyRule(OverriddenSuperCallRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_07.swift
+++ b/Tests/GeneratedTests/GeneratedTests_07.swift
@@ -10,6 +10,14 @@ import Testing
 @testable import SwiftLintCore
 
 @Suite(.rulesRegistered)
+struct OverriddenSuperCallRuleGeneratedTests {
+    @Test
+    func withDefaultConfiguration() {
+        verifyRule(OverriddenSuperCallRule.description)
+    }
+}
+
+@Suite(.rulesRegistered)
 struct OverrideInExtensionRuleGeneratedTests {
     @Test
     func withDefaultConfiguration() {
@@ -198,13 +206,5 @@ struct QuickDiscouragedPendingTestRuleGeneratedTests {
     @Test
     func withDefaultConfiguration() {
         verifyRule(QuickDiscouragedPendingTestRule.description)
-    }
-}
-
-@Suite(.rulesRegistered)
-struct RawValueForCamelCasedCodableEnumRuleGeneratedTests {
-    @Test
-    func withDefaultConfiguration() {
-        verifyRule(RawValueForCamelCasedCodableEnumRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_08.swift
+++ b/Tests/GeneratedTests/GeneratedTests_08.swift
@@ -10,6 +10,14 @@ import Testing
 @testable import SwiftLintCore
 
 @Suite(.rulesRegistered)
+struct RawValueForCamelCasedCodableEnumRuleGeneratedTests {
+    @Test
+    func withDefaultConfiguration() {
+        verifyRule(RawValueForCamelCasedCodableEnumRule.description)
+    }
+}
+
+@Suite(.rulesRegistered)
 struct ReduceBooleanRuleGeneratedTests {
     @Test
     func withDefaultConfiguration() {
@@ -198,13 +206,5 @@ struct SortedFirstLastRuleGeneratedTests {
     @Test
     func withDefaultConfiguration() {
         verifyRule(SortedFirstLastRule.description)
-    }
-}
-
-@Suite(.rulesRegistered)
-struct SortedImportsRuleGeneratedTests {
-    @Test
-    func withDefaultConfiguration() {
-        verifyRule(SortedImportsRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_09.swift
+++ b/Tests/GeneratedTests/GeneratedTests_09.swift
@@ -10,6 +10,14 @@ import Testing
 @testable import SwiftLintCore
 
 @Suite(.rulesRegistered)
+struct SortedImportsRuleGeneratedTests {
+    @Test
+    func withDefaultConfiguration() {
+        verifyRule(SortedImportsRule.description)
+    }
+}
+
+@Suite(.rulesRegistered)
 struct StatementPositionRuleGeneratedTests {
     @Test
     func withDefaultConfiguration() {
@@ -198,13 +206,5 @@ struct UnhandledThrowingTaskRuleGeneratedTests {
     @Test
     func withDefaultConfiguration() {
         verifyRule(UnhandledThrowingTaskRule.description)
-    }
-}
-
-@Suite(.rulesRegistered)
-struct UnneededBreakInSwitchRuleGeneratedTests {
-    @Test
-    func withDefaultConfiguration() {
-        verifyRule(UnneededBreakInSwitchRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_10.swift
+++ b/Tests/GeneratedTests/GeneratedTests_10.swift
@@ -10,6 +10,14 @@ import Testing
 @testable import SwiftLintCore
 
 @Suite(.rulesRegistered)
+struct UnneededBreakInSwitchRuleGeneratedTests {
+    @Test
+    func withDefaultConfiguration() {
+        verifyRule(UnneededBreakInSwitchRule.description)
+    }
+}
+
+@Suite(.rulesRegistered)
 struct UnneededEscapingRuleGeneratedTests {
     @Test
     func withDefaultConfiguration() {
@@ -198,13 +206,5 @@ struct VoidFunctionInTernaryConditionRuleGeneratedTests {
     @Test
     func withDefaultConfiguration() {
         verifyRule(VoidFunctionInTernaryConditionRule.description)
-    }
-}
-
-@Suite(.rulesRegistered)
-struct VoidReturnRuleGeneratedTests {
-    @Test
-    func withDefaultConfiguration() {
-        verifyRule(VoidReturnRule.description)
     }
 }

--- a/Tests/GeneratedTests/GeneratedTests_11.swift
+++ b/Tests/GeneratedTests/GeneratedTests_11.swift
@@ -10,6 +10,14 @@ import Testing
 @testable import SwiftLintCore
 
 @Suite(.rulesRegistered)
+struct VoidReturnRuleGeneratedTests {
+    @Test
+    func withDefaultConfiguration() {
+        verifyRule(VoidReturnRule.description)
+    }
+}
+
+@Suite(.rulesRegistered)
 struct WeakDelegateRuleGeneratedTests {
     @Test
     func withDefaultConfiguration() {

--- a/Tests/IntegrationTests/Resources/default_rule_configurations.yml
+++ b/Tests/IntegrationTests/Resources/default_rule_configurations.yml
@@ -239,6 +239,14 @@ discouraged_optional_collection:
   meta:
     opt-in: true
     correctable: false
+doc_comment_parameter:
+  severity: warning
+  validate_returns: false
+  validate_throws: false
+  enforce_parameter_syntax: false
+  meta:
+    opt-in: true
+    correctable: false
 duplicate_conditions:
   severity: error
   meta:


### PR DESCRIPTION
## New rule: \`doc_comment_parameter\`

Adds an opt-in lint rule that validates documentation comments on \`func\`, \`init\`, and \`subscript\` declarations are consistent with their actual signatures.

### What it checks

| Violation | Always on | Requires config |
|---|---|---|
| Extra \`- Parameter\` entry (documented name not in signature) | ✅ | |
| Missing \`- Parameter\` entry (signed param not documented, when others are) | ✅ | |
| \`- Returns:\` on a void function, or absent on a non-void one | | \`validate_returns: true\` |
| \`- Throws:\` on a non-throwing function, or absent on a throwing one | | \`validate_throws: true\` |
| Wrong parameter syntax style (singular vs. \`- Parameters:\` block) | | \`enforce_parameter_syntax: true\` |

### Configuration

\`\`\`yaml
doc_comment_parameter:
  severity: warning          # default
  validate_returns: false    # default
  validate_throws: false     # default
  enforce_parameter_syntax: false  # default
\`\`\`

### Examples

\`\`\`swift
// ✅ OK
/// Updates the label.
/// - Parameter with: The new text.
func updateLabel(with text: String) {}

// ✅ OK — no doc comment, no violation
func process(value: Int) {}

// ❌ Extra parameter that doesn't exist
/// - Parameter ↓ghost: Does not exist.
func greet() {}

// ❌ One of two params missing from docs
/// - Parameter lhs: Left side.
↓func add(lhs: Int, rhs: Int) -> Int { lhs + rhs }
\`\`\`

### Notes

- All three optional checks default to \`false\` — enabling the rule as-is only catches name mismatches.
- \`rethrows\` functions are lenient: \`- Throws:\` is allowed but not required.
- \`@discardableResult\` functions are exempt from the \`validate_returns\` missing-returns check.
- Supports both \`/// line\` and \`/** block */\` doc comment styles.
- Parameters with \`_\` external label (e.g. \`func log(_ message:)\`) are matched by their internal name.